### PR TITLE
Parse pg options and extract the search_path

### DIFF
--- a/graphmdl-main/src/main/java/io/graphmdl/main/wireprotocol/WireProtocolSession.java
+++ b/graphmdl-main/src/main/java/io/graphmdl/main/wireprotocol/WireProtocolSession.java
@@ -157,11 +157,12 @@ public class WireProtocolSession
 
     public String getDefaultSchema()
     {
-        // we only support the first search path to be the default schema
-        return extraSearchPath(properties.getProperty("options").split(",")[0]);
+        return Optional.ofNullable(properties.getProperty("search_path"))
+                // we only support the first search path to be the default schema
+                .orElse(extraFirstSearchPath(properties.getProperty("options")));
     }
 
-    private String extraSearchPath(String options)
+    private String extraFirstSearchPath(String options)
     {
         if (options == null) {
             return null;
@@ -173,7 +174,7 @@ public class WireProtocolSession
                 continue;
             }
             if (kv[0].equalsIgnoreCase("--search_path")) {
-                searchPath = kv[1];
+                searchPath = kv[1].split(",")[0];
             }
         }
         return searchPath;


### PR DESCRIPTION
Support to connect with psql with `PGOPTIONS` commands as below: 

1.
``` 
psql 'host=localhost dbname=canner-cml port=7432 options=--search_path=tpch_tiny
```
2.
```
PGOPTIONS=--search_path=myschema psql -h localhost -d canner-cml -p 7432
```