### PR TITLE
Remove legacy validation dependency

### DIFF
--- a/wren-shaded/pom.xml
+++ b/wren-shaded/pom.xml
@@ -37,12 +37,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.wren</groupId>
-            <artifactId>wren-validation</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <scope>runtime</scope>


### PR DESCRIPTION
# Description
Due to the stable release be failed. We should remove the legacy validation dependency.