### PR TITLE
Provide result set metadata in Preview data result

### DIFF
--- a/accio-main/src/main/java/io/accio/main/web/MDLResource.java
+++ b/accio-main/src/main/java/io/accio/main/web/MDLResource.java
@@ -91,6 +91,7 @@ public class MDLResource
     @GET
     @Path("/preview")
     @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public void preview(
             PreviewDto previewDto,
             @Suspended AsyncResponse asyncResponse)

--- a/accio-main/src/main/java/io/accio/main/web/dto/PreviewOutputDto.java
+++ b/accio-main/src/main/java/io/accio/main/web/dto/PreviewOutputDto.java
@@ -12,48 +12,37 @@
  * limitations under the License.
  */
 
-package io.accio.base;
+package io.accio.main.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.accio.base.type.AnyType;
-import io.accio.base.type.PGType;
-import io.accio.base.type.PGTypes;
+import io.accio.base.Column;
 
-public final class Column
+import java.util.List;
+
+public class PreviewOutputDto
 {
-    private final String name;
-    private final PGType<?> type;
+    private final List<Column> columns;
+    private final List<Object[]> data;
 
     @JsonCreator
-    public Column(
-            @JsonProperty("name") String name,
-            @JsonProperty("type") String type)
+    public PreviewOutputDto(
+            @JsonProperty("columns") List<Column> columns,
+            @JsonProperty("data") List<Object[]> data)
     {
-        this.name = name;
-        this.type = PGTypes.nameToPgType(type).orElse(AnyType.ANY);
-    }
-
-    public Column(String name, PGType<?> type)
-    {
-        this.name = name;
-        this.type = type;
+        this.columns = columns;
+        this.data = data;
     }
 
     @JsonProperty
-    public String getName()
+    public List<Column> getColumns()
     {
-        return name;
+        return columns;
     }
 
-    public PGType<?> getType()
+    @JsonProperty
+    public List<Object[]> getData()
     {
-        return type;
-    }
-
-    @JsonProperty("type")
-    public String getTypeName()
-    {
-        return type.typName();
+        return data;
     }
 }

--- a/accio-tests/src/test/java/io/accio/testing/RequireAccioServer.java
+++ b/accio-tests/src/test/java/io/accio/testing/RequireAccioServer.java
@@ -26,6 +26,7 @@ import io.accio.main.web.dto.DeployInputDto;
 import io.accio.main.web.dto.ErrorMessageDto;
 import io.accio.main.web.dto.LineageResult;
 import io.accio.main.web.dto.PreviewDto;
+import io.accio.main.web.dto.PreviewOutputDto;
 import io.accio.main.web.dto.SqlAnalysisInputDto;
 import io.accio.main.web.dto.SqlAnalysisOutputDto;
 import io.airlift.http.client.HttpClient;
@@ -81,6 +82,7 @@ public abstract class RequireAccioServer
     private static final JsonCodec<List<SqlAnalysisOutputDto>> SQL_ANALYSIS_OUTPUT_LIST_CODEC = listJsonCodec(SqlAnalysisOutputDto.class);
     private static final JsonCodec<ConfigManager.ConfigEntry> CONFIG_ENTRY_JSON_CODEC = jsonCodec(ConfigManager.ConfigEntry.class);
     private static final JsonCodec<List<ConfigManager.ConfigEntry>> CONFIG_ENTRY_LIST_CODEC = listJsonCodec(ConfigManager.ConfigEntry.class);
+    private static final JsonCodec<PreviewOutputDto> PREVIEW_OUTPUT_DTO_CODEC = jsonCodec(PreviewOutputDto.class);
 
     public RequireAccioServer() {}
 
@@ -151,7 +153,7 @@ public abstract class RequireAccioServer
         return client.execute(request, responseHandler);
     }
 
-    protected List<Object[]> preview(PreviewDto previewDto)
+    protected PreviewOutputDto preview(PreviewDto previewDto)
     {
         Request request = prepareGet()
                 .setUri(server().getHttpServerBasedUrl().resolve("/v1/mdl/preview"))
@@ -163,7 +165,7 @@ public abstract class RequireAccioServer
         if (response.getStatusCode() != 200) {
             getWebApplicationException(response);
         }
-        return JsonCodec.listJsonCodec(Object[].class).fromJson(response.getBody());
+        return PREVIEW_OUTPUT_DTO_CODEC.fromJson(response.getBody());
     }
 
     protected void deployMDL(DeployInputDto dto)

--- a/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
+++ b/accio-tests/src/test/java/io/accio/testing/TestMDLResource.java
@@ -16,9 +16,11 @@ package io.accio.testing;
 
 import com.google.common.collect.ImmutableMap;
 import io.accio.base.dto.Manifest;
+import io.accio.base.type.BigIntType;
 import io.accio.main.web.dto.CheckOutputDto;
 import io.accio.main.web.dto.DeployInputDto;
 import io.accio.main.web.dto.PreviewDto;
+import io.accio.main.web.dto.PreviewOutputDto;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -119,19 +121,21 @@ public class TestMDLResource
                 .build();
 
         PreviewDto testDefaultDto = new PreviewDto(previewManifest, "select custkey from Customer", null);
-        List<Object[]> testDefault = preview(testDefaultDto);
-        assertThat(testDefault.size()).isEqualTo(100);
-        assertThat(testDefault.get(0).length).isEqualTo(1);
+        PreviewOutputDto testDefault = preview(testDefaultDto);
+        assertThat(testDefault.getData().size()).isEqualTo(100);
+        assertThat(testDefault.getColumns().size()).isEqualTo(1);
+        assertThat(testDefault.getColumns().get(0).getName()).isEqualTo("custkey");
+        assertThat(testDefault.getColumns().get(0).getType()).isEqualTo(BigIntType.BIGINT);
 
         PreviewDto testDefaultDto1 = new PreviewDto(previewManifest, "select custkey from Customer limit 200", null);
-        List<Object[]> preview1 = preview(testDefaultDto1);
-        assertThat(preview1.size()).isEqualTo(100);
-        assertThat(preview1.get(0).length).isEqualTo(1);
+        PreviewOutputDto preview1 = preview(testDefaultDto1);
+        assertThat(preview1.getData().size()).isEqualTo(100);
+        assertThat(preview1.getColumns().size()).isEqualTo(1);
 
         PreviewDto testDefaultDto2 = new PreviewDto(previewManifest, "select custkey from Customer limit 200", 150L);
-        List<Object[]> preview2 = preview(testDefaultDto2);
-        assertThat(preview2.size()).isEqualTo(150);
-        assertThat(preview2.get(0).length).isEqualTo(1);
+        PreviewOutputDto preview2 = preview(testDefaultDto2);
+        assertThat(preview2.getData().size()).isEqualTo(150);
+        assertThat(preview2.getColumns().size()).isEqualTo(1);
 
         assertWebApplicationException(() -> preview(new PreviewDto(previewManifest, "select orderkey from Orders limit 100", null)))
                 .hasErrorMessageMatches(".*Table \"Orders\" must be qualified with a dataset.*");


### PR DESCRIPTION
# Description
To make user can be more easier to use the preview data API. This PR adds the column metadata for the result set.

# Sample Result
Given a input
```json
{
    "manifest" : {
        "catalog": "canner-cml",
        "schema": "tpch_tiny",
        "models": [
            {
                "name": "Orders",
                "refSql": "select * from \"canner-cml\".\"tpch_tiny\".\"orders\"",
                "columns": [
                    {
                        "name": "o_orderkey",
                        "type": "integer"
                    },
                    {
                        "name": "o_orderdate",
                        "type": "date"
                    
                    }
                ]
            }
        ]
    },
    "sql": "select o_orderkey, o_orderdate from Orders",
    "limit": 20
}
```

The output for the preview will be
```json
{
    "columns": [
        {
            "name": "o_orderkey",
            "type": "int8"
        },
        {
            "name": "o_orderdate",
            "type": "date"
        }
    ],
    "data": [
        [
            37315,
            "1992-06-06"
        ],
        [
            36485,
            "1992-06-06"
        ],
   ...
   }
}
```
