### PR TITLE
Optimize the behavior of server deploying

### DIFF
--- a/wren-base/src/main/java/io/wren/base/client/duckdb/FileUtil.java
+++ b/wren-base/src/main/java/io/wren/base/client/duckdb/FileUtil.java
@@ -25,6 +25,8 @@ import static java.nio.file.StandardOpenOption.APPEND;
 
 public class FileUtil
 {
+    public static final String ARCHIVED = "archived";
+
     private FileUtil() {}
 
     public static void createDir(Path path)
@@ -73,7 +75,7 @@ public class FileUtil
             if (!Files.exists(path)) {
                 return;
             }
-            Path archiveDir = path.getParent().resolve("archive");
+            Path archiveDir = path.getParent().resolve(ARCHIVED);
             if (!Files.exists(archiveDir)) {
                 createDir(archiveDir);
             }

--- a/wren-base/src/main/java/io/wren/base/config/ConfigManager.java
+++ b/wren-base/src/main/java/io/wren/base/config/ConfigManager.java
@@ -59,6 +59,7 @@ import static io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig.DUCKDB_STORA
 import static io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig.DUCKDB_STORAGE_REGION;
 import static io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig.DUCKDB_STORAGE_SECRET_KEY;
 import static io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig.DUCKDB_STORAGE_URL_STYLE;
+import static io.wren.base.client.duckdb.FileUtil.ARCHIVED;
 import static io.wren.base.config.PostgresConfig.POSTGRES_JDBC_URL;
 import static io.wren.base.config.PostgresConfig.POSTGRES_PASSWORD;
 import static io.wren.base.config.PostgresConfig.POSTGRES_USER;
@@ -386,7 +387,7 @@ public class ConfigManager
             throws IOException
     {
         Path home = new File(configFile).getParentFile().toPath();
-        File archived = home.resolve("archived").toFile();
+        File archived = home.resolve(ARCHIVED).toFile();
         if (!archived.exists()) {
             if (!archived.mkdir()) {
                 throw new IOException("Cannot create archive folder");

--- a/wren-main/src/main/java/io/wren/main/WrenManager.java
+++ b/wren-main/src/main/java/io/wren/main/WrenManager.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.wren.base.Utils.checkArgument;
+import static io.wren.base.client.duckdb.FileUtil.ARCHIVED;
 import static io.wren.base.dto.Manifest.MANIFEST_JSON_CODEC;
 import static io.wren.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -130,7 +131,7 @@ public class WrenManager
             throws IOException
     {
         cacheManager.removeCacheIfExist(oldWrenMDL.getCatalog(), oldWrenMDL.getSchema());
-        File archived = new File(wrenMDLDirectory.getAbsoluteFile() + "/archive");
+        File archived = new File(wrenMDLDirectory.getAbsoluteFile() + "/" + ARCHIVED);
         if (!archived.exists()) {
             if (!archived.mkdir()) {
                 throw new IOException("Cannot create archive folder");

--- a/wren-main/src/main/java/io/wren/main/connector/duckdb/DuckDBMetadata.java
+++ b/wren-main/src/main/java/io/wren/main/connector/duckdb/DuckDBMetadata.java
@@ -232,8 +232,9 @@ public class DuckDBMetadata
         try {
             return configManager.getConfig(CacheStorageConfig.class);
         }
-        catch (Exception e) {
-            LOG.warn(e, "%s connector does not support cache storage. Cache is disable.", configManager.getConfig(WrenConfig.class).getDataSourceType().name());
+        catch (Exception ignored) {
+            LOG.debug(ignored, "Failed to get cache storage config");
+            LOG.warn("%s connector does not support cache storage. Cache is disable.", configManager.getConfig(WrenConfig.class).getDataSourceType().name());
             return null;
         }
     }

--- a/wren-main/src/main/java/io/wren/main/wireprotocol/PgMetastoreImpl.java
+++ b/wren-main/src/main/java/io/wren/main/wireprotocol/PgMetastoreImpl.java
@@ -149,8 +149,9 @@ public class PgMetastoreImpl
         try {
             return configManager.getConfig(CacheStorageConfig.class);
         }
-        catch (Exception e) {
-            LOG.warn(e, "%s connector does not support cache storage. Cache is disable.", configManager.getConfig(WrenConfig.class).getDataSourceType().name());
+        catch (Exception ignored) {
+            LOG.debug(ignored, "Failed to get cache storage config");
+            LOG.warn("%s connector does not support cache storage. Cache is disable.", configManager.getConfig(WrenConfig.class).getDataSourceType().name());
             return null;
         }
     }

--- a/wren-tests/src/test/java/io/wren/testing/TestMDLResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestMDLResource.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static io.wren.base.Utils.randomIntString;
+import static io.wren.base.client.duckdb.FileUtil.ARCHIVED;
 import static io.wren.base.dto.Column.column;
 import static io.wren.base.dto.Manifest.MANIFEST_JSON_CODEC;
 import static io.wren.base.dto.Model.model;
@@ -105,7 +106,7 @@ public class TestMDLResource
         assertThat(getCurrentManifest().getModels().get(0).getColumns().size()).isEqualTo(1);
         waitUntilReady();
 
-        assertThat(requireNonNull(mdlDir.resolve("archive").toFile().listFiles()).length).isEqualTo(2);
+        assertThat(requireNonNull(mdlDir.resolve(ARCHIVED).toFile().listFiles()).length).isEqualTo(2);
         assertThatNoException().isThrownBy(() -> preview(new PreviewDto(null, "select orderkey from Orders limit 100", null)));
     }
 


### PR DESCRIPTION
# Changed
- Hide the stack trace when cache isn't supported
    - To simplify the server start message, show the exception stack trace when log level is debug only.
- Unify the name of archive folder to `archived`.