### PR TITLE
Remove the alias rewrite for anonymous

### DIFF
--- a/core/cml-main/src/main/java/io/cml/sql/PostgreSqlRewrite.java
+++ b/core/cml-main/src/main/java/io/cml/sql/PostgreSqlRewrite.java
@@ -203,26 +203,11 @@ public class PostgreSqlRewrite
             if (alias.isPresent()) {
                 return alias;
             }
-
-            if (expression instanceof DereferenceExpression) {
-                DereferenceExpression base = (DereferenceExpression) expression;
-                if (base.getBase() instanceof FunctionCall) {
-                    return Optional.of(new Identifier(base.getField().getValue()));
-                }
-                return Optional.empty();
-            }
-            else if (expression instanceof Identifier) {
-                String value = ((Identifier) expression).getValue();
-                if (isNonReservedLexer(value)) {
-                    return Optional.of(new Identifier(value));
-                }
-                return Optional.empty();
-            }
             else if (expression instanceof FunctionCall) {
                 FunctionCall functionCallExpression = (FunctionCall) expression;
                 return Optional.of(new Identifier(functionCallExpression.getName().getSuffix()));
             }
-            return Optional.of(new Identifier("?column?"));
+            return Optional.empty();
         }
 
         @Override

--- a/core/cml-main/src/test/java/io/cml/wireprotocol/TestPostgreSqlRewrite.java
+++ b/core/cml-main/src/test/java/io/cml/wireprotocol/TestPostgreSqlRewrite.java
@@ -153,7 +153,6 @@ public class TestPostgreSqlRewrite
         assertRewrite("select (information_schema._pg_expandarray(ARRAY ['a','b'])).n", "select _pg_expandarray(ARRAY ['a','b']).n n");
         assertRewrite("select (information_schema._pg_expandarray(ARRAY ['a','b']))", "select _pg_expandarray(ARRAY ['a','b']) _pg_expandarray");
         assertRewrite("select version()", "select pg_version() version");
-        assertRewrite("select current_user", "select \"$current_user\"() \"?column?\"");
         assertRewrite("select session_user", "select \"$current_user\"() session_user");
         assertRewrite("select user", "select \"$current_user\"() user");
         assertRewrite("select to_date()", "select pg_to_date() to_date");
@@ -177,9 +176,9 @@ public class TestPostgreSqlRewrite
     @Test
     public void testIntervalLiteralWithInternalField()
     {
-        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '-30 day')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL - '30' day)) AS date) \"?column?\"");
-        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '30 month')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL + '30' month)) AS date) \"?column?\"");
-        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '+30 month')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL + '30' month)) AS date) \"?column?\"");
+        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '-30 day')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL - '30' day)) AS date)");
+        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '30 month')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL + '30' month)) AS date)");
+        assertRewrite("select CAST((CAST(now() AS timestamp) + (INTERVAL '+30 month')) AS date)", "select CAST((CAST(now() AS timestamp) + (INTERVAL + '30' month)) AS date)");
     }
 
     @Test
@@ -199,21 +198,21 @@ public class TestPostgreSqlRewrite
         assertRewrite("SELECT * FROM pg_attribute WHERE attrelid = 't1'::regclass",
                 format("SELECT * FROM %s.pg_catalog.pg_attribute WHERE attrelid = %s", DEFAULT_CATALOG, oid("t1")));
         assertRewrite("SELECT typinput = 'array_in'::regproc FROM pg_type ",
-                format("SELECT typinput = %s \"?column?\" FROM %s.pg_catalog.pg_type", functionOid("array_in"), DEFAULT_CATALOG));
+                format("SELECT typinput = %s FROM %s.pg_catalog.pg_type", functionOid("array_in"), DEFAULT_CATALOG));
         assertRewrite(format("SELECT typinput = %s::regproc FROM pg_type ", functionOid("array_in")),
-                format("SELECT typinput = %s \"?column?\" FROM %s.pg_catalog.pg_type", functionOid("array_in"), DEFAULT_CATALOG));
+                format("SELECT typinput = %s FROM %s.pg_catalog.pg_type", functionOid("array_in"), DEFAULT_CATALOG));
         assertRewrite(format("SELECT attrelid = %s::regclass FROM pg_attribute ", oid("t1")),
-                format("SELECT attrelid = %s \"?column?\" FROM %s.pg_catalog.pg_attribute", oid("t1"), DEFAULT_CATALOG));
+                format("SELECT attrelid = %s FROM %s.pg_catalog.pg_attribute", oid("t1"), DEFAULT_CATALOG));
 
         assertRewrite(format("SELECT * FROM pg_type WHERE typinput = %s::regproc", functionOid("array_in")),
                 format("SELECT * FROM %s.pg_catalog.pg_type WHERE typinput = %s", DEFAULT_CATALOG, functionOid("array_in")));
         assertRewrite(format("SELECT * FROM pg_attribute WHERE attrelid = %s::regclass", oid("t1")),
                 format("SELECT * FROM %s.pg_catalog.pg_attribute WHERE attrelid = %s", DEFAULT_CATALOG, oid("t1")));
 
-        assertRewrite("SELECT 'array_in'::regproc", format("SELECT 'array_in' \"?column?\""));
-        assertRewrite("SELECT 't1'::regclass", format("SELECT 't1' \"?column?\""));
-        assertRewrite(format("SELECT %s::regproc", functionOid("array_in")), format("SELECT 'array_in' \"?column?\""));
-        assertRewrite(format("SELECT %s::regclass", oid("t1")), format("SELECT 't1' \"?column?\""));
+        assertRewrite("SELECT 'array_in'::regproc", "SELECT 'array_in'");
+        assertRewrite("SELECT 't1'::regclass", "SELECT 't1'");
+        assertRewrite(format("SELECT %s::regproc", functionOid("array_in")), "SELECT 'array_in'");
+        assertRewrite(format("SELECT %s::regclass", oid("t1")), "SELECT 't1'");
     }
 
     void assertTableNameRewriteAndNoRewrite(@Language("SQL") String sqlFormat)

--- a/core/cml-testing/src/test/java/io/cml/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/core/cml-testing/src/test/java/io/cml/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -839,6 +839,7 @@ public class TestWireProtocolWithBigquery
                         "  \"cannerflow-286003\".pg_catalog.pg_class c\n" +
                         "WHERE (c.oid = t.typrelid)\n" +
                         ")))"},
+                {"SELECT 1, 2, 3"}
         };
     }
 


### PR DESCRIPTION
PostgreSQL will add column alias `?column?` for anonymous column but BigQuery doesn't support the alias name start with `?`.

BigQuery Error message:
```
Invalid field name "?column?". Fields must contain only letters, numbers, and underscores, start with a letter or underscore, and be at most 300 characters long.
```