### PR TITLE
Fix typo in config.properties

### DIFF
--- a/example/duckdb-tpch-example/etc/config.properties
+++ b/example/duckdb-tpch-example/etc/config.properties
@@ -19,4 +19,4 @@ pg-wire-protocol.auth.file=/usr/src/app/etc/accounts
 wren.experimental-enable-dynamic-fields=false
 wren.datasource.type=duckdb
 duckdb.connector.init-sql-path=/usr/src/app/etc/duckdb-init.sql
-duckdb.connector.session-sql-path=/usr/src/app/etc/mdl/duckdb-session.sql
+duckdb.connector.session-sql-path=/usr/src/app/etc/duckdb-session.sql


### PR DESCRIPTION
Wrong path example for session-sql