### PR TITLE
Fix query view with filter for bigquery connector

### DIFF
--- a/wren-base/src/main/java/io/wren/base/WrenMDL.java
+++ b/wren-base/src/main/java/io/wren/base/WrenMDL.java
@@ -270,7 +270,7 @@ public class WrenMDL
                 .findAny();
     }
 
-    public String getColumnType(String objectName, String columnName)
+    public Optional<String> getColumnType(String objectName, String columnName)
     {
         if (!isObjectExist(objectName)) {
             throw new IllegalArgumentException("Dataset " + objectName + " not found");
@@ -279,26 +279,27 @@ public class WrenMDL
             return getModel(objectName).get().getColumns().stream()
                     .filter(column -> columnName.equals(column.getName()))
                     .map(io.wren.base.dto.Column::getType)
-                    .findAny()
-                    .orElseThrow(() -> new IllegalArgumentException("Column " + columnName + " not found in " + objectName));
+                    .findAny();
         }
         else if (getMetric(objectName).isPresent()) {
             return getMetric(objectName).get().getColumns().stream()
                     .filter(column -> columnName.equals(column.getName()))
                     .map(Column::getType)
-                    .findAny()
-                    .orElseThrow(() -> new IllegalArgumentException("Column " + columnName + " not found in " + objectName));
+                    .findAny();
         }
         else if (getCumulativeMetric(objectName).isPresent()) {
             CumulativeMetric cumulativeMetric = getCumulativeMetric(objectName).get();
             if (cumulativeMetric.getMeasure().getName().equals(columnName)) {
-                return cumulativeMetric.getMeasure().getType();
+                return Optional.of(cumulativeMetric.getMeasure().getType());
             }
             if (cumulativeMetric.getWindow().getName().equals(columnName)) {
                 return getColumnType(cumulativeMetric.getBaseObject(), cumulativeMetric.getWindow().getRefColumn());
             }
         }
-        throw new IllegalArgumentException("Dataset " + objectName + " is not a model, metric or cumulative metric");
+        else if (getView(objectName).isPresent()) {
+            return Optional.empty();
+        }
+        throw new IllegalArgumentException("Dataset " + objectName + " is not a model, metric, cumulative metric or view");
     }
 
     public DateSpine getDateSpine()

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionTypeAnalyzer.java
@@ -324,7 +324,7 @@ public class ExpressionTypeAnalyzer
         if (!mdl.isObjectExist(objectName)) {
             return null;
         }
-        return PGTypes.nameToPgType(mdl.getColumnType(objectName, columnName)).orElse(null);
+        return mdl.getColumnType(objectName, columnName).flatMap(PGTypes::nameToPgType).orElse(null);
     }
 
     @Override

--- a/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManager.java
+++ b/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManager.java
@@ -138,7 +138,8 @@ public class PgCatalogManager
                         metric.getMeasure().getName(),
                         pgMetastore.handlePgType(metric.getMeasure().getType()),
                         metric.getWindow().getName(),
-                        mdl.getColumnType(metric.getName(), metric.getWindow().getName()));
+                        mdl.getColumnType(metric.getName(), metric.getWindow().getName())
+                                .orElseThrow(() -> new IllegalArgumentException("Unknown window column type")));
                 sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), metric.getName(), cols));
             });
             mdl.listViews()

--- a/wren-main/src/main/java/io/wren/main/web/LineageResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/LineageResource.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static io.wren.base.Utils.checkArgument;
+import static io.wren.base.type.AnyType.ANY;
 import static io.wren.main.web.WrenExceptionMapper.bindAsyncResponse;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static java.util.Objects.requireNonNull;
@@ -96,7 +97,7 @@ public class LineageResource
                             .map(entry -> new LineageResult(
                                     entry.getKey(),
                                     entry.getValue().stream().map(column ->
-                                            new LineageResult.Column(column, Map.of("type", mdl.getColumnType(entry.getKey(), column)))).collect(toList())))
+                                            new LineageResult.Column(column, Map.of("type", mdl.getColumnType(entry.getKey(), column).orElse(ANY.typName())))).collect(toList())))
                             .collect(Collectors.toList());
                 })
                 .whenComplete(bindAsyncResponse(asyncResponse));

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolWithBigquery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolWithBigquery.java
@@ -1479,6 +1479,11 @@ public class TestWireProtocolWithBigquery
                 ResultSet resultSet = stmt.executeQuery("SELECT * FROM \"selectOrders\"");
                 resultSet.next();
             });
+
+            assertThatNoException().isThrownBy(() -> {
+                ResultSet resultSet = stmt.executeQuery("SELECT * FROM \"selectOrders\" WHERE orderkey = 111");
+                resultSet.next();
+            });
             ResultSet viewResultSet = conn.getMetaData().getTables(null, null, "selectOrders", null);
             assertThat(viewResultSet.next()).isTrue();
             // TODO: jdbc describe wrong type


### PR DESCRIPTION
# Description
BigQuery connector will trigger the type coercion rewrite. We should handle the get column type of view. However, we didn't store the metadata of view. Currently, return empty result for view.