### PR TITLE
Support query view in dynamic access mode

### DIFF
--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioPlanner.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/AccioPlanner.java
@@ -23,15 +23,18 @@ import io.trino.sql.tree.Statement;
 
 import java.util.List;
 
+import static io.accio.base.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
 import static io.accio.base.sqlrewrite.EnumRewrite.ENUM_REWRITE;
+import static io.accio.base.sqlrewrite.GenerateViewRewrite.GENERATE_VIEW_REWRITE;
 import static io.accio.base.sqlrewrite.MetricRollupRewrite.METRIC_ROLLUP_REWRITE;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
 
 public class AccioPlanner
 {
     public static final List<AccioRule> ALL_RULES = List.of(
+            GENERATE_VIEW_REWRITE,
             METRIC_ROLLUP_REWRITE,
-            AccioSqlRewrite.ACCIO_SQL_REWRITE,
+            ACCIO_SQL_REWRITE,
             ENUM_REWRITE);
     private static final SqlParser SQL_PARSER = new SqlParser();
 

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/GenerateViewRewrite.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/GenerateViewRewrite.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import io.accio.base.AnalyzedMDL;
+import io.accio.base.SessionContext;
+import io.accio.base.sqlrewrite.analyzer.Analysis;
+import io.accio.base.sqlrewrite.analyzer.StatementAnalyzer;
+import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.WithQuery;
+import org.jgrapht.graph.DirectedAcyclicGraph;
+import org.jgrapht.graph.GraphCycleProhibitedException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.accio.base.Utils.checkArgument;
+import static io.accio.base.sqlrewrite.WithRewriter.getWithQuery;
+import static java.util.stream.Collectors.toSet;
+
+public class GenerateViewRewrite
+        implements AccioRule
+{
+    public static final GenerateViewRewrite GENERATE_VIEW_REWRITE = new GenerateViewRewrite();
+
+    @Override
+    public Statement apply(Statement root, SessionContext sessionContext, AnalyzedMDL analyzedMDL)
+    {
+        Analysis analysis = new Analysis(root);
+        StatementAnalyzer.analyze(analysis, root, sessionContext, analyzedMDL.getAccioMDL());
+        return apply(root, sessionContext, analysis, analyzedMDL);
+    }
+
+    @Override
+    public Statement apply(Statement root, SessionContext sessionContext, Analysis analysis, AnalyzedMDL analyzedMDL)
+    {
+        Set<QueryDescriptor> viewDescriptors = analysis.getViews().stream().map(view -> ViewInfo.get(view, analyzedMDL, sessionContext)).collect(toSet());
+        DirectedAcyclicGraph<String, Object> graph = new DirectedAcyclicGraph<>(Object.class);
+        Set<QueryDescriptor> requiredQueryDescriptors = new HashSet<>();
+        viewDescriptors.forEach(viewDescriptor -> addSqlDescriptorToGraph(viewDescriptor, graph, analyzedMDL, requiredQueryDescriptors, sessionContext));
+
+        Map<String, QueryDescriptor> descriptorMap = new HashMap<>();
+        viewDescriptors.forEach(queryDescriptor -> descriptorMap.put(queryDescriptor.getName(), queryDescriptor));
+        requiredQueryDescriptors.forEach(queryDescriptor -> descriptorMap.put(queryDescriptor.getName(), queryDescriptor));
+
+        List<WithQuery> withQueries = new ArrayList<>();
+        graph.iterator().forEachRemaining(objectName -> {
+            QueryDescriptor queryDescriptor = descriptorMap.get(objectName);
+            checkArgument(queryDescriptor != null, objectName + " not found in query descriptors");
+            withQueries.add(getWithQuery(queryDescriptor));
+        });
+
+        return (Statement) new WithRewriter(withQueries).process(root);
+    }
+
+    private static void addSqlDescriptorToGraph(
+            QueryDescriptor queryDescriptor,
+            DirectedAcyclicGraph<String, Object> graph,
+            AnalyzedMDL analyzedMDL,
+            Set<QueryDescriptor> queryDescriptors,
+            SessionContext sessionContext)
+    {
+        // add vertex
+        graph.addVertex(queryDescriptor.getName());
+        Set<String> requiredViews = queryDescriptor.getRequiredObjects().stream()
+                .filter(name -> analyzedMDL.getAccioMDL().getView(name).isPresent()).collect(toSet());
+        requiredViews.forEach(graph::addVertex);
+
+        //add edge
+        try {
+            requiredViews.forEach(name ->
+                    graph.addEdge(name, queryDescriptor.getName()));
+        }
+        catch (GraphCycleProhibitedException ex) {
+            throw new IllegalArgumentException("found cycle in view", ex);
+        }
+        catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("found issue in view", ex);
+        }
+
+        // add required view to graph
+        requiredViews.forEach(name -> {
+            ViewInfo descriptor = (ViewInfo) QueryDescriptor.of(name, analyzedMDL, sessionContext);
+            queryDescriptors.add(descriptor);
+            addSqlDescriptorToGraph(descriptor, graph, analyzedMDL, queryDescriptors, sessionContext);
+        });
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/WithRewriter.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/WithRewriter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.Query;
+import io.trino.sql.tree.With;
+import io.trino.sql.tree.WithQuery;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+public class WithRewriter
+        extends BaseRewriter<Void>
+{
+    private final List<WithQuery> withQueries;
+
+    public WithRewriter(List<WithQuery> withQueries)
+    {
+        this.withQueries = requireNonNull(withQueries, "withQueries is null");
+    }
+
+    @Override
+    protected Node visitQuery(Query node, Void context)
+    {
+        return new Query(
+                node.getWith()
+                        .map(with -> new With(
+                                with.isRecursive(),
+                                // model queries must come first since with-queries may use models
+                                // and tables in with query should all be in order.
+                                Stream.concat(withQueries.stream(), with.getQueries().stream())
+                                        .collect(toUnmodifiableList())))
+                        .or(() -> withQueries.isEmpty() ? Optional.empty() : Optional.of(new With(false, withQueries))),
+                node.getQueryBody(),
+                node.getOrderBy(),
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    public static WithQuery getWithQuery(QueryDescriptor queryDescriptor)
+    {
+        return new WithQuery(new Identifier(queryDescriptor.getName(), true), queryDescriptor.getQuery(), Optional.empty());
+    }
+}

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetricViewSqlRewrite.java
@@ -37,6 +37,7 @@ import static io.accio.base.dto.TimeGrain.timeGrain;
 import static io.accio.base.dto.TimeUnit.YEAR;
 import static io.accio.base.dto.View.view;
 import static io.accio.base.sqlrewrite.AccioSqlRewrite.ACCIO_SQL_REWRITE;
+import static io.accio.base.sqlrewrite.GenerateViewRewrite.GENERATE_VIEW_REWRITE;
 import static io.accio.base.sqlrewrite.MetricRollupRewrite.METRIC_ROLLUP_REWRITE;
 import static io.accio.base.sqlrewrite.Utils.SQL_PARSER;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
@@ -313,6 +314,6 @@ public class TestMetricViewSqlRewrite
 
     private String rewrite(String sql, AccioMDL accioMDL)
     {
-        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null), List.of(METRIC_ROLLUP_REWRITE, ACCIO_SQL_REWRITE));
+        return AccioPlanner.rewrite(sql, DEFAULT_SESSION_CONTEXT, new AnalyzedMDL(accioMDL, null), List.of(GENERATE_VIEW_REWRITE, METRIC_ROLLUP_REWRITE, ACCIO_SQL_REWRITE));
     }
 }


### PR DESCRIPTION
# Description
This PR allows user to query views in dynamic access mode. The statement of view will be used to create a CTE. Every behavior of dynamic accessing only apply on the internal statement.

# Example
When dynamic accessing is enable, given view and metric
```
metric CountOrders @baseObject(Orders) {
   custkey: integer @dim
   orderstatus: varchar @dim
   totalprice: integer @measure(sum(totalprice))
}

view {
  "selectAll": "select * from CountOrders",
  "selectOneDim": "select custkey from CountOrders"
}
```

Query a SQL
```
select custkey from selectAll
```
The CountOrders will be grouped by all dimension, `custkey` and `orderstatus`.

Query another SQL
```
select custkey from selectOneDim
```
The CountOrders will be grouped by `custkey`.
