### PR TITLE
Fix the DuckDB type mapping and enhance the error handling for MDL deploying

### DIFF
--- a/wren-base/src/main/java/io/wren/base/client/duckdb/DuckdbTypes.java
+++ b/wren-base/src/main/java/io/wren/base/client/duckdb/DuckdbTypes.java
@@ -18,14 +18,17 @@ import com.google.common.collect.ImmutableMap;
 import io.wren.base.WrenException;
 import io.wren.base.type.BigIntType;
 import io.wren.base.type.BooleanType;
+import io.wren.base.type.BpCharType;
 import io.wren.base.type.ByteaType;
 import io.wren.base.type.CharType;
 import io.wren.base.type.DateType;
 import io.wren.base.type.DoubleType;
+import io.wren.base.type.InetType;
 import io.wren.base.type.IntegerType;
 import io.wren.base.type.IntervalType;
 import io.wren.base.type.JsonType;
 import io.wren.base.type.NumericType;
+import io.wren.base.type.OidType;
 import io.wren.base.type.PGType;
 import io.wren.base.type.PGTypes;
 import io.wren.base.type.RealType;
@@ -33,6 +36,7 @@ import io.wren.base.type.SmallIntType;
 import io.wren.base.type.TimestampType;
 import io.wren.base.type.TimestampWithTimeZoneType;
 import io.wren.base.type.TinyIntType;
+import io.wren.base.type.UuidType;
 import io.wren.base.type.VarcharType;
 
 import java.sql.ResultSetMetaData;
@@ -68,6 +72,7 @@ public final class DuckdbTypes
     public static final DuckdbType TIMESTAMP_WITH_TIMEZONE = new DuckdbType(Types.TIMESTAMP_WITH_TIMEZONE, "TIMESTAMP WITH TIMEZONE");
     public static final DuckdbType VARCHAR = new DuckdbType(Types.VARCHAR, "VARCHAR");
     public static final DuckdbType JSON = new DuckdbType(Types.STRUCT, "JSON");
+    public static final DuckdbType UUID = new DuckdbType(Types.JAVA_OBJECT, "UUID");
 
     private static final Map<String, DuckdbType> duckdbTypes = ImmutableMap.<String, DuckdbType>builder()
             .put(BOOLEAN.getName(), BOOLEAN)
@@ -89,6 +94,7 @@ public final class DuckdbTypes
             .put(VARCHAR.getName(), VARCHAR)
             .put(JSON.getName(), JSON)
             .put(HUGEINT.getName(), HUGEINT)
+            .put(UUID.getName(), UUID)
             .build();
 
     private static final Map<Integer, PGType<?>> duckdbTypeToPgTypeMap = ImmutableMap.<Integer, PGType<?>>builder()
@@ -108,6 +114,7 @@ public final class DuckdbTypes
             .put(JSON.getJdbcType(), JsonType.JSON)
             .build();
 
+    // TODO: RECORD, HSTORE
     private static final Map<PGType<?>, DuckdbType> pgTypeToDuckdbTypeMap = ImmutableMap.<PGType<?>, DuckdbType>builder()
             .put(BooleanType.BOOLEAN, BOOLEAN)
             .put(ByteaType.BYTEA, BLOB)
@@ -119,12 +126,18 @@ public final class DuckdbTypes
             .put(DoubleType.DOUBLE, DOUBLE)
             .put(NumericType.NUMERIC, DECIMAL)
             .put(VarcharType.VARCHAR, VARCHAR)
+            .put(VarcharType.TextType.TEXT, VARCHAR)
+            .put(VarcharType.NameType.NAME, VARCHAR)
             .put(CharType.CHAR, VARCHAR)
             .put(DateType.DATE, DATE)
             .put(TimestampType.TIMESTAMP, TIMESTAMP)
             .put(TimestampWithTimeZoneType.TIMESTAMP_WITH_TIMEZONE, TIMESTAMP_WITH_TIMEZONE)
             .put(IntervalType.INTERVAL, INTERVAL)
             .put(JsonType.JSON, JSON)
+            .put(UuidType.UUID, UUID)
+            .put(OidType.OID_INSTANCE, BIGINT)
+            .put(InetType.INET, VARCHAR)
+            .put(BpCharType.BPCHAR, VARCHAR)
             .build();
 
     /**
@@ -177,13 +190,13 @@ public final class DuckdbTypes
     public static PGType<?> toPGType(int type)
     {
         return Optional.ofNullable(duckdbTypeToPgTypeMap.get(type))
-                .orElseThrow(() -> new WrenException(NOT_SUPPORTED, "Unsupported Type: " + type));
+                .orElseThrow(() -> new WrenException(NOT_SUPPORTED, "DuckDB unsupported Type: " + type));
     }
 
     public static DuckdbType toDuckdbType(PGType<?> type)
     {
         return Optional.ofNullable(pgTypeToDuckdbTypeMap.get(type))
-                .orElseThrow(() -> new WrenException(NOT_SUPPORTED, "Unsupported Type: " + type));
+                .orElseThrow(() -> new WrenException(NOT_SUPPORTED, "DuckDB unsupported Type: " + type));
     }
 
     public static List<String> getDuckDBTypeNames()

--- a/wren-base/src/main/java/io/wren/base/type/PGTypes.java
+++ b/wren-base/src/main/java/io/wren/base/type/PGTypes.java
@@ -42,6 +42,7 @@ public final class PGTypes
 
     static {
         TYPE_TABLE.put(BOOLEAN.oid(), BOOLEAN);
+        TYPE_TABLE.put(TinyIntType.TINYINT.oid(), TinyIntType.TINYINT);
         TYPE_TABLE.put(SmallIntType.SMALLINT.oid(), SmallIntType.SMALLINT);
         TYPE_TABLE.put(IntegerType.INTEGER.oid(), IntegerType.INTEGER);
         TYPE_TABLE.put(BigIntType.BIGINT.oid(), BigIntType.BIGINT);
@@ -90,6 +91,8 @@ public final class PGTypes
         TYPE_NAME_TABLE.put("INTEGER", IntegerType.INTEGER);
         TYPE_NAME_TABLE.put("SMALLINT", SmallIntType.SMALLINT);
         TYPE_NAME_TABLE.put("BIGINT", BigIntType.BIGINT);
+        TYPE_NAME_TABLE.put("STRING", VarcharType.VARCHAR);
+        TYPE_NAME_TABLE.put("DECIMAL", NumericType.NUMERIC);
     }
 
     public static Iterable<PGType<?>> pgTypes()

--- a/wren-main/src/main/java/io/wren/main/pgcatalog/exception/DeployException.java
+++ b/wren-main/src/main/java/io/wren/main/pgcatalog/exception/DeployException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.main.pgcatalog.exception;
+
+import static java.lang.String.format;
+
+public class DeployException
+        extends Exception
+{
+    public DeployException(String message)
+    {
+        super(message);
+    }
+
+    public DeployException(String message, Throwable cause)
+    {
+        super(format("%s: %s", message, cause.getMessage()), cause);
+    }
+}

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/AbstractWireProtocolTestWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/AbstractWireProtocolTestWithDuckDB.java
@@ -17,6 +17,8 @@ package io.wren.testing.duckdb;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.inject.Key;
+import io.wren.base.WrenMDL;
+import io.wren.base.dto.Manifest;
 import io.wren.main.connector.duckdb.DuckDBMetadata;
 import io.wren.testing.AbstractWireProtocolTest;
 import io.wren.testing.TestingWrenServer;
@@ -46,6 +48,10 @@ public abstract class AbstractWireProtocolTestWithDuckDB
         Path dir = Files.createTempDirectory(getWrenDirectory());
         if (getWrenMDLPath().isPresent()) {
             Files.copy(Path.of(getWrenMDLPath().get()), dir.resolve("mdl.json"));
+        }
+        else {
+            Files.write(dir.resolve("manifest.json"),
+                    Manifest.MANIFEST_JSON_CODEC.toJsonBytes(getManifest().orElse(WrenMDL.EMPTY.getManifest())));
         }
         propBuilder.put("wren.directory", dir.toString());
 
@@ -79,9 +85,9 @@ public abstract class AbstractWireProtocolTestWithDuckDB
         metadata.reload();
     }
 
-    protected Optional<String> getWrenMDLPath()
+    protected Optional<Manifest> getManifest()
     {
-        return Optional.of(requireNonNull(getClass().getClassLoader().getResource("duckdb/mdl.json")).getPath());
+        return Optional.empty();
     }
 
     @Override

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestDeployDuckDBRuntime.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestDeployDuckDBRuntime.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static io.wren.base.config.ConfigManager.ConfigEntry.configEntry;
 import static io.wren.base.config.PostgresConfig.POSTGRES_JDBC_URL;
@@ -31,6 +32,7 @@ import static io.wren.base.config.PostgresConfig.POSTGRES_USER;
 import static io.wren.base.config.WrenConfig.DataSourceType.DUCKDB;
 import static io.wren.base.config.WrenConfig.DataSourceType.POSTGRES;
 import static io.wren.base.config.WrenConfig.WREN_DATASOURCE_TYPE;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @Test(singleThreaded = true)
@@ -38,6 +40,12 @@ public class TestDeployDuckDBRuntime
         extends AbstractWireProtocolTestWithDuckDB
 {
     TestingPostgreSqlServer testingPostgreSqlServer;
+
+    @Override
+    protected Optional<String> getWrenMDLPath()
+    {
+        return Optional.of(requireNonNull(getClass().getClassLoader().getResource("duckdb/mdl.json")).getPath());
+    }
 
     @Override
     protected Map<String, String> properties()

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
@@ -37,6 +37,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -46,12 +47,19 @@ import static io.wren.testing.TestingWireProtocolClient.DescribeType.PORTAL;
 import static io.wren.testing.TestingWireProtocolClient.DescribeType.STATEMENT;
 import static io.wren.testing.TestingWireProtocolClient.Parameter.textParameter;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestWireProtocolWithDuckDB
         extends AbstractWireProtocolTestWithDuckDB
 {
+    @Override
+    protected Optional<String> getWrenMDLPath()
+    {
+        return Optional.of(requireNonNull(getClass().getClassLoader().getResource("duckdb/mdl.json")).getPath());
+    }
+
     @Test
     public void testSimpleQuery()
             throws IOException
@@ -979,7 +987,7 @@ public class TestWireProtocolWithDuckDB
                 // TODO: Support timestamptz
                 // {"timestamptz", ZonedDateTime.of(LocalDateTime.of(1900, 1, 3, 12, 10, 16, 123000000), ZoneId.of("America/Los_Angeles"))},
                 {"json", "{\"test\":3, \"test2\":4}"},
-                {"bytea", "test1".getBytes(UTF_8)},
+                {"bytea", "test1" .getBytes(UTF_8)},
                 // TODO: Support interval
                 // {"interval", new PGInterval(1, 5, -3, 7, 55, 20)},
                 // TODO: Wait DuckDB support array type

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolWithDuckDB.java
@@ -987,7 +987,7 @@ public class TestWireProtocolWithDuckDB
                 // TODO: Support timestamptz
                 // {"timestamptz", ZonedDateTime.of(LocalDateTime.of(1900, 1, 3, 12, 10, 16, 123000000), ZoneId.of("America/Los_Angeles"))},
                 {"json", "{\"test\":3, \"test2\":4}"},
-                {"bytea", "test1" .getBytes(UTF_8)},
+                {"bytea", "test1".getBytes(UTF_8)},
                 // TODO: Support interval
                 // {"interval", new PGInterval(1, 5, -3, 7, 55, 20)},
                 // TODO: Wait DuckDB support array type

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenTypeDeploy.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenTypeDeploy.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.testing.duckdb;
+
+import io.wren.base.dto.Manifest;
+import io.wren.base.dto.Model;
+import io.wren.main.web.dto.DeployInputDto;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.wren.base.dto.Column.column;
+import static io.wren.testing.WebApplicationExceptionAssert.assertWebApplicationException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+public class TestWrenTypeDeploy
+        extends AbstractWireProtocolTestWithDuckDB
+{
+    private final Manifest stdManifest = Manifest.builder()
+            .setCatalog("test")
+            .setSchema("duck")
+            .setModels(List.of(Model.model("type_test", "select 1",
+                    List.of(column("c_bool", "BOOLEAN", null, true, "true"),
+                            column("c_tinyint", "TINYINT", null, true, "1"),
+                            column("c_int2", "INT2", null, true, "1"),
+                            column("c_smallint", "SMALLINT", null, true, "1"),
+                            column("c_int4", "INT4", null, true, "1"),
+                            column("c_integer", "INTEGER", null, true, "1"),
+                            column("c_int8", "INT8", null, true, "1"),
+                            column("c_bigint", "BIGINT", null, true, "1"),
+                            column("c_float4", "FLOAT4", null, true, "1.0"),
+                            column("c_real", "REAL", null, true, "1.0"),
+                            column("c_float8", "FLOAT8", null, true, "1.0"),
+                            column("c_double", "DOUBLE", null, true, "1.0"),
+                            column("c_numeric", "NUMERIC", null, true, "1.0"),
+                            column("c_decimal", "DECIMAL", null, true, "1.0"),
+                            column("c_varchar", "VARCHAR", null, true, "'1'"),
+                            column("c_string", "STRING", null, true, "'1'"),
+                            column("c_char", "CHAR", null, true, "'1'"),
+                            column("c_json", "JSON", null, true, "'{\"key\": \"value\"}'"),
+                            column("c_timestamp", "TIMESTAMP", null, true, "'2021-01-01 00:00:00'"),
+                            column("c_timestamptz", "TIMESTAMP WITH TIME ZONE", null, true, "'2021-01-01 00:00:00'"),
+                            column("c_text", "TEXT", null, true, "'1'"),
+                            column("c_name", "NAME", null, true, "'1'"),
+                            column("c_oid", "OID", null, true, "1"),
+                            column("c_date", "DATE", null, true, "'2021-01-01'"),
+                            column("c_bytea", "BYTEA", null, true, "'\\x01'"),
+                            column("c_uuid", "UUID", null, true, "'123e4567-e89b-12d3-a456-426614174000'"),
+                            column("c_interval", "INTERVAL", null, true, "interval '1' day"),
+                            column("c_bpchar", "BPCHAR", null, true, "'1'"),
+                            column("c_inet", "INET", null, true, "'192.168/24'"),
+                            column("c_varchar_array", "VARCHAR[]", null, true, "ARRAY['1']")))))
+            .build();
+
+    @Test
+    public void testDeploy()
+    {
+        assertThatNoException().isThrownBy(() -> deployMDL(new DeployInputDto(stdManifest, null)));
+
+        Manifest unknownPgType = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("duck")
+                .setModels(List.of(Model.model("type_test", "select 1",
+                        List.of(column("c_bool", "BOOLEAN", null, true, "true"),
+                                column("c_notofund_array", "_NOTFOUND", null, true, "ARRAY['1']"),
+                                column("c_notfound", "NOTFOUND", null, true, "'1'")))))
+                .build();
+        // We map the unknown type to varchar always
+        assertThatNoException().isThrownBy(() -> deployMDL(new DeployInputDto(unknownPgType, null)));
+
+        // Known pg type but not supported by duckdb
+        Manifest invalid = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("duck")
+                .setModels(List.of(Model.model("type_test", "select 1",
+                        List.of(column("c_bool", "BOOLEAN", null, true, "true"),
+                                column("c_hstore", "HSTORE", null, true, "'key=>value'")))))
+                .build();
+
+        assertWebApplicationException(() -> deployMDL(new DeployInputDto(invalid, null)))
+                .hasHTTPStatus(400)
+                .hasErrorMessageMatches("Failed to sync PG Metastore: DuckDB unsupported Type: io.wren.base.type.HstoreType(.|\\n)*");
+
+        Manifest invalidArray = Manifest.builder()
+                .setCatalog("test")
+                .setSchema("duck")
+                .setModels(List.of(Model.model("type_test", "select 1",
+                        List.of(column("c_bool", "BOOLEAN", null, true, "true"),
+                                column("c_hstore_array", "_HSTORE", null, true, "'key=>value'")))))
+                .build();
+
+        assertWebApplicationException(() -> deployMDL(new DeployInputDto(invalidArray, null)))
+                .hasHTTPStatus(400)
+                .hasErrorMessageMatches("Failed to sync PG Metastore: DuckDB unsupported Type: io.wren.base.type.HstoreType(.|\\n)*");
+    }
+}

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -20,7 +20,9 @@ import org.testng.annotations.Test;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.Optional;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +30,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestWrenWithDuckDB
         extends AbstractWireProtocolTestWithDuckDB
 {
+    @Override
+    protected Optional<String> getWrenMDLPath()
+    {
+        return Optional.of(requireNonNull(getClass().getClassLoader().getResource("duckdb/mdl.json")).getPath());
+    }
+
     @DataProvider
     public Object[][] queryModel()
     {


### PR DESCRIPTION
# Description
- add missing type mapping for PGType to DuckDB Type
- Handle the error for known pg type which don't supported by DuckDB
- Return http 400 error when mdl deploying failed.