### PR TITLE
Fix the user-defined CTE query failed

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/Utils.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/Utils.java
@@ -65,10 +65,7 @@ public final class Utils
 
     public static Query parseView(String sql)
     {
-        Query query = (Query) parseSql(sql);
-        // TODO: we don't support view have WITH clause yet
-        io.wren.base.Utils.checkArgument(query.getWith().isEmpty(), "view cannot have WITH clause");
-        return query;
+        return (Query) parseSql(sql);
     }
 
     public static Expression parseExpression(String expression)

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
@@ -148,9 +148,7 @@ public class WrenSqlRewrite
             CumulativeMetric cumulativeMetric = wrenMDL.getCumulativeMetric(name).get();
             descriptorsBuilder.add(CumulativeMetricInfo.get(cumulativeMetric, wrenMDL));
         }
-        else {
-            throw new IllegalArgumentException(name + " not found in mdl");
-        }
+        // If the table is not found in mdl, it could be a remote table or a CTE.
     }
 
     private void addDescriptor(String name, WrenMDL wrenMDL, ImmutableList.Builder<QueryDescriptor> descriptorsBuilder)
@@ -167,9 +165,7 @@ public class WrenSqlRewrite
             CumulativeMetric cumulativeMetric = wrenMDL.getCumulativeMetric(name).get();
             descriptorsBuilder.add(CumulativeMetricInfo.get(cumulativeMetric, wrenMDL));
         }
-        else {
-            throw new IllegalArgumentException(name + " not found in mdl");
-        }
+        // If the table is not found in mdl, it could be a remote table or a CTE.
     }
 
     private Statement apply(

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
@@ -318,6 +318,12 @@ public class ExpressionTypeAnalyzer
     {
         String objectName = field.getTableName().getSchemaTableName().getTableName();
         String columnName = field.getColumnName();
+
+        // TODO: support to analyze the column type of CTE.
+        // It could be a remote table or a custom CTE.
+        if (!mdl.isObjectExist(objectName)) {
+            return null;
+        }
         return PGTypes.nameToPgType(mdl.getColumnType(objectName, columnName)).orElse(null);
     }
 

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestModel.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestModel.java
@@ -312,6 +312,24 @@ public abstract class AbstractTestModel
     }
 
     @Test
+    public void testCustomCTE()
+    {
+        Manifest manifest = withDefaultCatalogSchema()
+                .setModels(List.of(customer, orders, lineitem))
+                .build();
+        WrenMDL mdl = WrenMDL.fromManifest(manifest);
+        assertThatCode(() -> query(rewrite("WITH cte AS (SELECT * FROM Orders) SELECT * FROM cte", mdl, true)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> query(rewrite("WITH cte AS (SELECT * FROM Orders) SELECT * FROM cte", mdl, false)))
+                .doesNotThrowAnyException();
+
+        assertThatCode(() -> query(rewrite("WITH cte AS (SELECT * FROM Orders), cte2 as (SELECT * FROM cte) SELECT * FROM cte2", mdl, true)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> query(rewrite("WITH cte AS (SELECT * FROM Orders), cte2 as (SELECT * FROM cte) SELECT * FROM cte2", mdl, false)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
     public void testSelectNotFound()
     {
         Manifest manifest = withDefaultCatalogSchema()

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestWrenWithBigquery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestWrenWithBigquery.java
@@ -269,4 +269,23 @@ public class TestWrenWithBigquery
             assertThat(count).isEqualTo(100);
         }
     }
+
+    @Test
+    public void testQueryCte()
+    {
+        assertThatNoException().isThrownBy(() -> {
+            try (Connection connection = createConnection()) {
+                PreparedStatement stmt = connection.prepareStatement("with cte as (select * from Orders) select * from cte");
+                ResultSet resultSet = stmt.executeQuery();
+                resultSet.next();
+            }
+
+            // test type correction rewrite
+            try (Connection connection = createConnection()) {
+                PreparedStatement stmt = connection.prepareStatement("with cte as (select * from Orders) select * from cte join Orders on cte.orderkey = Orders.orderkey");
+                ResultSet resultSet = stmt.executeQuery();
+                resultSet.next();
+            }
+        });
+    }
 }


### PR DESCRIPTION
# Description
- Ignore the exception when dataset isn't found in MDL because it could be a remote table or CTE.
- Allow to define CTE in a view.