### PR TITLE
Support access array element for BigQuery

### DIFF
--- a/core/cml-main/src/main/java/io/cml/calcite/BigQueryCmlSqlDialect.java
+++ b/core/cml-main/src/main/java/io/cml/calcite/BigQueryCmlSqlDialect.java
@@ -18,10 +18,13 @@ import io.airlift.log.Logger;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlAlienSystemTypeNameSpec;
 import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.dialect.BigQuerySqlDialect;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -141,5 +144,26 @@ public class BigQueryCmlSqlDialect
         SqlAlienSystemTypeNameSpec typeNameSpec = new SqlAlienSystemTypeNameSpec(
                 typeAlias, typeName, SqlParserPos.ZERO);
         return new SqlDataTypeSpec(typeNameSpec, SqlParserPos.ZERO);
+    }
+
+    @Override
+    public void unparseCall(final SqlWriter writer, final SqlCall call, final int leftPrec,
+            final int rightPrec)
+    {
+        if (call.getKind() == SqlKind.ITEM) {
+            call.operand(0).unparse(writer, leftPrec, rightPrec);
+            final SqlWriter.Frame indexFrame = writer.startList("[", "]");
+            // BigQuery doesn't support the normal way to access array element like `ARRAY[1,2,3][1]`.
+            // It should use `ORDINAL` or `OFFSET` operator to handle index value.
+            // Since pg is 1-based array index, that's why we use `ORDINAL` here.
+            // https://cloud.google.com/bigquery/docs/reference/standard-sql/arrays#accessing_array_elements
+            final SqlWriter.Frame funcFrame = writer.startFunCall("ORDINAL");
+            call.operand(1).unparse(writer, leftPrec, rightPrec);
+            writer.endFunCall(funcFrame);
+            writer.endList(indexFrame);
+        }
+        else {
+            super.unparseCall(writer, call, leftPrec, rightPrec);
+        }
     }
 }

--- a/core/cml-testing/src/test/java/io/cml/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/core/cml-testing/src/test/java/io/cml/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -839,7 +839,9 @@ public class TestWireProtocolWithBigquery
                         "  \"canner-cml\".pg_catalog.pg_class c\n" +
                         "WHERE (c.oid = t.typrelid)\n" +
                         ")))"},
-                {"SELECT 1, 2, 3"}
+                {"SELECT 1, 2, 3"},
+                {"SELECT array[1,2,3][1]"},
+                {"select current_schemas(false)[1]"}
         };
     }
 


### PR DESCRIPTION
Overwrite BigQuerySqlDialect to handle accessing array element.
```sql
SELECT array[1,2,3][1] -> SELECT array[1,2,3][ORDINAL(1)]
select current_schemas(false)[1] -> select current_schemas(false)[ORDINAL(1)]
```