### PR TITLE
Remove legacy decorrelate rewrite for BigQuery

### DIFF
--- a/wren-main/src/main/java/io/wren/main/connector/bigquery/BigQuerySqlConverter.java
+++ b/wren-main/src/main/java/io/wren/main/connector/bigquery/BigQuerySqlConverter.java
@@ -31,7 +31,6 @@ import io.wren.main.sql.bigquery.RewriteArithmetic;
 import io.wren.main.sql.bigquery.RewriteNamesToAlias;
 import io.wren.main.sql.bigquery.RewriteToBigQueryFunction;
 import io.wren.main.sql.bigquery.RewriteToBigQueryType;
-import io.wren.main.sql.bigquery.TransformCorrelatedJoinToJoin;
 import io.wren.main.sql.bigquery.TypeCoercionRewrite;
 import org.intellij.lang.annotations.Language;
 
@@ -71,8 +70,6 @@ public class BigQuerySqlConverter
                 RemoveColumnAliasInAliasRelation.INSTANCE,
                 // bigquery doesn't support column alias in unnest alias relation
                 ReplaceColumnAliasInUnnest.INSTANCE,
-                // bigquery doesn't support correlated join in where clause
-                TransformCorrelatedJoinToJoin.INSTANCE,
                 RewriteToBigQueryFunction.INSTANCE,
                 RewriteToBigQueryType.INSTANCE,
                 // bigquery doesn't support parameter in types in cast

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestBigQuerySqlConverter.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestBigQuerySqlConverter.java
@@ -253,43 +253,6 @@ public class TestBigQuerySqlConverter
     }
 
     @Test
-    public void testTransformCorrelatedJoinToJoin()
-    {
-        assertThat(bigQuerySqlConverter.convert(
-                "SELECT t.typname, t.oid\n" +
-                        "FROM pg_type AS t\n" +
-                        "  INNER JOIN pg_namespace AS n ON t.typnamespace = n.oid\n" +
-                        "WHERE n.nspname <> 'pg_toast'\n" +
-                        "  AND (t.typrelid = 0\n" +
-                        "  OR (SELECT c.relkind = 'c'\n" +
-                        "      FROM pg_class AS c\n" +
-                        "      WHERE c.oid = t.typrelid))", DEFAULT_SESSION_CONTEXT))
-                .isEqualTo("SELECT\n" +
-                        "  t.typname\n" +
-                        ", t.oid\n" +
-                        "FROM\n" +
-                        "  ((pg_type t\n" +
-                        "INNER JOIN pg_namespace n ON (t.typnamespace = n.oid))\n" +
-                        "LEFT JOIN pg_class c ON (c.oid = t.typrelid))\n" +
-                        "WHERE ((n.nspname <> 'pg_toast') AND ((t.typrelid = 0) OR (c.relkind = 'c')))\n");
-
-        assertThat(bigQuerySqlConverter.convert(
-                "SELECT n.nationkey, n.name\n" +
-                        "FROM nation n\n" +
-                        "WHERE \n" +
-                        "  (SELECT (r.regionkey = 1)\n" +
-                        "    FROM region r\n" +
-                        "    WHERE (r.regionkey = n.regionkey))", DEFAULT_SESSION_CONTEXT))
-                .isEqualTo("SELECT\n" +
-                        "  n.nationkey\n" +
-                        ", n.name\n" +
-                        "FROM\n" +
-                        "  (nation n\n" +
-                        "LEFT JOIN region r ON (r.regionkey = n.regionkey))\n" +
-                        "WHERE (r.regionkey = 1)\n");
-    }
-
-    @Test
     public void testRemoveCatalogSchemaColumnPrefix()
     {
         assertThat(bigQuerySqlConverter.convert(


### PR DESCRIPTION
# Describe
It's the legacy rewrite rule for BigQuery as the PG wire protocol engine. Currently, all of metadata query have been executed by PgMetastore (DuckDB). The rule has some issue will impact some subquery syntax. For example
```sql
SELECT DISTINCT f.Lname FROM Faculty f JOIN Member_of m ON f.FacID = m.FacID WHERE m.DNO = (SELECT DNO FROM Department WHERE Dname = 'Computer Science');
```