### PR TITLE
Create view metadata in pg_catalog

### DIFF
--- a/wren-base/src/main/java/io/wren/base/WrenMDL.java
+++ b/wren-base/src/main/java/io/wren/base/WrenMDL.java
@@ -250,6 +250,11 @@ public class WrenMDL
         return Optional.empty();
     }
 
+    public List<View> listViews()
+    {
+        return manifest.getViews();
+    }
+
     public static Optional<io.wren.base.dto.Column> getRelationshipColumn(Model model, String name)
     {
         return getColumn(model, name)

--- a/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManager.java
+++ b/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManager.java
@@ -16,15 +16,19 @@ package io.wren.main.pgcatalog;
 
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.wren.base.Column;
 import io.wren.base.WrenMDL;
 import io.wren.base.pgcatalog.function.DataSourceFunctionRegistry;
 import io.wren.base.pgcatalog.function.PgMetastoreFunctionRegistry;
 import io.wren.base.wireprotocol.PgMetastore;
+import io.wren.main.PreviewService;
 import io.wren.main.WrenMetastore;
 import io.wren.main.metadata.Metadata;
 import io.wren.main.pgcatalog.builder.PgFunctionBuilderManager;
 import io.wren.main.pgcatalog.builder.PgMetastoreFunctionBuilder;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -34,7 +38,6 @@ public class PgCatalogManager
 {
     private static final Logger LOG = Logger.get(PgCatalogManager.class);
 
-    protected final String metadataSchemaName;
     protected final String pgCatalogName;
 
     private final Metadata connector;
@@ -44,23 +47,25 @@ public class PgCatalogManager
     private final PgMetastoreFunctionBuilder pgMetastoreFunctionBuilder;
     private final PgMetastore pgMetastore;
     private final WrenMetastore wrenMetastore;
+    private final PreviewService previewService;
 
     @Inject
     public PgCatalogManager(
             Metadata connector,
             PgFunctionBuilderManager pgFunctionBuilderManager,
             PgMetastore pgMetastore,
-            WrenMetastore wrenMetastore)
+            WrenMetastore wrenMetastore,
+            PreviewService previewService)
     {
         this.connector = requireNonNull(connector, "connector is null");
         this.pgFunctionBuilderManager = requireNonNull(pgFunctionBuilderManager, "pgFunctionBuilderManager is null");
-        this.metadataSchemaName = requireNonNull(connector.getMetadataSchemaName());
         this.pgCatalogName = requireNonNull(connector.getPgCatalogName());
         this.dataSourceFunctionRegistry = new DataSourceFunctionRegistry();
         this.metastoreFunctionRegistry = new PgMetastoreFunctionRegistry();
         this.pgMetastore = requireNonNull(pgMetastore, "pgMetastore is null");
         this.pgMetastoreFunctionBuilder = new PgMetastoreFunctionBuilder(pgMetastore);
         this.wrenMetastore = requireNonNull(wrenMetastore, "wrenMetastore is null");
+        this.previewService = requireNonNull(previewService, "previewService is null");
     }
 
     public void initPgCatalog()
@@ -135,6 +140,10 @@ public class PgCatalogManager
                         mdl.getColumnType(metric.getName(), metric.getWindow().getName()));
                 sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), metric.getName(), cols));
             });
+            mdl.listViews().stream().map(view -> new DescribedView(view.getName(), previewService.dryRun(mdl, view.getStatement()).join())).forEach(describedView -> {
+                String cols = describedView.columns.stream().map(column -> format("\"%s\" %s", column.getName(), column.getType().typName())).collect(joining(","));
+                sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), describedView.name, cols));
+            });
             String syncSql = sb.toString();
             LOG.info("Sync PG Metastore DDL:\n %s", syncSql);
             if (!syncSql.isEmpty()) {
@@ -144,6 +153,18 @@ public class PgCatalogManager
         catch (Exception e) {
             // won't throw exception to avoid the sever start failed.
             LOG.error(e, "Failed to sync PG Metastore");
+        }
+    }
+
+    static class DescribedView
+    {
+        private final String name;
+        private final List<Column> columns;
+
+        public DescribedView(String name, List<Column> columns)
+        {
+            this.name = name;
+            this.columns = columns;
         }
     }
 }

--- a/wren-main/src/main/java/io/wren/main/wireprotocol/PgMetastoreImpl.java
+++ b/wren-main/src/main/java/io/wren/main/wireprotocol/PgMetastoreImpl.java
@@ -37,6 +37,7 @@ import io.wren.main.connector.duckdb.DuckDBSqlConverter;
 import java.util.List;
 
 import static io.wren.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.wren.base.type.PGTypes.nameToPgType;
 import static io.wren.main.pgcatalog.PgCatalogUtils.PG_CATALOG_NAME;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -111,10 +112,8 @@ public class PgMetastoreImpl
         if (type.startsWith("_")) {
             return format("%s[]", handlePgType(type.substring(1)));
         }
-        else if (!DuckdbTypes.getDuckDBTypeNames().contains(type)) {
-            return "VARCHAR";
-        }
-        return type;
+        return DuckdbTypes.toDuckdbType(nameToPgType(type)
+                .orElse(VarcharType.VARCHAR)).getName();
     }
 
     @Override

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
@@ -14,7 +14,6 @@
 
 package io.wren.testing.bigquery;
 
-import com.google.cloud.bigquery.DatasetId;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Key;
 import io.airlift.log.Logger;
@@ -96,8 +95,6 @@ public abstract class AbstractWireProtocolTestWithBigQuery
         try {
             BigQueryMetadata metadata = getInstance(Key.get(BigQueryMetadata.class));
             BigQueryClient bigQueryClient = metadata.getBigQueryClient();
-            bigQueryClient.dropDatasetWithAllContent(DatasetId.of(getDefaultCatalog(), metadata.getPgCatalogName()));
-            bigQueryClient.dropDatasetWithAllContent(DatasetId.of(getDefaultCatalog(), metadata.getMetadataSchemaName()));
         }
         catch (Exception ex) {
             LOG.error(ex, "cleanup bigquery schema failed");

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestResultSetMetadata.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestResultSetMetadata.java
@@ -658,6 +658,20 @@ public class TestResultSetMetadata
         }
     }
 
+    @Test
+    public void testGetView()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            ResultSet rs = connection.getMetaData().getTables(null, null, "selectNation", null);
+            assertThat(readRows(rs)).contains(asList(null, "tpch_tiny", "selectNation", "TABLE", null, "", "", "", "", ""));
+
+            ResultSet viewColumns = connection.getMetaData().getColumns(null, "tpch_tiny", "selectNation", null);
+            ResultSet modelColumns = connection.getMetaData().getColumns(null, "tpch_tiny", "Nation", null);
+            assertThat(readRows(viewColumns).size()).isEqualTo(readRows(modelColumns).size());
+        }
+    }
+
     public static ResultSetAssert assertResultSet(ResultSet resultSet)
     {
         return new ResultSetAssert(resultSet);

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -1469,4 +1469,36 @@ public class TestWireProtocolWithBigquery
         //     });
         // }
     }
+
+    @Test
+    public void testView()
+            throws Exception
+    {
+        try (Connection conn = createConnection(); Statement stmt = conn.createStatement()) {
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT * FROM \"selectOrders\"");
+                resultSet.next();
+            });
+            ResultSet viewResultSet = conn.getMetaData().getTables(null, null, "selectOrders", null);
+            assertThat(viewResultSet.next()).isTrue();
+            // TODO: jdbc describe wrong type
+            // assertThat(getColumnType(conn.getMetaData().getColumns(null, null, "selectOrders", "orderkey")))
+            //         .isEqualTo(Types.BIGINT);
+            // assertThat(getColumnType(conn.getMetaData().getColumns(null, null, "selectOrders", "custkey")))
+            //         .isEqualTo(Types.BIGINT);
+            // assertThat(getColumnType(conn.getMetaData().getColumns(null, null, "selectOrders", "orderstatus")))
+            //         .isEqualTo(Types.VARCHAR);
+            // assertThat(getColumnType(conn.getMetaData().getColumns(null, null, "selectOrders", "totalprice")))
+            //         .isEqualTo(Types.DOUBLE);
+            // assertThat(getColumnType(conn.getMetaData().getColumns(null, null, "selectOrders", "orderdate")))
+            //         .isEqualTo(Types.DATE);
+        }
+    }
+
+    private int getColumnType(ResultSet resultSet)
+            throws SQLException
+    {
+        resultSet.next();
+        return resultSet.getInt("DATA_TYPE");
+    }
 }

--- a/wren-tests/src/test/resources/bigquery/TestResultSetMetadata.json
+++ b/wren-tests/src/test/resources/bigquery/TestResultSetMetadata.json
@@ -29,5 +29,11 @@
       ],
       "primaryKey": "nationkey"
     }
+  ],
+  "views": [
+    {
+      "name": "selectNation",
+      "statement": "select * from Nation"
+    }
   ]
 }

--- a/wren-tests/src/test/resources/bigquery/TestWireProtocolWithBigquery.json
+++ b/wren-tests/src/test/resources/bigquery/TestWireProtocolWithBigquery.json
@@ -202,5 +202,11 @@
       ],
       "timeGrain": []
     }
+  ],
+  "views": [
+    {
+      "name": "selectOrders",
+      "statement": "select * from Orders"
+    }
   ]
 }


### PR DESCRIPTION
# Description
To get the view metadata by PG wire protocol, we should create the mock table in pg metastore.

# Changed
- Describe view statement and create table in pg_catalog
- Remove legacy metadata schema name.

# Known issue
- Get wrong type by JDBC column metadata 