### PR TITLE
Support to_char function

### DIFF
--- a/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctionRegistry.java
+++ b/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctionRegistry.java
@@ -37,6 +37,7 @@ import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_GET_EXPR_PRETTY
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_GET_FUNCTION_RESULT;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_RELATION_SIZE__INT_VARCHAR___BIGINT;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_RELATION_SIZE__INT___BIGINT;
+import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_TO_CHAR;
 
 @ThreadSafe
 public final class PgFunctionRegistry
@@ -59,6 +60,7 @@ public final class PgFunctionRegistry
                 .add(PG_GET_EXPR_PRETTY)
                 .add(FORMAT_TYPE)
                 .add(PG_GET_FUNCTION_RESULT)
+                .add(PG_TO_CHAR)
                 .build();
 
         // TODO: handle function name overloading

--- a/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestFunctions.java
+++ b/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestFunctions.java
@@ -58,6 +58,7 @@ public class TestFunctions
                 {"select regexp_like('pg_temp_table', '^pg_temp_')", "t", false},
                 {"select date_trunc('year', '2023-03-30')", "2023-01-01", false},
                 {"select date_trunc('day', timestamp '2023-03-30 18:00:00')", "2023-03-30 00:00:00.000000", false},
+                {"SELECT to_char(TIMESTAMP '2023-06-13 09:17:04.859462', 'YYYY-MM-DD HH24:MI:SS.MS TZ') to_char", "2023-06-13 09:17:04.859 UTC", false},
         };
     }
 


### PR DESCRIPTION
## Description
Because `Metabase` will use sql as below,
```
SELECT to_char(current_timestamp, 'YYYY-MM-DD HH24:MI:SS.MS TZ')
```

So we support `to_char` function when the input is the timestamp type here.
https://www.postgresql.org/docs/13/functions-formatting.html

## Implement
Use BigQuery `CAST(string_expression AS type FORMAT format_string_expression)` to implement it.
https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_string_as_datetime

