### PR TITLE
Fix the duplicate required relationship info for an expression

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/MetricSqlRender.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/MetricSqlRender.java
@@ -143,7 +143,7 @@ public class MetricSqlRender
         boolean isMeasure = metric.getMeasure().stream().anyMatch(measure -> measure.getName().equals(column.getName()));
         Model baseModel = mdl.getModel(metric.getBaseObject()).orElseThrow(() -> new IllegalArgumentException(format("cannot find model %s", metric.getBaseObject())));
         Expression expression = parseExpression(column.getSqlExpression());
-        List<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
+        Set<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel).stream().collect(toImmutableSet());
 
         if (!relationshipInfos.isEmpty() && relationableBase.isPresent()) {
             Expression newExpression = (Expression) RelationshipRewriter.relationshipAware(relationshipInfos, relationableBase.get(), expression);
@@ -175,7 +175,7 @@ public class MetricSqlRender
             return;
         }
         Expression expression = parseExpression(column.getSqlExpression());
-        List<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
+        Set<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
         if (!relationshipInfos.isEmpty()) {
             calculatedRequiredRelationshipInfos.add(new CalculatedFieldRelationshipInfo(column, relationshipInfos));
             // collect all required models in relationships
@@ -206,7 +206,7 @@ public class MetricSqlRender
 
         String requiredExpressions = relationshipInfos.stream()
                 .map(CalculatedFieldRelationshipInfo::getExpressionRelationshipInfo)
-                .flatMap(List::stream)
+                .flatMap(Set::stream)
                 .map(RelationshipRewriter::toDereferenceExpression)
                 .map(Expression::toString)
                 .distinct()
@@ -214,7 +214,7 @@ public class MetricSqlRender
 
         List<Relationship> requiredRelationships = relationshipInfos.stream()
                 .map(CalculatedFieldRelationshipInfo::getExpressionRelationshipInfo)
-                .flatMap(List::stream)
+                .flatMap(Set::stream)
                 .map(ExpressionRelationshipInfo::getRelationships)
                 .flatMap(List::stream)
                 .distinct()

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/ModelSqlRender.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/ModelSqlRender.java
@@ -116,7 +116,7 @@ public class ModelSqlRender
     protected void collectRelationship(Column column, Model baseModel)
     {
         Expression expression = parseExpression(column.getSqlExpression());
-        List<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
+        Set<ExpressionRelationshipInfo> relationshipInfos = ExpressionRelationshipAnalyzer.getRelationships(expression, mdl, baseModel);
         if (column.isCalculated() && relationshipInfos.size() > 0) {
             if (!requiredFields.contains(column.getName())) {
                 return;
@@ -159,9 +159,9 @@ public class ModelSqlRender
     // only accept to-one relationship(s) in this method
     private List<SubQueryJoinInfo> getToOneRelationshipsQuery(Model baseModel, Collection<CalculatedFieldRelationshipInfo> relationshipInfos)
     {
-        List<CalculatedFieldRelationshipInfo> toOneRelationships = relationshipInfos.stream()
+        Set<CalculatedFieldRelationshipInfo> toOneRelationships = relationshipInfos.stream()
                 .filter(relationshipInfo -> !relationshipInfo.isAggregated())
-                .collect(toImmutableList());
+                .collect(toImmutableSet());
 
         if (toOneRelationships.isEmpty()) {
             return ImmutableList.of();
@@ -178,7 +178,7 @@ public class ModelSqlRender
 
         List<Relationship> requiredRelationships = toOneRelationships.stream()
                 .map(CalculatedFieldRelationshipInfo::getExpressionRelationshipInfo)
-                .flatMap(List::stream)
+                .flatMap(Set::stream)
                 .map(ExpressionRelationshipInfo::getRelationships)
                 .flatMap(List::stream)
                 .distinct()

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/RelationableSqlRender.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/RelationableSqlRender.java
@@ -81,10 +81,10 @@ public abstract class RelationableSqlRender
     public static class CalculatedFieldRelationshipInfo
     {
         private final Column column;
-        private final List<ExpressionRelationshipInfo> expressionRelationshipInfo;
+        private final Set<ExpressionRelationshipInfo> expressionRelationshipInfo;
         private final boolean isAggregated;
 
-        public CalculatedFieldRelationshipInfo(Column column, List<ExpressionRelationshipInfo> expressionRelationshipInfo)
+        public CalculatedFieldRelationshipInfo(Column column, Set<ExpressionRelationshipInfo> expressionRelationshipInfo)
         {
             this.column = requireNonNull(column);
             this.expressionRelationshipInfo = requireNonNull(expressionRelationshipInfo);
@@ -105,7 +105,7 @@ public abstract class RelationableSqlRender
             return column;
         }
 
-        public List<ExpressionRelationshipInfo> getExpressionRelationshipInfo()
+        public Set<ExpressionRelationshipInfo> getExpressionRelationshipInfo()
         {
             return expressionRelationshipInfo;
         }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/RelationshipRewriter.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/RelationshipRewriter.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.trino.sql.tree.DereferenceExpression.getQualifiedName;
 import static java.util.Objects.requireNonNull;
@@ -35,7 +36,7 @@ public class RelationshipRewriter
 {
     private final Map<QualifiedName, DereferenceExpression> replacements;
 
-    public static Node rewrite(List<ExpressionRelationshipInfo> relationshipInfos, Expression expression)
+    public static Node rewrite(Set<ExpressionRelationshipInfo> relationshipInfos, Expression expression)
     {
         requireNonNull(relationshipInfos);
         HashMap<QualifiedName, DereferenceExpression> replacements = new HashMap<>();
@@ -44,7 +45,7 @@ public class RelationshipRewriter
                 .process(expression);
     }
 
-    public static Node relationshipAware(List<ExpressionRelationshipInfo> relationshipInfos, String relationshipPrefix, Expression expression)
+    public static Node relationshipAware(Set<ExpressionRelationshipInfo> relationshipInfos, String relationshipPrefix, Expression expression)
     {
         requireNonNull(relationshipInfos);
         return new RelationshipRewriter(relationshipInfos.stream()

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionRelationshipAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionRelationshipAnalyzer.java
@@ -14,6 +14,7 @@
 
 package io.wren.base.sqlrewrite.analyzer;
 
+import com.google.common.collect.ImmutableSet;
 import io.trino.sql.tree.DefaultTraversalVisitor;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
@@ -24,9 +25,11 @@ import io.wren.base.dto.Model;
 import io.wren.base.dto.Relationship;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.sql.tree.DereferenceExpression.getQualifiedName;
@@ -45,7 +48,7 @@ public class ExpressionRelationshipAnalyzer
      * @param model the model that expression belongs to
      * @return ExpressionRelationshipInfo
      */
-    public static List<ExpressionRelationshipInfo> getToOneRelationships(Expression expression, WrenMDL mdl, Model model)
+    public static Set<ExpressionRelationshipInfo> getToOneRelationships(Expression expression, WrenMDL mdl, Model model)
     {
         RelationshipCollector collector = new RelationshipCollector(mdl, model, false);
         collector.process(expression);
@@ -60,7 +63,7 @@ public class ExpressionRelationshipAnalyzer
      * @param model the model that expression belongs to
      * @return ExpressionRelationshipInfo
      */
-    public static List<ExpressionRelationshipInfo> getRelationships(Expression expression, WrenMDL mdl, Model model)
+    public static Set<ExpressionRelationshipInfo> getRelationships(Expression expression, WrenMDL mdl, Model model)
     {
         RelationshipCollector collector = new RelationshipCollector(mdl, model, true);
         collector.process(expression);
@@ -73,7 +76,7 @@ public class ExpressionRelationshipAnalyzer
         private final WrenMDL wrenMDL;
         private final Model model;
         private final boolean allowToManyRelationship;
-        private final List<ExpressionRelationshipInfo> relationships = new ArrayList<>();
+        private final Set<ExpressionRelationshipInfo> relationships = new HashSet<>();
 
         public RelationshipCollector(WrenMDL wrenMDL, Model model, boolean allowToManyRelationship)
         {
@@ -82,9 +85,9 @@ public class ExpressionRelationshipAnalyzer
             this.allowToManyRelationship = allowToManyRelationship;
         }
 
-        public List<ExpressionRelationshipInfo> getExpressionRelationshipInfo()
+        public Set<ExpressionRelationshipInfo> getExpressionRelationshipInfo()
         {
-            return relationships;
+            return ImmutableSet.copyOf(relationships);
         }
 
         @Override


### PR DESCRIPTION
# Description
If an expression include the duplicate child expression, engine may get duplicate relationship info. Use `Set` to avoid this case.
# Sample case
```
customer.custkey + customer.custkey
```
We got two `Customer` relationship here.