### PR TITLE
Support _pg_expandarray function

### DIFF
--- a/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctionRegistry.java
+++ b/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctionRegistry.java
@@ -33,6 +33,7 @@ import static io.graphmdl.main.pgcatalog.function.PgFunctions.CURRENT_DATABASE;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.CURRENT_SCHEMAS;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.FORMAT_TYPE;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.NOW;
+import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_EXPANDARRAY;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_GET_EXPR;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_GET_EXPR_PRETTY;
 import static io.graphmdl.main.pgcatalog.function.PgFunctions.PG_GET_FUNCTION_RESULT;
@@ -63,6 +64,7 @@ public final class PgFunctionRegistry
                 .add(PG_GET_FUNCTION_RESULT)
                 .add(PG_TO_CHAR)
                 .add(NOW)
+                .add(PG_EXPANDARRAY)
                 .build();
 
         // TODO: handle function name overloading

--- a/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctions.java
+++ b/graphmdl-main/src/main/java/io/graphmdl/main/pgcatalog/function/PgFunctions.java
@@ -15,12 +15,14 @@
 package io.graphmdl.main.pgcatalog.function;
 
 import com.google.common.collect.ImmutableList;
+import io.graphmdl.base.type.RecordType;
 
 import java.util.List;
 
 import static io.graphmdl.base.type.BigIntType.BIGINT;
 import static io.graphmdl.base.type.BooleanType.BOOLEAN;
 import static io.graphmdl.base.type.IntegerType.INTEGER;
+import static io.graphmdl.base.type.PGArray.INT4_ARRAY;
 import static io.graphmdl.base.type.PGArray.VARCHAR_ARRAY;
 import static io.graphmdl.base.type.TimestampType.TIMESTAMP;
 import static io.graphmdl.base.type.VarcharType.VARCHAR;
@@ -156,5 +158,14 @@ public final class PgFunctions
             .setLanguage(SQL)
             .setDefinition("SELECT CURRENT_TIMESTAMP")
             .setReturnType(TIMESTAMP)
+            .build();
+
+    // TODO This is a mock function, need to be implemented
+    public static final PgFunction PG_EXPANDARRAY = builder()
+            .setName("_pg_expandarray")
+            .setLanguage(SQL)
+            .setDefinition("SELECT CASE WHEN (array_length(int_arr) > 0) THEN CAST((int_arr[0], 1) AS STRUCT<x INT64, n INT64>) ELSE NULL END")
+            .setArguments(List.of(argument("int_arr", INT4_ARRAY)))
+            .setReturnType(new RecordType(List.of(BIGINT, BIGINT)))
             .build();
 }

--- a/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestFunctions.java
+++ b/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestFunctions.java
@@ -60,6 +60,7 @@ public class TestFunctions
                 {"select date_trunc('year', '2023-03-30')", "2023-01-01", false},
                 {"select date_trunc('day', timestamp '2023-03-30 18:00:00')", "2023-03-30 00:00:00.000000", false},
                 {"SELECT to_char(TIMESTAMP '2023-06-13 09:17:04.859462', 'YYYY-MM-DD HH24:MI:SS.MS TZ') to_char", "2023-06-13 09:17:04.859 UTC", false},
+                {"select information_schema._pg_expandarray(array[1, 2, 3])", "(1,1)", false},
         };
     }
 


### PR DESCRIPTION
## Description
Metabase will use `_pg_expandarray` function with intput integer array.
Like the sql as below to get metadata when sync database
```
SELECT        
  result.TABLE_CAT,
  result.TABLE_SCHEM,
  result.TABLE_NAME,
  result.COLUMN_NAME,
  result.KEY_SEQ,
  result.PK_NAME 
FROM (
  SELECT 
    NULL AS TABLE_CAT, 
    n.nspname AS TABLE_SCHEM,
    ct.relname AS TABLE_NAME,
    a.attname AS COLUMN_NAME,
    (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, 
    ci.relname AS PK_NAME,   
    information_schema._pg_expandarray(i.indkey) AS KEYS, 
    a.attnum AS A_ATTNUM 
  FROM pg_catalog.pg_class ct   
  JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid)   
  JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid)   
  JOIN pg_catalog.pg_index i ON ( a.attrelid = i.indrelid)   
  JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid) 
  WHERE true  AND n.nspname = E'cml_temp' AND ct.relname = E'test1' AND i.indisprimary) result 
where  result.A_ATTNUM = (result.KEYS).x  
ORDER BY result.table_name, result.pk_name, result.key_seq
```

### About `_pg_expandarray` function
```
cannerflow-sql-engine=# \df *._pg_expandarray
                                             List of functions
       Schema       |      Name       | Result data type |            Argument data types            | Type 
--------------------+-----------------+------------------+-------------------------------------------+------
 information_schema | _pg_expandarray | SETOF record     | anyarray, OUT x anyelement, OUT n integer | func
(1 row)

cannerflow-sql-engine=# SELECT information_schema._pg_expandarray(ARRAY[123, 456]) AS result;
 result  
---------
 (123,1)
 (456,2)
(2 rows)
```
Detail can reference
https://crate.io/docs/crate/reference/en/5.3/general/builtins/table-functions.html#information-schema-pg-expandarray-array