### PR TITLE
Add TableReference field for Model to optimize the query projection

### DIFF
--- a/accio-base/src/main/java/io/accio/base/AccioMDL.java
+++ b/accio-base/src/main/java/io/accio/base/AccioMDL.java
@@ -93,6 +93,7 @@ public class AccioMDL
                     model.getName(),
                     model.getRefSql(),
                     model.getBaseObject(),
+                    model.getTableReference(),
                     processed,
                     model.getPrimaryKey(),
                     model.isCached(),

--- a/accio-base/src/main/java/io/accio/base/dto/Model.java
+++ b/accio-base/src/main/java/io/accio/base/dto/Model.java
@@ -34,6 +34,7 @@ public class Model
     private final String name;
     private final String refSql;
     private final String baseObject;
+    private final TableReference tableReference;
     private final List<Column> columns;
     private final String primaryKey;
     private final boolean cached;
@@ -47,22 +48,22 @@ public class Model
 
     public static Model model(String name, String refSql, List<Column> columns, boolean cached)
     {
-        return new Model(name, refSql, null, columns, null, cached, null, ImmutableMap.of());
+        return new Model(name, refSql, null, null, columns, null, cached, null, ImmutableMap.of());
     }
 
     public static Model model(String name, String refSql, List<Column> columns, String primaryKey)
     {
-        return model(name, refSql, columns, primaryKey, null);
-    }
-
-    public static Model model(String name, String refSql, List<Column> columns, String primaryKey, String description)
-    {
-        return new Model(name, refSql, null, columns, primaryKey, false, null, ImmutableMap.of());
+        return new Model(name, refSql, null, null, columns, primaryKey, false, null, ImmutableMap.of());
     }
 
     public static Model onBaseObject(String name, String baseObject, List<Column> columns, String primaryKey)
     {
-        return new Model(name, null, baseObject, columns, primaryKey, false, null, ImmutableMap.of());
+        return new Model(name, null, baseObject, null, columns, primaryKey, false, null, ImmutableMap.of());
+    }
+
+    public static Model onTableReference(String name, TableReference tableReference, List<Column> columns, String primaryKey)
+    {
+        return new Model(name, null, null, tableReference, columns, primaryKey, false, null, ImmutableMap.of());
     }
 
     @JsonCreator
@@ -70,6 +71,7 @@ public class Model
             @JsonProperty("name") String name,
             @JsonProperty("refSql") String refSql,
             @JsonProperty("baseObject") String baseObject,
+            @JsonProperty("tableReference") TableReference tableReference,
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("primaryKey") String primaryKey,
             @JsonProperty("cached") boolean cached,
@@ -77,15 +79,27 @@ public class Model
             @JsonProperty("properties") Map<String, String> properties)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
-        checkArgument(Stream.of(refSql, baseObject).filter(value -> value == null || value.isEmpty()).count() == 1,
-                "either none or more than one of (refSql, baseObject) are set");
+        checkArgument(Stream.of(refSql, baseObject, tableReference).filter(Model::isSet).count() == 1,
+                "either none or more than one of (refSql, baseObject, tableReference) are set");
         this.refSql = refSql;
         this.baseObject = baseObject;
+        this.tableReference = tableReference;
         this.columns = columns == null ? List.of() : columns;
         this.primaryKey = primaryKey;
         this.cached = cached;
         this.refreshTime = refreshTime == null ? defaultRefreshTime : refreshTime;
         this.properties = properties == null ? ImmutableMap.of() : properties;
+    }
+
+    private static boolean isSet(Object value)
+    {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof String) {
+            return !((String) value).isEmpty();
+        }
+        return true;
     }
 
     @JsonProperty
@@ -105,6 +119,12 @@ public class Model
     public String getBaseObject()
     {
         return baseObject;
+    }
+
+    @JsonProperty
+    public TableReference getTableReference()
+    {
+        return tableReference;
     }
 
     @Override
@@ -154,6 +174,7 @@ public class Model
                 Objects.equals(name, that.name) &&
                 Objects.equals(refSql, that.refSql) &&
                 Objects.equals(baseObject, that.baseObject) &&
+                Objects.equals(tableReference, that.tableReference) &&
                 Objects.equals(columns, that.columns) &&
                 Objects.equals(primaryKey, that.primaryKey) &&
                 Objects.equals(refreshTime, that.refreshTime) &&
@@ -163,7 +184,7 @@ public class Model
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, refSql, baseObject, columns, primaryKey, properties);
+        return Objects.hash(name, refSql, baseObject, tableReference, columns, primaryKey, properties);
     }
 
     @Override
@@ -173,6 +194,7 @@ public class Model
                 .add("name", name)
                 .add("refSql", refSql)
                 .add("baseObject", baseObject)
+                .add("tableReference", tableReference)
                 .add("columns", columns)
                 .add("cached", cached)
                 .add("refreshTime", refreshTime)

--- a/accio-base/src/main/java/io/accio/base/dto/Model.java
+++ b/accio-base/src/main/java/io/accio/base/dto/Model.java
@@ -79,7 +79,7 @@ public class Model
             @JsonProperty("properties") Map<String, String> properties)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
-        checkArgument(Stream.of(refSql, baseObject, tableReference).filter(Model::isSet).count() == 1,
+        checkArgument(Stream.of(refSql, baseObject, tableReference).filter(Model::isNonNullOrNonEmpty).count() == 1,
                 "either none or more than one of (refSql, baseObject, tableReference) are set");
         this.refSql = refSql;
         this.baseObject = baseObject;
@@ -91,7 +91,7 @@ public class Model
         this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
-    private static boolean isSet(Object value)
+    private static boolean isNonNullOrNonEmpty(Object value)
     {
         if (value == null) {
             return false;

--- a/accio-base/src/main/java/io/accio/base/dto/TableReference.java
+++ b/accio-base/src/main/java/io/accio/base/dto/TableReference.java
@@ -17,6 +17,8 @@ package io.accio.base.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.accio.base.Utils.requireNonNullEmpty;
 import static java.lang.String.format;
@@ -75,6 +77,25 @@ public class TableReference
     private boolean isNullOrEmpty(String str)
     {
         return str == null || str.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableReference that = (TableReference) o;
+        return Objects.equals(catalog, that.catalog) && Objects.equals(schema, that.schema) && Objects.equals(table, that.table);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(catalog, schema, table);
     }
 
     @Override

--- a/accio-base/src/main/java/io/accio/base/dto/TableReference.java
+++ b/accio-base/src/main/java/io/accio/base/dto/TableReference.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.accio.base.Utils.requireNonNullEmpty;
+import static java.lang.String.format;
+
+public class TableReference
+{
+    public static TableReference tableReference(String catalog, String schema, String table)
+    {
+        return new TableReference(catalog, schema, table);
+    }
+
+    private final String catalog;
+    private final String schema;
+    private final String table;
+
+    @JsonCreator
+    public TableReference(
+            @JsonProperty("catalog") String catalog,
+            @JsonProperty("schema") String schema,
+            @JsonProperty("table") String table)
+    {
+        this.catalog = catalog;
+        this.schema = schema;
+        this.table = requireNonNullEmpty(table, "table should not be empty");
+    }
+
+    @JsonProperty
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    @JsonProperty
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public String getTable()
+    {
+        return table;
+    }
+
+    public String toQualifiedName()
+    {
+        if (isNullOrEmpty(catalog)) {
+            if (isNullOrEmpty(schema)) {
+                return format("\"%s\"", table);
+            }
+            return format("\"%s\".\"%s\"", schema, table);
+        }
+        return format("\"%s\".\"%s\".\"%s\"", catalog, schema, table);
+    }
+
+    private boolean isNullOrEmpty(String str)
+    {
+        return str == null || str.isEmpty();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalog", catalog)
+                .add("schema", schema)
+                .add("table", table)
+                .toString();
+    }
+}

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
@@ -65,10 +65,14 @@ public class ModelSqlRender
         checkArgument(relationable instanceof Model, "relationable must be model");
         Model model = (Model) relationable;
         if (model.getRefSql() != null) {
-            return model.getRefSql();
+            return "(" + model.getRefSql() + ")";
         }
         else if (model.getBaseObject() != null) {
-            return "SELECT * FROM \"" + model.getBaseObject() + "\"";
+            return "(SELECT * FROM \"" + model.getBaseObject() + "\")";
+        }
+        else if (model.getTableReference() != null) {
+
+            return model.getTableReference().toQualifiedName();
         }
         else {
             throw new IllegalArgumentException("cannot get reference sql from model");
@@ -279,6 +283,6 @@ public class ModelSqlRender
                 .filter(column -> column.getRelationship().isEmpty())
                 .map(column -> format("%s AS \"%s\"", column.getSqlExpression(), column.getName()))
                 .collect(joining(", "));
-        return format("SELECT %s FROM (%s) AS \"%s\"", selectItems, refSql, model.getName());
+        return format("SELECT %s FROM %s AS \"%s\"", selectItems, refSql, model.getName());
     }
 }

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
@@ -71,7 +71,6 @@ public class ModelSqlRender
             return "(SELECT * FROM \"" + model.getBaseObject() + "\")";
         }
         else if (model.getTableReference() != null) {
-
             return model.getTableReference().toQualifiedName();
         }
         else {

--- a/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
+++ b/accio-base/src/main/java/io/accio/base/sqlrewrite/ModelSqlRender.java
@@ -218,7 +218,7 @@ public class ModelSqlRender
                 .forEach(column -> collectRelationship(column, baseModel));
         String modelSubQuerySelectItemsExpression = getModelSubQuerySelectItemsExpression(columnWithoutRelationships);
 
-        String modelSubQuery = format("(SELECT %s FROM (%s) AS \"%s\") AS \"%s\"",
+        String modelSubQuery = format("(SELECT %s FROM %s AS \"%s\") AS \"%s\"",
                 modelSubQuerySelectItemsExpression,
                 refSql,
                 baseModel.getName(),

--- a/accio-base/src/test/java/io/accio/base/dto/TestManifestSerDe.java
+++ b/accio-base/src/test/java/io/accio/base/dto/TestManifestSerDe.java
@@ -52,6 +52,7 @@ public class TestManifestSerDe
                         new Model("OrdersModel",
                                 "select * from orders",
                                 null,
+                                null,
                                 List.of(
                                         new Column("orderkey", "integer", null, false, true, null,
                                                 ImmutableMap.of("description", "the key of each order")),
@@ -71,6 +72,7 @@ public class TestManifestSerDe
                         new Model("LineitemModel",
                                 "select * from lineitem",
                                 null,
+                                null,
                                 List.of(
                                         new Column("orderkey", "integer", null, false, true, null, null),
                                         new Column("linenumber", "integer", null, false, true, null, null),
@@ -80,8 +82,9 @@ public class TestManifestSerDe
                                 null,
                                 null),
                         new Model("CustomerModel",
-                                "select * from customer",
                                 null,
+                                null,
+                                new TableReference("test-catalog", "test-schema", "customer"),
                                 List.of(
                                         new Column("custkey", "integer", null, false, true, null, null),
                                         new Column("name", "string", null, false, true, null, null),

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/AbstractTestFramework.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/AbstractTestFramework.java
@@ -32,7 +32,6 @@ import org.testng.annotations.BeforeClass;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.accio.base.dto.Model.model;
 import static io.trino.sql.SqlFormatter.Dialect.DUCKDB;
 import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
@@ -53,14 +52,19 @@ public abstract class AbstractTestFramework
 
     public static Model addColumnsToModel(Model model, Column... columns)
     {
-        return model(
+        return new Model(
                 model.getName(),
                 model.getRefSql(),
+                model.getBaseObject(),
+                model.getTableReference(),
                 ImmutableList.<Column>builder()
                         .addAll(model.getColumns())
                         .add(columns)
                         .build(),
-                model.getPrimaryKey());
+                model.getPrimaryKey(),
+                model.isCached(),
+                model.getRefreshTime(),
+                model.getProperties());
     }
 
     @BeforeClass

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestMetric.java
@@ -35,7 +35,9 @@ import static io.accio.base.dto.JoinType.ONE_TO_MANY;
 import static io.accio.base.dto.Metric.metric;
 import static io.accio.base.dto.Model.model;
 import static io.accio.base.dto.Model.onBaseObject;
+import static io.accio.base.dto.Model.onTableReference;
 import static io.accio.base.dto.Relationship.relationship;
+import static io.accio.base.dto.TableReference.tableReference;
 import static io.accio.base.dto.TimeGrain.timeGrain;
 import static io.accio.base.dto.TimeUnit.DAY;
 import static io.accio.base.dto.TimeUnit.MONTH;
@@ -55,8 +57,8 @@ public class TestMetric
     {
         manifest = withDefaultCatalogSchema()
                 .setModels(List.of(
-                        model("Orders",
-                                "select * from main.orders",
+                        onTableReference("Orders",
+                                tableReference("memory", "main", "orders"),
                                 List.of(
                                         column("orderkey", INTEGER, null, true),
                                         column("custkey", INTEGER, null, true),

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelRefSql.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelRefSql.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import static io.accio.base.dto.Model.model;
+
+public class TestModelRefSql
+        extends AbstractTestModel
+{
+    public TestModelRefSql()
+    {
+        super();
+        orders = model("Orders", "select * from main.orders", ordersColumns, "orderkey");
+        lineitem = model("Lineitem", "select * from main.lineitem", lineitemColumns, "orderkey_linenumber");
+        customer = model("Customer", "select * from main.customer", customerColumns, "custkey");
+    }
+}

--- a/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelTableReference.java
+++ b/accio-base/src/test/java/io/accio/base/sqlrewrite/TestModelTableReference.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.accio.base.sqlrewrite;
+
+import io.accio.base.dto.Model;
+
+import static io.accio.base.dto.TableReference.tableReference;
+
+public class TestModelTableReference
+        extends AbstractTestModel
+{
+    public TestModelTableReference()
+    {
+        super();
+        orders = Model.onTableReference("Orders", tableReference("memory", "main", "orders"), ordersColumns, "orderkey");
+        lineitem = Model.onTableReference("Lineitem", tableReference("memory", "main", "lineitem"), lineitemColumns, "orderkey_linenumber");
+        customer = Model.onTableReference("Customer", tableReference("memory", "main", "customer"), customerColumns, "custkey");
+    }
+}

--- a/accio-main/src/test/java/io/accio/main/pgcatalog/builder/TestCreateBigQueryTempTable.java
+++ b/accio-main/src/test/java/io/accio/main/pgcatalog/builder/TestCreateBigQueryTempTable.java
@@ -65,8 +65,7 @@ public class TestCreateBigQueryTempTable
                                                 column("shippriority", "int4", null, true),
                                                 column("comment", "varchar", null, true),
                                                 column("customer", "CustomerModel", "OrdersCustomer", true)),
-                                        "orderkey",
-                                        "tpch tiny orders table"),
+                                        "orderkey"),
                                 model("LineitemModel",
                                         "select * from lineitem",
                                         List.of(
@@ -168,8 +167,7 @@ public class TestCreateBigQueryTempTable
                                                 column("c_bool_array4", "bool array", null, true),
                                                 column("c_boolean_array", "boolean[]", null, true),
                                                 column("c_boolean_array2", "boolean array", null, true)),
-                                        "c_boolean",
-                                        "test type table")))
+                                        "c_boolean")))
                         .build());
 
         assertThat(createOrReplaceAllColumn(typeMDL, ACCIO_TEMP_NAME, PG_CATALOG_NAME))

--- a/accio-tests/src/test/resources/bigquery/TestWireProtocolWithBigquery.json
+++ b/accio-tests/src/test/resources/bigquery/TestWireProtocolWithBigquery.json
@@ -24,7 +24,11 @@
   "models": [
     {
       "name": "Orders",
-      "refSql": "select * from \"canner-cml\".tpch_tiny.orders",
+      "tableReference": {
+        "catalog": "canner-cml",
+        "schema": "tpch_tiny",
+        "table": "orders"
+      },
       "columns": [
         {
           "name": "orderkey",


### PR DESCRIPTION
# Description
To optimize the SQL easily, we provide a new way to build a model. `TableReference` is build from `catalog`, `schema` and `table` which point to the physical table in the datasource. Instead of `refSql`, we can accurately to set which columns the SQL actually used.  This way make data source side can optimize the SQL plan more easily.

# Sample
```
{
   "name": "Orders",
   "tableReference: {
        "catalog": "memory",
        "schema": "tpch",
        "table": "orders"
    },
    columns: [
        ...
    ]
}
```