### PR TITLE
Redefine calculated and expression in model field

### DIFF
--- a/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/ModelSqlRender.java
+++ b/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/ModelSqlRender.java
@@ -14,6 +14,7 @@
 
 package io.accio.sqlrewrite;
 
+import com.google.common.collect.ImmutableList;
 import io.accio.base.AccioMDL;
 import io.accio.base.dto.Column;
 import io.accio.base.dto.Model;
@@ -23,18 +24,20 @@ import io.accio.sqlrewrite.analyzer.ExpressionRelationshipAnalyzer;
 import io.accio.sqlrewrite.analyzer.ExpressionRelationshipInfo;
 import io.trino.sql.tree.Expression;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.accio.base.Utils.checkArgument;
 import static io.accio.sqlrewrite.Utils.parseExpression;
 import static io.accio.sqlrewrite.Utils.parseQuery;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 public class ModelSqlRender
@@ -79,12 +82,6 @@ public class ModelSqlRender
     }
 
     @Override
-    protected String getModelExpression(Column column)
-    {
-        return format("%s AS \"%s\"", column.getExpression().orElse(column.getName()), column.getName());
-    }
-
-    @Override
     protected String getModelSubQuerySelectItemsExpression(Map<String, String> columnWithoutRelationships)
     {
         return columnWithoutRelationships.entrySet().stream()
@@ -105,38 +102,10 @@ public class ModelSqlRender
     protected void collectRelationship(Column column, Model baseModel)
     {
         Expression expression = parseExpression(column.getExpression().orElseThrow(() -> new IllegalArgumentException("expression not found in column")));
-        if (column.isCalculated()) {
-            processCalculatedField(column, baseModel, expression);
-        }
-        else {
-            processRegularField(column, baseModel, expression);
-        }
-    }
-
-    private void processCalculatedField(Column column, Model baseModel, Expression expression)
-    {
         List<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
-        calculatedRequiredRelationshipInfos.add(new CalculatedFieldRelationshipInfo(column, relationshipInfos));
-        processRelationshipInfos(column, baseModel, relationshipInfos, Optional.of(column.getName()));
-    }
-
-    private void processRegularField(Column column, Model baseModel, Expression expression)
-    {
-        List<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getToOneRelationships(expression, mdl, baseModel);
-        requiredRelationshipInfos.addAll(relationshipInfos.stream()
-                .map(info -> new ColumnAliasExpressionRelationshipInfo(column.getName(), info))
-                .collect(toSet()));
-        processRelationshipInfos(column, baseModel, relationshipInfos, Optional.of(getRelationableAlias(baseModel.getName())));
-    }
-
-    private void processRelationshipInfos(Column column, Model baseModel, List<ExpressionRelationshipInfo> relationshipInfos, Optional<String> alias)
-    {
-        if (relationshipInfos.isEmpty()) {
-            // No relationships, add select item with no alias
-            selectItems.add(getSelectItemsExpression(column, Optional.empty()));
-            columnWithoutRelationships.put(column.getName(), column.getExpression().get());
-        }
-        else {
+        if (column.isCalculated() && relationshipInfos.size() > 0) {
+            CalculatedFieldRelationshipInfo calculatedFieldRelationshipInfo = new CalculatedFieldRelationshipInfo(column, relationshipInfos);
+            calculatedRequiredRelationshipInfos.add(calculatedFieldRelationshipInfo);
             // Collect all required models in relationships
             requiredObjects.addAll(relationshipInfos.stream()
                     .map(ExpressionRelationshipInfo::getRelationships)
@@ -147,35 +116,119 @@ public class ModelSqlRender
                     .collect(toSet()));
 
             // Add select items based on the type of column
-            selectItems.add(getSelectItemsExpression(column, alias));
+            if (calculatedFieldRelationshipInfo.isAggregated()) {
+                selectItems.add(getSelectItemsExpression(column, Optional.of(calculatedFieldRelationshipInfo.getAlias())));
+            }
+            else {
+                selectItems.add(getSelectItemsExpression(column, Optional.of(getRelationableAlias(baseModel.getName()))));
+            }
+        }
+        else {
+            // No relationships, add select item with no alias
+            selectItems.add(getSelectItemsExpression(column, Optional.empty()));
+            columnWithoutRelationships.put(column.getName(), column.getExpression().get());
         }
     }
 
     @Override
-    protected String getCalculatedSubQuery(Model baseModel, CalculatedFieldRelationshipInfo relationshipInfo)
+    protected List<SubQueryJoinInfo> getCalculatedSubQuery(Model baseModel, List<CalculatedFieldRelationshipInfo> relationshipInfos)
     {
-        String requiredExpressions = format("%s AS \"%s\"",
-                RelationshipRewriter.rewrite(relationshipInfo.getExpressionRelationshipInfo(), parseExpression(relationshipInfo.getColumn().getExpression().get())),
-                relationshipInfo.getAlias());
+        ImmutableList.Builder<SubQueryJoinInfo> queries = ImmutableList.builder();
+        queries.addAll(getToOneRelationshipsQuery(baseModel, relationshipInfos));
+        queries.addAll(getToManyRelationshipsQuery(baseModel, relationshipInfos));
+        return queries.build();
+    }
 
+    // only accept to-one relationship(s) in this method
+    private List<SubQueryJoinInfo> getToOneRelationshipsQuery(Model baseModel, Collection<CalculatedFieldRelationshipInfo> relationshipInfos)
+    {
+        List<CalculatedFieldRelationshipInfo> toOneRelationships = relationshipInfos.stream()
+                .filter(relationshipInfo -> !relationshipInfo.isAggregated())
+                .collect(toImmutableList());
+
+        if (toOneRelationships.isEmpty()) {
+            return ImmutableList.of();
+        }
+
+        String requiredExpressions = toOneRelationships.stream()
+                .map(info -> format("%s AS \"%s\"",
+                        RelationshipRewriter.rewrite(
+                                        info.getExpressionRelationshipInfo(),
+                                        parseExpression(info.getColumn().getExpression().orElseThrow()))
+                                .toString(),
+                        info.getAlias()))
+                .collect(joining(", "));
+
+        List<Relationship> requiredRelationships = toOneRelationships.stream()
+                .map(CalculatedFieldRelationshipInfo::getExpressionRelationshipInfo)
+                .flatMap(List::stream)
+                .map(ExpressionRelationshipInfo::getRelationships)
+                .flatMap(List::stream)
+                .distinct()
+                .collect(toImmutableList());
         String tableJoins = format("(%s) AS \"%s\" %s",
-                getSqlForBaseModelKey(
-                        baseModel,
-                        relationshipInfo.getExpressionRelationshipInfo().stream()
-                                .map(ExpressionRelationshipInfo::getBaseModelRelationship)
-                                .collect(toList()), mdl),
+                getBaseModelSql(baseModel),
                 baseModel.getName(),
-                relationshipInfo.getExpressionRelationshipInfo().stream()
-                        .map(ExpressionRelationshipInfo::getRelationships)
-                        .flatMap(List::stream)
-                        .distinct()
+                requiredRelationships.stream()
                         .map(relationship -> format(" LEFT JOIN \"%s\" ON %s", relationship.getModels().get(1), relationship.getCondition()))
                         .collect(joining()));
 
-        checkArgument(baseModel.getPrimaryKey() != null, format("primary key in model %s contains relationship shouldn't be null", baseModel.getName()));
-        return format("SELECT %s, %s FROM (%s) GROUP BY 1",
-                format("\"%s\".\"%s\"", baseModel.getName(), baseModel.getPrimaryKey()),
-                requiredExpressions,
-                tableJoins);
+        Function<String, String> tableJoinCondition =
+                (name) -> format("\"%s\".\"%s\" = \"%s\".\"%s\"", baseModel.getName(), baseModel.getPrimaryKey(), name, baseModel.getPrimaryKey());
+        return ImmutableList.of(
+                new SubQueryJoinInfo(
+                        format("SELECT \"%s\".\"%s\", %s FROM (%s)",
+                                baseModel.getName(),
+                                baseModel.getPrimaryKey(),
+                                requiredExpressions,
+                                tableJoins),
+                        getRelationableAlias(baseModel.getName()),
+                        tableJoinCondition.apply(getRelationableAlias(baseModel.getName()))));
+    }
+
+    // accept to-one relationship(s) and at least one to-many relationship in this method, and use group by model primary key
+    // to aggregate the query result as to-many relationship could lead to duplicate rows. Here we didn't check if there
+    // is an aggregation function or not, we should add aggregation function in expression to avoid sql syntax error.
+    private List<SubQueryJoinInfo> getToManyRelationshipsQuery(Model baseModel, Collection<CalculatedFieldRelationshipInfo> relationshipInfos)
+    {
+        return relationshipInfos.stream()
+                .filter(CalculatedFieldRelationshipInfo::isAggregated)
+                .map(relationshipInfo -> {
+                    String requiredExpressions = format("%s AS \"%s\"",
+                            RelationshipRewriter.rewrite(relationshipInfo.getExpressionRelationshipInfo(), parseExpression(relationshipInfo.getColumn().getExpression().get())),
+                            relationshipInfo.getAlias());
+
+                    String tableJoins = format("(%s) AS \"%s\" %s",
+                            getBaseModelSql(baseModel),
+                            baseModel.getName(),
+                            relationshipInfo.getExpressionRelationshipInfo().stream()
+                                    .map(ExpressionRelationshipInfo::getRelationships)
+                                    .flatMap(List::stream)
+                                    .distinct()
+                                    .map(relationship -> format(" LEFT JOIN \"%s\" ON %s", relationship.getModels().get(1), relationship.getCondition()))
+                                    .collect(joining()));
+
+                    checkArgument(baseModel.getPrimaryKey() != null, format("primary key in model %s contains relationship shouldn't be null", baseModel.getName()));
+                    Function<String, String> tableJoinCondition =
+                            (name) -> format("\"%s\".\"%s\" = \"%s\".\"%s\"", baseModel.getName(), baseModel.getPrimaryKey(), name, baseModel.getPrimaryKey());
+                    return new SubQueryJoinInfo(
+                            format("SELECT %s, %s FROM (%s) GROUP BY 1",
+                                    format("\"%s\".\"%s\"", baseModel.getName(), baseModel.getPrimaryKey()),
+                                    requiredExpressions,
+                                    tableJoins),
+                            relationshipInfo.getAlias(),
+                            tableJoinCondition.apply(relationshipInfo.getAlias()));
+                })
+                .collect(toImmutableList());
+    }
+
+    private String getBaseModelSql(Model model)
+    {
+        String selectItems = model.getColumns().stream()
+                .filter(column -> !column.isCalculated())
+                .filter(column -> column.getRelationship().isEmpty())
+                .map(Column::getSqlExpression)
+                .collect(joining(", "));
+        return format("SELECT %s FROM (%s) AS \"%s\"", selectItems, refSql, model.getName());
     }
 }

--- a/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/RelationshipRewriter.java
+++ b/accio-sqlrewrite/src/main/java/io/accio/sqlrewrite/RelationshipRewriter.java
@@ -22,6 +22,7 @@ import io.trino.sql.tree.Node;
 import io.trino.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,9 +38,9 @@ public class RelationshipRewriter
     public static Node rewrite(List<ExpressionRelationshipInfo> relationshipInfos, Expression expression)
     {
         requireNonNull(relationshipInfos);
-        return new RelationshipRewriter(
-                relationshipInfos.stream()
-                        .collect(toUnmodifiableMap(ExpressionRelationshipInfo::getQualifiedName, RelationshipRewriter::toDereferenceExpression)))
+        HashMap<QualifiedName, DereferenceExpression> replacements = new HashMap<>();
+        relationshipInfos.forEach(info -> replacements.put(info.getQualifiedName(), toDereferenceExpression(info)));
+        return new RelationshipRewriter(replacements)
                 .process(expression);
     }
 

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestAllRulesRewrite.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestAllRulesRewrite.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import static io.accio.base.AccioTypes.INTEGER;
 import static io.accio.base.AccioTypes.VARCHAR;
+import static io.accio.base.dto.Column.caluclatedColumn;
 import static io.accio.base.dto.Column.column;
 import static io.accio.base.dto.Column.relationshipColumn;
 import static io.accio.base.dto.EnumDefinition.enumDefinition;
@@ -59,7 +60,7 @@ public class TestAllRulesRewrite
                                         relationshipColumn("band", "Band", "AlbumBand"),
                                         column("price", INTEGER, null, true),
                                         column("bandId", INTEGER, null, true),
-                                        column("bandName", VARCHAR, null, true, "band.name"),
+                                        caluclatedColumn("bandName", VARCHAR, "band.name"),
                                         column("status", "Inventory", null, true),
                                         column("statusA", "InventoryA", null, true),
                                         relationshipColumn("orders", "Order", "AlbumOrder")),

--- a/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetric.java
+++ b/accio-sqlrewrite/src/test/java/io/accio/sqlrewrite/TestMetric.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static io.accio.base.AccioTypes.DATE;
 import static io.accio.base.AccioTypes.INTEGER;
 import static io.accio.base.AccioTypes.VARCHAR;
+import static io.accio.base.dto.Column.caluclatedColumn;
 import static io.accio.base.dto.Column.column;
 import static io.accio.base.dto.JoinType.MANY_TO_ONE;
 import static io.accio.base.dto.JoinType.ONE_TO_MANY;
@@ -64,8 +65,8 @@ public class TestMetric
                                         column("clerk", VARCHAR, null, true),
                                         column("shippriority", INTEGER, null, true),
                                         column("comment", VARCHAR, null, true),
-                                        column("customer_name", VARCHAR, null, true, "customer.name"),
-                                        column("cumstomer_address", VARCHAR, null, true, "customer.address"),
+                                        caluclatedColumn("customer_name", VARCHAR, "customer.name"),
+                                        caluclatedColumn("cumstomer_address", VARCHAR, "customer.address"),
                                         column("customer", "Customer", "OrdersCustomer", true),
                                         column("lineitem", "Lineitem", "OrdersLineitem", true)),
                                 "orderkey"),

--- a/accio-tests/src/test/java/io/accio/testing/bigquery/TestAccioWithBigquery.java
+++ b/accio-tests/src/test/java/io/accio/testing/bigquery/TestAccioWithBigquery.java
@@ -102,20 +102,19 @@ public class TestAccioWithBigquery
         }
 
         // test the TO_MANY relationship
-        // TODO: support TO_MANY relationship in metric
-        // try (Connection connection = createConnection()) {
-        //     PreparedStatement stmt = connection.prepareStatement("select custkey, totalprice from CustomerRevenue limit 100");
-        //     ResultSet resultSet = stmt.executeQuery();
-        //     resultSet.next();
-        //     assertThatNoException().isThrownBy(() -> resultSet.getString("custkey"));
-        //     assertThatNoException().isThrownBy(() -> resultSet.getInt("totalprice"));
-        //     int count = 1;
-        //
-        //     while (resultSet.next()) {
-        //         count++;
-        //     }
-        //     assertThat(count).isEqualTo(100);
-        // }
+        try (Connection connection = createConnection()) {
+            PreparedStatement stmt = connection.prepareStatement("select custkey, totalprice from CustomerRevenue limit 100");
+            ResultSet resultSet = stmt.executeQuery();
+            resultSet.next();
+            assertThatNoException().isThrownBy(() -> resultSet.getString("custkey"));
+            assertThatNoException().isThrownBy(() -> resultSet.getInt("totalprice"));
+            int count = 1;
+
+            while (resultSet.next()) {
+                count++;
+            }
+            assertThat(count).isEqualTo(100);
+        }
     }
 
     // TODO: support metric roll up relationship

--- a/accio-tests/src/test/resources/tpch_mdl.json
+++ b/accio-tests/src/test/resources/tpch_mdl.json
@@ -28,6 +28,7 @@
         },
         {
           "name": "nation_name",
+          "isCalculated": true,
           "expression": "customer.nation.name",
           "type": "varchar"
         },


### PR DESCRIPTION
The "model expression" in the past allowed the mixing of column
names produced in refSql with relationship columns, causing
confusion for users. This PR redefines the usage scenarios for expr and calc.

- Currently, in the model, expr can only utilize columns from
the baseObject or those produced in refSql. Relationship columns
cannot be applied in expr. If one intends to use a relationship column,
it must be defined in calc. Additionally, calc can only utilize
columns within the model itself and cannot use columns from baseObject or refSql.
- And users should be aware that model primary key and relationship join key in
join critera shouldn't use `calc`.
- In metric, all expr in dimensions and measure are treated as calculated field.
- This pr also remove primary key and join key validation as they should be placed
in validation rules not in runtime.