### PR TITLE
Refine the release and deploy flow

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -43,6 +43,6 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag ghcr.io/canner/wren-engine:main-${LATEST_COMMIT} \
-            --tag ghcr.io/canner/wren-engine:latest \
+            --tag ghcr.io/canner/wren-engine:nightly \
             --push -f ./Dockerfile \
             --build-arg "WREN_VERSION=${WREN_VERSION}" .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy
 
 on:
-  push:
-    tags:
-      - '**'
+  workflow_dispatch
 
 jobs:
   deploy:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -16,8 +16,8 @@ jobs:
           token: ${{ secrets.GHCR_TOKEN }}
       - name: Set up Git
         run: |
-          git config --global user.email "liugs963@gmail.com"
-          git config --global user.name "goldmedal"
+          git config --global user.email "fake@cannerdata.com"
+          git config --global user.name "stable-release-bot"
       - name: Maven Prepare Release
         id: maven_prepare_release
         run: |

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,0 +1,63 @@
+name: Stable Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      specific_version:
+        type: string
+        description: Specific version number (Optional). Default will be the current version plus 0.0.1.
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GHCR_TOKEN }}
+      - name: Set up Git
+        run: |
+          git config --global user.email "liugs963@gmail.com"
+          git config --global user.name "goldmedal"
+      - name: Maven Prepare Release
+        id: maven_prepare_release
+        run: |
+          if [ -n "${{ github.event.inputs.specific_version }}" ]; then
+            version_number=${{ github.event.inputs.specific_version }}
+            ./mvnw release:prepare -B -DreleaseVersion=${{ github.event.inputs.specific_version }}
+          else
+            version_number=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout | sed -n 's/^\(.*\)-SNAPSHOT/\1/p')
+            ./mvnw release:prepare -B -DreleaseVersion=${version_number}
+          fi
+          git push
+          git push origin $version_number
+          echo "version_number=$version_number" >> $GITHUB_OUTPUT
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: 'maven'
+      - name: Build
+        run: |
+          ./mvnw clean install -B -DskipTests -P exec-jar
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        run: |
+          WREN_VERSION=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout)
+          cd ./docker
+          cp ../wren-server/target/wren-server-${WREN_VERSION}-executable.jar ./
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --tag ghcr.io/goldmedal/wren-engine:${{ steps.maven_prepare_release.outputs.version_number }} \
+            --tag ghcr.io/goldmedal/wren-engine:latest \
+            --push -f ./Dockerfile \
+            --build-arg "WREN_VERSION=${WREN_VERSION}" .

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -57,7 +57,7 @@ jobs:
           cp ../wren-server/target/wren-server-${WREN_VERSION}-executable.jar ./
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            --tag ghcr.io/goldmedal/wren-engine:${{ steps.maven_prepare_release.outputs.version_number }} \
-            --tag ghcr.io/goldmedal/wren-engine:latest \
+            --tag ghcr.io/canner/wren-engine:${{ steps.maven_prepare_release.outputs.version_number }} \
+            --tag ghcr.io/canner/wren-engine:latest \
             --push -f ./Dockerfile \
             --build-arg "WREN_VERSION=${WREN_VERSION}" .


### PR DESCRIPTION
# Changed

- Add `nightly` tag for nightly build.
- disable the push tag event for deploy to canner maven repo.
- Add stable release flow

## Stable Release
- The stable release will build a image and tag it with given tag and `latest`.
- When trigger the flow, we can assign a specific tag or use default value. The default value is the current version number plus a patch number.  

## How to test
- I've test this workflow in my personal repo. 
- I've test this workflow in this repo.