### PR TITLE
Fix pg table without catalog and schema

### DIFF
--- a/graphmdl-base/src/main/java/io/graphmdl/base/metadata/SchemaTableName.java
+++ b/graphmdl-base/src/main/java/io/graphmdl/base/metadata/SchemaTableName.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-import static io.graphmdl.base.metadata.SchemaUtil.checkNotEmpty;
-
 public final class SchemaTableName
 {
     private final String schemaName;
@@ -29,8 +27,8 @@ public final class SchemaTableName
     @JsonCreator
     public SchemaTableName(@JsonProperty("schema") String schemaName, @JsonProperty("table") String tableName)
     {
-        this.schemaName = checkNotEmpty(schemaName, "schemaName");
-        this.tableName = checkNotEmpty(tableName, "tableName");
+        this.schemaName = schemaName;
+        this.tableName = tableName;
     }
 
     @JsonProperty("schema")

--- a/graphmdl-sqlrewrite/src/main/java/io/graphmdl/sqlrewrite/Utils.java
+++ b/graphmdl-sqlrewrite/src/main/java/io/graphmdl/sqlrewrite/Utils.java
@@ -181,10 +181,8 @@ public final class Utils
 
         List<String> parts = Lists.reverse(name.getParts());
         String objectName = parts.get(0);
-        String schemaName = (parts.size() > 1) ? parts.get(1) : sessionContext.getSchema().orElseThrow(() ->
-                new IllegalArgumentException("Schema must be specified when session schema is not set"));
-        String catalogName = (parts.size() > 2) ? parts.get(2) : sessionContext.getCatalog().orElseThrow(() ->
-                new IllegalArgumentException("Catalog must be specified when session catalog is not set"));
+        String schemaName = (parts.size() > 1) ? parts.get(1) : sessionContext.getSchema().orElse(null);
+        String catalogName = (parts.size() > 2) ? parts.get(2) : sessionContext.getCatalog().orElse(null);
 
         return new CatalogSchemaTableName(catalogName, schemaName, objectName);
     }

--- a/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/graphmdl-tests/src/test/java/io/graphmdl/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -842,6 +842,7 @@ public class TestWireProtocolWithBigquery
                         ", current_schemas(false)[s.r] nspname\n" +
                         "FROM\n" +
                         "UNNEST(generate_array(1, array_upper(current_schemas(false), 1))) s (r)"},
+                {"SELECT nspname, typname FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE t.oid IN (SELECT DISTINCT enumtypid FROM pg_enum e)"},
         };
     }
 


### PR DESCRIPTION
## Description

In PostgreSQL, we can query table without schema, so we need to support it.
Like Metabase will use the query as below,
```
SELECT nspname, typname 
FROM pg_type t 
JOIN pg_namespace n ON n.oid = t.typnamespace 
WHERE t.oid IN (SELECT DISTINCT enumtypid FROM pg_enum e)
```

## Implement
Original in `PostgreSqlRewrite#visitTable`, we would give pg table schema and catalog.
So we just need to remove the restriction when do `GraphMDLPlanner` rewrite.

