### PR TITLE
Set up JDK 21 before preparing release

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -62,11 +62,11 @@ jobs:
             )
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v2
         with:
-          java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
+          java-version: '21'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -18,6 +18,12 @@ jobs:
         run: |
           git config --global user.email "dev@cannerdata.com"
           git config --global user.name "stable-release-bot"
+      - name: Set up JDK 21
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
       - name: Maven Prepare Release
         id: maven_prepare_release
         run: |
@@ -31,12 +37,6 @@ jobs:
           git push
           git push origin $version_number
           echo "version_number=$version_number" >> $GITHUB_OUTPUT
-      - name: Set up JDK 21
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
       - name: Build
         run: |
           ./mvnw clean install -B -DskipTests -P exec-jar


### PR DESCRIPTION
# Description
`ubuntu-latest` uses java 11 in default. We should set up java 21 before executing maven command.