### PR TITLE
Remove and rename some configs

### DIFF
--- a/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
+++ b/accio-base/src/main/java/io/accio/base/client/duckdb/DuckDBConfig.java
@@ -26,7 +26,7 @@ public class DuckDBConfig
     public static final String DUCKDB_HOME_DIRECTORY = "duckdb.home-directory";
     public static final String DUCKDB_TEMP_DIRECTORY = "duckdb.temp-directory";
     public static final String DUCKDB_MAX_CONCURRENT_TASKS = "duckdb.max-concurrent-tasks";
-    public static final String DUCKDB_MAX_CONCURRENT_QUERIES = "duckdb.max-concurrent-queries";
+    public static final String DUCKDB_MAX_CONCURRENT_METADATA_QUERIES = "duckdb.max-concurrent-metadata-queries";
     public static final String DUCKDB_MAX_CACHE_QUERY_TIMEOUT = "duckdb.max-cache-query-timeout";
 
     public static final String DUCKDB_MAX_CACHE_TABLE_SIZE_RATIO = "duckdb.max-cache-table-size-ratio";
@@ -89,7 +89,7 @@ public class DuckDBConfig
         return maxConcurrentMetadataQueries;
     }
 
-    @Config(DUCKDB_MAX_CONCURRENT_QUERIES)
+    @Config(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES)
     public void setMaxConcurrentMetadataQueries(int maxConcurrentMetadataQueries)
     {
         this.maxConcurrentMetadataQueries = maxConcurrentMetadataQueries;

--- a/accio-base/src/main/java/io/accio/base/config/AccioConfig.java
+++ b/accio-base/src/main/java/io/accio/base/config/AccioConfig.java
@@ -19,11 +19,9 @@ import io.airlift.configuration.Config;
 import javax.validation.constraints.NotNull;
 
 import java.io.File;
-import java.util.Optional;
 
 public class AccioConfig
 {
-    public static final String ACCIO_FILE = "accio.file";
     public static final String ACCIO_DIRECTORY = "accio.directory";
     public static final String ACCIO_DATASOURCE_TYPE = "accio.datasource.type";
     public static final String ACCIO_ENABLE_DYNAMIC_FIELDS = "accio.experimental-enable-dynamic-fields";
@@ -35,25 +33,9 @@ public class AccioConfig
         DUCKDB,
     }
 
-    @Deprecated
-    private File accioMDLFile = new File("etc/mdl/manifest.json");
     private File accioMDLDirectory = new File("etc/mdl");
     private DataSourceType dataSourceType = DataSourceType.DUCKDB;
     private boolean enableDynamicFields;
-
-    @Deprecated
-    public Optional<File> getAccioMDLFile()
-    {
-        return Optional.ofNullable(accioMDLFile);
-    }
-
-    @Deprecated
-    @Config(ACCIO_FILE)
-    public AccioConfig setAccioMDLFile(File accioMDLFile)
-    {
-        this.accioMDLFile = accioMDLFile;
-        return this;
-    }
 
     @NotNull
     public File getAccioMDLDirectory()

--- a/accio-base/src/main/java/io/accio/base/config/BigQueryConfig.java
+++ b/accio-base/src/main/java/io/accio/base/config/BigQueryConfig.java
@@ -27,14 +27,12 @@ public class BigQueryConfig
     public static final String BIGQUERY_CRENDITALS_KEY = "bigquery.credentials-key";
     public static final String BIGQUERY_CRENDITALS_FILE = "bigquery.credentials-file";
     public static final String BIGQUERY_PROJECT_ID = "bigquery.project-id";
-    public static final String BIGQUERY_PARENT_PROJECT_ID = "bigquery.parent-project-id";
     public static final String BIGQUERY_LOCATION = "bigquery.location";
     public static final String BIGQUERY_BUCKET_NAME = "bigquery.bucket-name";
     public static final String BIGQUERY_METADATA_SCHEMA_PREFIX = "bigquery.metadata.schema.prefix";
     private Optional<String> credentialsKey = Optional.empty();
     private Optional<String> credentialsFile = Optional.empty();
     private Optional<String> projectId = Optional.empty();
-    private Optional<String> parentProjectId = Optional.empty();
 
     private Optional<String> location = Optional.empty();
 
@@ -78,19 +76,6 @@ public class BigQueryConfig
     public BigQueryConfig setProjectId(String projectId)
     {
         this.projectId = Optional.ofNullable(projectId);
-        return this;
-    }
-
-    public Optional<String> getParentProjectId()
-    {
-        return parentProjectId;
-    }
-
-    @Config(BIGQUERY_PARENT_PROJECT_ID)
-    @ConfigDescription("The Google Cloud Project ID to bill for the export")
-    public BigQueryConfig setParentProjectId(String parentProjectId)
-    {
-        this.parentProjectId = Optional.ofNullable(parentProjectId);
         return this;
     }
 

--- a/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
+++ b/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
@@ -46,7 +46,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_CACHE_TASK_RETRY_DELAY;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_HOME_DIRECTORY;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CACHE_QUERY_TIMEOUT;
-import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CONCURRENT_QUERIES;
+import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CONCURRENT_METADATA_QUERIES;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CONCURRENT_TASKS;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MEMORY_LIMIT;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_TEMP_DIRECTORY;
@@ -146,7 +146,7 @@ public class ConfigManager
         initConfig(DUCKDB_HOME_DIRECTORY, duckDBConfig.getHomeDirectory(), true, false);
         initConfig(DUCKDB_TEMP_DIRECTORY, duckDBConfig.getTempDirectory(), true, false);
         initConfig(DUCKDB_MAX_CONCURRENT_TASKS, Integer.toString(duckDBConfig.getMaxConcurrentTasks()), true, false);
-        initConfig(DUCKDB_MAX_CONCURRENT_QUERIES, Integer.toString(duckDBConfig.getMaxConcurrentMetadataQueries()), true, false);
+        initConfig(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES, Integer.toString(duckDBConfig.getMaxConcurrentMetadataQueries()), true, false);
         initConfig(DUCKDB_MAX_CACHE_QUERY_TIMEOUT, Long.toString(duckDBConfig.getMaxCacheQueryTimeout()), true, false);
         initConfig(DUCKDB_CACHE_TASK_RETRY_DELAY, Long.toString(duckDBConfig.getCacheTaskRetryDelay()), true, false);
         initConfig(PG_WIRE_PROTOCOL_PORT, postgresWireProtocolConfig.getPort(), false, true);
@@ -262,7 +262,7 @@ public class ConfigManager
         result.setHomeDirectory(configs.get(DUCKDB_HOME_DIRECTORY));
         result.setTempDirectory(configs.get(DUCKDB_TEMP_DIRECTORY));
         result.setMaxConcurrentTasks(Integer.parseInt(configs.get(DUCKDB_MAX_CONCURRENT_TASKS)));
-        result.setMaxConcurrentMetadataQueries(Integer.parseInt(configs.get(DUCKDB_MAX_CONCURRENT_QUERIES)));
+        result.setMaxConcurrentMetadataQueries(Integer.parseInt(configs.get(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES)));
         result.setMaxCacheQueryTimeout(Integer.parseInt(configs.get(DUCKDB_MAX_CACHE_QUERY_TIMEOUT)));
         result.setCacheTaskRetryDelay(Integer.parseInt(configs.get(DUCKDB_CACHE_TASK_RETRY_DELAY)));
         return result;

--- a/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
+++ b/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
@@ -58,7 +58,6 @@ import static io.accio.base.client.duckdb.DuckdbS3StyleStorageConfig.DUCKDB_STOR
 import static io.accio.base.config.AccioConfig.ACCIO_DATASOURCE_TYPE;
 import static io.accio.base.config.AccioConfig.ACCIO_DIRECTORY;
 import static io.accio.base.config.AccioConfig.ACCIO_ENABLE_DYNAMIC_FIELDS;
-import static io.accio.base.config.AccioConfig.ACCIO_FILE;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_BUCKET_NAME;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_CRENDITALS_FILE;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_CRENDITALS_KEY;
@@ -136,7 +135,6 @@ public class ConfigManager
             PostgresWireProtocolConfig postgresWireProtocolConfig,
             DuckdbS3StyleStorageConfig duckdbS3StyleStorageConfig)
     {
-        initConfig(ACCIO_FILE, accioConfig.getAccioMDLFile().map(File::getAbsolutePath).orElse(null), false, true);
         initConfig(ACCIO_DIRECTORY, accioConfig.getAccioMDLDirectory().getPath(), false, true);
         initConfig(ACCIO_DATASOURCE_TYPE, Optional.ofNullable(accioConfig.getDataSourceType()).map(Enum::name).orElse(null), true, false);
         initConfig(ACCIO_ENABLE_DYNAMIC_FIELDS, Boolean.toString(accioConfig.getEnableDynamicFields()), false, false);
@@ -231,8 +229,6 @@ public class ConfigManager
     private AccioConfig getAccioConfig()
     {
         AccioConfig result = new AccioConfig();
-        Optional.ofNullable(configs.get(ACCIO_FILE))
-                .ifPresent(file -> result.setAccioMDLFile(new File(file)));
         Optional.ofNullable(configs.get(ACCIO_DIRECTORY))
                 .ifPresent(directory -> result.setAccioMDLDirectory(new File(directory)));
         result.setDataSourceType(AccioConfig.DataSourceType.valueOf(configs.get(ACCIO_DATASOURCE_TYPE).toUpperCase(Locale.ROOT)));

--- a/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
+++ b/accio-base/src/main/java/io/accio/base/config/ConfigManager.java
@@ -63,7 +63,6 @@ import static io.accio.base.config.BigQueryConfig.BIGQUERY_CRENDITALS_FILE;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_CRENDITALS_KEY;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_LOCATION;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_METADATA_SCHEMA_PREFIX;
-import static io.accio.base.config.BigQueryConfig.BIGQUERY_PARENT_PROJECT_ID;
 import static io.accio.base.config.BigQueryConfig.BIGQUERY_PROJECT_ID;
 import static io.accio.base.config.PostgresConfig.POSTGRES_JDBC_URL;
 import static io.accio.base.config.PostgresConfig.POSTGRES_PASSWORD;
@@ -157,7 +156,6 @@ public class ConfigManager
         initConfig(BIGQUERY_CRENDITALS_KEY, bigQueryConfig.getCredentialsKey().orElse(null), true, false);
         initConfig(BIGQUERY_CRENDITALS_FILE, bigQueryConfig.getCredentialsFile().orElse(null), true, false);
         initConfig(BIGQUERY_PROJECT_ID, bigQueryConfig.getProjectId().orElse(null), true, false);
-        initConfig(BIGQUERY_PARENT_PROJECT_ID, bigQueryConfig.getParentProjectId().orElse(null), true, false);
         initConfig(BIGQUERY_LOCATION, bigQueryConfig.getLocation().orElse(null), true, false);
         initConfig(BIGQUERY_BUCKET_NAME, bigQueryConfig.getBucketName().orElse(null), true, false);
         initConfig(BIGQUERY_METADATA_SCHEMA_PREFIX, bigQueryConfig.getMetadataSchemaPrefix(), true, false);
@@ -242,7 +240,6 @@ public class ConfigManager
         result.setCredentialsKey(configs.get(BIGQUERY_CRENDITALS_KEY));
         result.setCredentialsFile(configs.get(BIGQUERY_CRENDITALS_FILE));
         result.setProjectId(configs.get(BIGQUERY_PROJECT_ID));
-        result.setParentProjectId(configs.get(BIGQUERY_PARENT_PROJECT_ID));
         result.setLocation(configs.get(BIGQUERY_LOCATION));
         result.setBucketName(configs.get(BIGQUERY_BUCKET_NAME));
         result.setMetadataSchemaPrefix(configs.get(BIGQUERY_METADATA_SCHEMA_PREFIX));

--- a/accio-main/src/main/java/io/accio/main/AccioManager.java
+++ b/accio-main/src/main/java/io/accio/main/AccioManager.java
@@ -49,7 +49,6 @@ public class AccioManager
     private final CacheManager cacheManager;
     private final PgCatalogManager pgCatalogManager;
     private final AccioMetastore accioMetastore;
-    private final AccioConfig accioConfig;
 
     @Inject
     public AccioManager(AccioConfig accioConfig,
@@ -57,7 +56,7 @@ public class AccioManager
             CacheManager cacheManager,
             PgCatalogManager pgCatalogManager)
     {
-        this.accioConfig = requireNonNull(accioConfig, "accioConfig is null");
+        requireNonNull(accioConfig, "accioConfig is null");
         this.accioMDLDirectory = requireNonNull(accioConfig.getAccioMDLDirectory(), "accioMDLDirectory is null");
         this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
         this.pgCatalogManager = requireNonNull(pgCatalogManager, "pgCatalogManager is null");
@@ -66,10 +65,6 @@ public class AccioManager
         try {
             if (mdlFiles != null && mdlFiles.length > 0) {
                 deployAccioMDLFromDir(mdlFiles);
-            }
-            else if (accioConfig.getAccioMDLFile().isPresent()) {
-                this.accioMDLFile = accioConfig.getAccioMDLFile().get();
-                deployAccioMDLFromFile(null);
             }
             else {
                 LOG.warn("No AccioMDL file found. AccioMDL will not be deployed, and no pg table will be generated.");

--- a/accio-main/src/main/java/io/accio/main/connector/bigquery/BigQueryMetadata.java
+++ b/accio-main/src/main/java/io/accio/main/connector/bigquery/BigQueryMetadata.java
@@ -340,7 +340,7 @@ public class BigQueryMetadata
 
     public static GcsStorageClient provideGcsStorageClient(BigQueryConfig config, HeaderProvider headerProvider, BigQueryCredentialsSupplier bigQueryCredentialsSupplier)
     {
-        String billingProjectId = calculateBillingProjectId(config.getParentProjectId(), bigQueryCredentialsSupplier.getCredentials());
+        String billingProjectId = calculateBillingProjectId(config.getProjectId(), bigQueryCredentialsSupplier.getCredentials());
         StorageOptions.Builder options = StorageOptions.newBuilder()
                 .setHeaderProvider(headerProvider)
                 .setProjectId(billingProjectId);

--- a/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
+++ b/accio-tests/src/test/java/io/accio/TestBigQuerySqlConverter.java
@@ -50,7 +50,6 @@ public class TestBigQuerySqlConverter
     {
         BigQueryConfig config = new BigQueryConfig();
         config.setProjectId(getenv("TEST_BIG_QUERY_PROJECT_ID"))
-                .setParentProjectId(getenv("TEST_BIG_QUERY_PARENT_PROJECT_ID"))
                 .setCredentialsKey(getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
                 .setLocation("asia-east1");
 

--- a/accio-tests/src/test/java/io/accio/testing/TestConfigResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestConfigResource.java
@@ -27,7 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CONCURRENT_QUERIES;
+import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MAX_CONCURRENT_METADATA_QUERIES;
 import static io.accio.base.client.duckdb.DuckDBConfig.DUCKDB_MEMORY_LIMIT;
 import static io.accio.base.config.AccioConfig.ACCIO_DATASOURCE_TYPE;
 import static io.accio.base.config.AccioConfig.ACCIO_DIRECTORY;
@@ -83,11 +83,11 @@ public class TestConfigResource
     @Test
     public void testuUpdateConfigs()
     {
-        patchConfig(List.of(configEntry(DUCKDB_MEMORY_LIMIT, "2GB"), configEntry(DUCKDB_MAX_CONCURRENT_QUERIES, "20")));
+        patchConfig(List.of(configEntry(DUCKDB_MEMORY_LIMIT, "2GB"), configEntry(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES, "20")));
         assertThat(getConfig(ACCIO_DATASOURCE_TYPE)).isEqualTo(configEntry(ACCIO_DATASOURCE_TYPE, DUCKDB.name()));
         assertThat(getConfig(ACCIO_DIRECTORY)).isEqualTo(configEntry(ACCIO_DIRECTORY, mdlDir.toAbsolutePath().toString()));
         assertThat(getConfig(DUCKDB_MEMORY_LIMIT)).isEqualTo(configEntry(DUCKDB_MEMORY_LIMIT, "2GB"));
-        assertThat(getConfig(DUCKDB_MAX_CONCURRENT_QUERIES)).isEqualTo(configEntry(DUCKDB_MAX_CONCURRENT_QUERIES, "20"));
+        assertThat(getConfig(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES)).isEqualTo(configEntry(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES, "20"));
 
         resetConfig();
         DuckDBConfig duckDBConfig = new DuckDBConfig();
@@ -95,7 +95,7 @@ public class TestConfigResource
         assertThat(getConfig(ACCIO_DATASOURCE_TYPE)).isEqualTo(configEntry(ACCIO_DATASOURCE_TYPE, accioConfig.getDataSourceType().name()));
         assertThat(getConfig(ACCIO_DIRECTORY)).isEqualTo(configEntry(ACCIO_DIRECTORY, accioConfig.getAccioMDLDirectory().getPath()));
         assertThat(getConfig(DUCKDB_MEMORY_LIMIT)).isEqualTo(configEntry(DUCKDB_MEMORY_LIMIT, duckDBConfig.getMemoryLimit().toString()));
-        assertThat(getConfig(DUCKDB_MAX_CONCURRENT_QUERIES)).isEqualTo(configEntry(DUCKDB_MAX_CONCURRENT_QUERIES, String.valueOf(duckDBConfig.getMaxConcurrentMetadataQueries())));
+        assertThat(getConfig(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES)).isEqualTo(configEntry(DUCKDB_MAX_CONCURRENT_METADATA_QUERIES, String.valueOf(duckDBConfig.getMaxConcurrentMetadataQueries())));
     }
 
     @Test

--- a/accio-tests/src/test/java/io/accio/testing/postgres/AbstractWireProtocolTestWithPostgres.java
+++ b/accio-tests/src/test/java/io/accio/testing/postgres/AbstractWireProtocolTestWithPostgres.java
@@ -15,13 +15,21 @@
 package io.accio.testing.postgres;
 
 import com.google.common.collect.ImmutableMap;
+import io.accio.base.dto.Manifest;
 import io.accio.testing.AbstractWireProtocolTest;
 import io.accio.testing.TestingAccioServer;
 import io.accio.testing.TestingPostgreSqlServer;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 public abstract class AbstractWireProtocolTestWithPostgres
         extends AbstractWireProtocolTest
 {
+    protected static final Manifest DEFAULT_MANIFEST = Manifest.builder()
+            .setCatalog("tpch")
+            .setSchema("tpch")
+            .build();
     private TestingPostgreSqlServer testingPostgreSqlServer;
 
     @Override
@@ -34,10 +42,19 @@ public abstract class AbstractWireProtocolTestWithPostgres
                 .put("postgres.password", testingPostgreSqlServer.getPassword())
                 .put("accio.datasource.type", "POSTGRES");
 
-        if (getAccioMDLPath().isPresent()) {
-            properties.put("accio.file", getAccioMDLPath().get());
+        try {
+            Path dir = Files.createTempDirectory(getAccioDirectory());
+            if (getAccioMDLPath().isPresent()) {
+                Files.copy(Path.of(getAccioMDLPath().get()), dir.resolve("mdl.json"));
+            }
+            else {
+                Files.write(dir.resolve("manifest.json"), Manifest.MANIFEST_JSON_CODEC.toJsonBytes(DEFAULT_MANIFEST));
+            }
+            properties.put("accio.directory", dir.toString());
         }
-
+        catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
         return TestingAccioServer.builder()
                 .setRequiredConfigs(properties.build())
                 .build();

--- a/etc/config.properties
+++ b/etc/config.properties
@@ -20,4 +20,4 @@ bigquery.location=
 bigquery.bucket-name=
 duckdb.storage.access-key=
 duckdb.storage.secret-key=
-accio.file=
+accio.directory=


### PR DESCRIPTION
# Description
- `accio.file`: After #421, use `accio.directory` instead.
- `bigquery.parent-project-id`: Only use `bigquery.project-id`.
- `duckdb.max-concurrent-queries`: fix the name to `duckdb.max-concurrent-metadata-queries`