### PR TITLE
Provide API for SQL Dry-Run and Dry-Plan

### DIFF
--- a/wren-main/src/main/java/io/wren/main/web/MDLResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/MDLResource.java
@@ -20,6 +20,7 @@ import io.wren.main.PreviewService;
 import io.wren.main.WrenManager;
 import io.wren.main.web.dto.CheckOutputDto;
 import io.wren.main.web.dto.DeployInputDto;
+import io.wren.main.web.dto.DryPlanDto;
 import io.wren.main.web.dto.PreviewDto;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -105,6 +106,44 @@ public class MDLResource
                         mdl,
                         previewDto.getSql(),
                         Optional.ofNullable(previewDto.getLimit()).orElse(100L))
+                .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    @GET
+    @Path("/dry-plan")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public void dryPlan(
+            DryPlanDto dryPlanDto,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        WrenMDL mdl;
+        if (dryPlanDto.getManifest() == null) {
+            mdl = wrenManager.getAnalyzedMDL().getWrenMDL();
+        }
+        else {
+            mdl = WrenMDL.fromManifest(dryPlanDto.getManifest());
+        }
+        previewService.dryPlan(mdl, dryPlanDto.getSql(), dryPlanDto.isModelingOnly())
+                .whenComplete(bindAsyncResponse(asyncResponse));
+    }
+
+    @GET
+    @Path("/dry-run")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public void dryRun(
+            PreviewDto previewDto,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        WrenMDL mdl;
+        if (previewDto.getManifest() == null) {
+            mdl = wrenManager.getAnalyzedMDL().getWrenMDL();
+        }
+        else {
+            mdl = WrenMDL.fromManifest(previewDto.getManifest());
+        }
+        previewService.dryRun(mdl, previewDto.getSql())
                 .whenComplete(bindAsyncResponse(asyncResponse));
     }
 }

--- a/wren-main/src/main/java/io/wren/main/web/dto/DryPlanDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/DryPlanDto.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.wren.base.dto.Manifest;
+
+public class DryPlanDto
+{
+    private final Manifest manifest;
+    private final String sql;
+    private final boolean isModelingOnly;
+
+    @JsonCreator
+    public DryPlanDto(
+            @JsonProperty("manifest") Manifest manifest,
+            @JsonProperty("sql") String sql,
+            @JsonProperty("modelingOnly") boolean modelingOnly)
+    {
+        this.manifest = manifest;
+        this.sql = sql;
+        this.isModelingOnly = modelingOnly;
+    }
+
+    @JsonProperty
+    public Manifest getManifest()
+    {
+        return manifest;
+    }
+
+    @JsonProperty
+    public String getSql()
+    {
+        return sql;
+    }
+
+    @JsonProperty
+    public boolean isModelingOnly()
+    {
+        return isModelingOnly;
+    }
+}


### PR DESCRIPTION
# Description
Provide a API to get the result metadata or inner SQL without executing.

## Dry Run
Get the result metadata without executing SQL
```
GET /v1/mdl/dry-run
```
### Sample Body
```
{
    "manifest" : {
        "catalog": "canner-cml",
        "schema": "tpch_tiny",
        "models": [
            {
                "name": "Orders",
                "refSql": "select * from \"memory\".\"tpch\".\"orders\"",
                "columns": [
                    {
                        "name": "o_orderkey",
                        "type": "integer"
                    },
                    {
                        "name": "o_orderdate",
                        "type": "date"
                    
                    }
                ]
            }
        ]
    },
    "sql": "select \"o_orderkey\", \"o_orderdate\" from \"Orders\" wehre \"o_orderdate\" > ?",
}
```
- `manifest`: It's optional. If we don't carry it, use deployed MDL in default.
- `sql`: It's required. The sql will be dry-run.

## Dry Plan
Get the dry-planned SQL which is a SQL can be executed in the data source side.
```
GET /v1/mdl/dry-plan
```
### Sample Body
```
{
    "manifest" : {
        "catalog": "canner-cml",
        "schema": "tpch_tiny",
        "models": [
            {
                "name": "Orders",
                "refSql": "select * from \"memory\".\"tpch\".\"orders\"",
                "columns": [
                    {
                        "name": "o_orderkey",
                        "type": "integer"
                    },
                    {
                        "name": "o_orderdate",
                        "type": "date"
                    
                    }
                ]
            }
        ]
    },
    "sql": "select \"o_orderkey\", \"o_orderdate\" from \"Orders\" wehre \"o_orderdate\" > ?",
    "modelingOnly": false
}
```
- `manifest`: It's optional. If we don't carry it, use deployed MDL in default.
- `sql`: It's required. The sql will be planned.
- `modelingOnly`: It's optional. Enable it to get the SQL without translating by SqlDialect.