### PR TITLE
Describe query followed the behavior of DuckDB

### DIFF
--- a/wren-base/src/main/java/io/wren/base/client/duckdb/DuckdbClient.java
+++ b/wren-base/src/main/java/io/wren/base/client/duckdb/DuckdbClient.java
@@ -164,17 +164,16 @@ public final class DuckdbClient
         }
     }
 
+    /**
+     * Describe the output of a query. DuckDB won't support to describe a sql with parameters in the select items.
+     * So we ignore the parameters here.
+     */
     @Override
-    public List<ColumnMetadata> describe(String sql, List<Parameter> parameters)
+    public List<ColumnMetadata> describe(String sql, List<Parameter> ignored)
     {
         try (Connection connection = createConnection()) {
             PreparedStatement preparedStatement = connection.prepareStatement(sql);
-            for (int i = 0; i < parameters.size(); i++) {
-                preparedStatement.setObject(i + 1, parameters.get(i).getValue());
-            }
-            // workaround for describe duckdb sql
-            preparedStatement.execute();
-            ResultSetMetaData metaData = preparedStatement.getResultSet().getMetaData();
+            ResultSetMetaData metaData = preparedStatement.getMetaData();
             int columnCount = metaData.getColumnCount();
 
             ImmutableList.Builder<ColumnMetadata> builder = ImmutableList.builder();

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
@@ -25,7 +25,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ParameterMetaData;
 import java.sql.PreparedStatement;
@@ -33,8 +32,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -45,7 +42,6 @@ import static io.wren.base.type.VarcharType.VARCHAR;
 import static io.wren.testing.TestingWireProtocolClient.DescribeType.PORTAL;
 import static io.wren.testing.TestingWireProtocolClient.DescribeType.STATEMENT;
 import static io.wren.testing.TestingWireProtocolClient.Parameter.textParameter;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -940,76 +936,6 @@ public class TestWireProtocolWithDuckDB
             PreparedStatement stmt = connection.prepareStatement(sql);
             ResultSet resultSet = stmt.executeQuery();
             resultSet.next();
-        }
-    }
-
-    @DataProvider
-    public Object[][] paramTypes()
-    {
-        return new Object[][] {
-                {"bool", true},
-                {"bool", false},
-                {"int8", Long.MIN_VALUE},
-                {"int8", Long.MAX_VALUE},
-                {"float8", Double.MIN_VALUE},
-                {"float8", Double.MAX_VALUE},
-                {"char", "c"},
-                {"varchar", "Bag full of 💰"},
-                {"text", "Bag full of 💰"},
-                {"name", "Piękna łąka w 東京都"},
-                {"int4", Integer.MIN_VALUE},
-                {"int4", Integer.MAX_VALUE},
-                {"int2", Short.MIN_VALUE},
-                {"int2", Short.MAX_VALUE},
-                {"float4", Float.MIN_VALUE},
-                {"float4", Float.MAX_VALUE},
-                {"oid", 1L},
-                {"numeric", new BigDecimal("30.123")},
-                {"date", LocalDate.of(1900, 1, 3)},
-                // TODO: Support time
-                // {"time", LocalTime.of(12, 10, 16)},
-                {"timestamp", LocalDateTime.of(1900, 1, 3, 12, 10, 16, 123000000)},
-                // TODO: Support timestamptz
-                // {"timestamptz", ZonedDateTime.of(LocalDateTime.of(1900, 1, 3, 12, 10, 16, 123000000), ZoneId.of("America/Los_Angeles"))},
-                {"json", "{\"test\":3, \"test2\":4}"},
-                {"bytea", "test1".getBytes(UTF_8)},
-                // TODO: Support interval
-                // {"interval", new PGInterval(1, 5, -3, 7, 55, 20)},
-                // TODO: Wait DuckDB support array type
-                // {"array", new Boolean[] {true, false}},
-                // {"array", new Double[] {1.0, 2.0, 3.0}},
-                // {"array", new String[] {"hello", "world"}}
-        };
-    }
-
-    @Test(dataProvider = "paramTypes")
-    public void testJdbcParamTypes(String name, Object obj)
-            throws SQLException
-    {
-        try (Connection conn = createConnection()) {
-            PreparedStatement stmt = conn.prepareStatement("SELECT ? as col;");
-            stmt.setObject(1, obj);
-            ResultSet result = stmt.executeQuery();
-            result.next();
-            Object expected = obj;
-
-            if (name.equals("int2")) {
-                expected = ((Short) obj).intValue();
-            }
-
-            if (name.equals("array")) {
-                assertThat(result.getArray(1).getArray()).isEqualTo(expected);
-            }
-            else if (name.equals("date")) {
-                // pg jdbc handle date type as String if using `getObject`
-                assertThat(result.getDate(1).toLocalDate()).isEqualTo(expected);
-            }
-            else if (name.equals("timestamp")) {
-                assertThat(result.getTimestamp(1).toLocalDateTime()).isEqualTo(expected);
-            }
-            else {
-                assertThat(result.getObject(1)).isEqualTo(expected);
-            }
         }
     }
 


### PR DESCRIPTION
# Description

The original workaround is very expensive. In the original DuckDB behavior, it doesn't support describing a query that contains any parameters in select items. Mostly, the parameter is used for filtering or other purposes. It's not worth supporting this kind of query and then trying to use an expensive method.

## Example
### Supported
```sql
SELECT orderkey FROM Orders WHERE orderkey = ?
```

### Not Supported
```sql
SELECT ?, orderkey FROM Orders
```

## Follow-up Issue
- Support selecting parameter items.