### PR TITLE
Fix SQLGlot deadlock via pre-load python module

### DIFF
--- a/wren-main/src/main/java/io/wren/main/sqlglot/SQLGlot.java
+++ b/wren-main/src/main/java/io/wren/main/sqlglot/SQLGlot.java
@@ -31,15 +31,11 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.ExecutorService;
 
 import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
 import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static io.wren.main.sqlglot.SQLGlot.Dialect.DUCKDB;
-import static io.wren.main.sqlglot.SQLGlot.Dialect.TRINO;
-import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -72,14 +68,12 @@ public class SQLGlot
 
     private final URI baseUri;
     private final HttpClient client;
-    private boolean sqlGlotServerReady;
 
     @Inject
     public SQLGlot(SQLGlotConfig config)
     {
         this.baseUri = getBaseUri(config);
         this.client = new JettyHttpClient(new HttpClientConfig().setIdleTimeout(new Duration(20, SECONDS)));
-        probeSQLGlotServer();
     }
 
     @Override
@@ -102,33 +96,6 @@ public class SQLGlot
             throwWebApplicationException(response);
         }
         return TRANSPILE_DTO_JSON_CODEC.fromJson(response.getBody()).getSql();
-    }
-
-    private void probeSQLGlotServer()
-    {
-        ExecutorService executor = newFixedThreadPool(1);
-        executor.submit(() -> {
-            sqlGlotServerReady = checkSQLGlotServer();
-            if (sqlGlotServerReady) {
-                executor.shutdown();
-            }
-        });
-    }
-
-    private boolean checkSQLGlotServer()
-    {
-        Request request = preparePost()
-                .setUri(UriBuilder.fromUri(baseUri).path("sqlglot").path("transpile").build())
-                .setHeader(CONTENT_TYPE, APPLICATION_JSON)
-                .setBodyGenerator(jsonBodyGenerator(TRANSPILE_DTO_JSON_CODEC, new TranspileDTO("SELECT 1", TRINO.getDialect(), DUCKDB.getDialect())))
-                .build();
-        try {
-            StringResponseHandler.StringResponse response = client.execute(request, createStringResponseHandler());
-            return response.getStatusCode() != 200;
-        }
-        catch (Exception e) {
-            return false;
-        }
     }
 
     private static void throwWebApplicationException(StringResponseHandler.StringResponse response)

--- a/wren-sqlglot-server/main.py
+++ b/wren-sqlglot-server/main.py
@@ -16,6 +16,9 @@ logger = logging.getLogger()
 
 sqlglot.logger.setLevel(os.getenv('SQLGLOT_LOG_LEVEL', 'ERROR'))
 
+# Pre run to avoid deadlock when concurrent loading modules
+sqlglot.transpile('SELECT 1', read='trino', write='duckdb')
+
 app = FastAPI()
 
 

--- a/wren-sqlglot-server/main.py
+++ b/wren-sqlglot-server/main.py
@@ -19,7 +19,6 @@ sqlglot.logger.setLevel(os.getenv('SQLGLOT_LOG_LEVEL', 'ERROR'))
 # Pre run to avoid deadlock when concurrent loading modules
 sqlglot.transpile('SELECT ARRAY[1,2,3][1]', read='trino', write='duckdb')
 
-
 app = FastAPI()
 
 

--- a/wren-sqlglot-server/main.py
+++ b/wren-sqlglot-server/main.py
@@ -18,7 +18,6 @@ sqlglot.logger.setLevel(os.getenv('SQLGLOT_LOG_LEVEL', 'ERROR'))
 
 # Pre run to avoid deadlock when concurrent loading modules
 sqlglot.transpile('SELECT ARRAY[1,2,3][1]', read='trino', write='duckdb')
-sqlglot.transpile('SELECT custkey, COUNT(*) AS cnt FROM "Order" GROUP BY 1', read='trino', write='bigquery')
 
 
 app = FastAPI()

--- a/wren-sqlglot-server/main.py
+++ b/wren-sqlglot-server/main.py
@@ -17,7 +17,9 @@ logger = logging.getLogger()
 sqlglot.logger.setLevel(os.getenv('SQLGLOT_LOG_LEVEL', 'ERROR'))
 
 # Pre run to avoid deadlock when concurrent loading modules
-sqlglot.transpile('SELECT 1', read='trino', write='duckdb')
+sqlglot.transpile('SELECT ARRAY[1,2,3][1]', read='trino', write='duckdb')
+sqlglot.transpile('SELECT custkey, COUNT(*) AS cnt FROM "Order" GROUP BY 1', read='trino', write='bigquery')
+
 
 app = FastAPI()
 

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestSQLGlotConverter.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestSQLGlotConverter.java
@@ -29,7 +29,7 @@ import static io.wren.main.sqlglot.SQLGlot.Dialect.BIGQUERY;
 import static io.wren.main.sqlglot.SQLGlot.Dialect.DUCKDB;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Test
+@Test(singleThreaded = true)
 public class TestSQLGlotConverter
         extends AbstractSqlConverterTest
 {

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestSQLGlotConverter.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestSQLGlotConverter.java
@@ -29,7 +29,7 @@ import static io.wren.main.sqlglot.SQLGlot.Dialect.BIGQUERY;
 import static io.wren.main.sqlglot.SQLGlot.Dialect.DUCKDB;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Test(singleThreaded = true)
+@Test
 public class TestSQLGlotConverter
         extends AbstractSqlConverterTest
 {

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithDuckDB.java
@@ -26,7 +26,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@Test
+@Test(singleThreaded = true)
 public class TestTPCHWithDuckDB
         extends AbstractTPCHTest
 {

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithDuckDB.java
@@ -26,7 +26,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@Test(singleThreaded = true)
+@Test
 public class TestTPCHWithDuckDB
         extends AbstractTPCHTest
 {

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithSnowflake.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithSnowflake.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import static io.wren.main.sqlglot.SQLGlot.Dialect.SNOWFLAKE;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@Test(singleThreaded = true, enabled = false, description = "It requires a Snowflake account.")
+@Test(enabled = false, description = "It requires a Snowflake account.")
 public class TestTPCHWithSnowflake
         extends AbstractTPCHTest
 {

--- a/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithSnowflake.java
+++ b/wren-tests/src/test/java/io/wren/testing/sqlglot/TestTPCHWithSnowflake.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import static io.wren.main.sqlglot.SQLGlot.Dialect.SNOWFLAKE;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@Test(enabled = false, description = "It requires a Snowflake account.")
+@Test(singleThreaded = true, enabled = false, description = "It requires a Snowflake account.")
 public class TestTPCHWithSnowflake
         extends AbstractTPCHTest
 {


### PR DESCRIPTION
After testing, we found the `sqlglot` python could be pre-load by calling function before concurrent requests to avoid deadlock when the python runtime loading module. And can not use the `SELECT 1` simple statement, should use `SELECT ARRAY[1,2,3][1]` a little complicated statement.
