### PR TITLE
Disable the Wren Protocol and cache layer in default

### DIFF
--- a/wren-base/src/main/java/io/wren/base/config/PostgresWireProtocolConfig.java
+++ b/wren-base/src/main/java/io/wren/base/config/PostgresWireProtocolConfig.java
@@ -20,6 +20,7 @@ import java.io.File;
 
 public class PostgresWireProtocolConfig
 {
+    public static final String PG_WIRE_PROTOCOL_ENABLED = "pg-wire-protocol.enabled";
     public static final String PG_WIRE_PROTOCOL_SSL_ENABLED = "pg-wire-protocol.ssl.enabled";
     public static final String PG_WIRE_PROTOCOL_NETTY_THREAD_COUNT = "pg-wire-protocol.netty.thread.count";
     public static final String PG_WIRE_PROTOCOL_AUTH_FILE = "pg-wire-protocol.auth.file";
@@ -29,6 +30,7 @@ public class PostgresWireProtocolConfig
     private boolean sslEnable;
     private int nettyThreadCount;
     private File authFile = new File("etc/accounts");
+    private boolean pgWireProtocolEnabled;
 
     @NotNull
     public String getPort()
@@ -79,5 +81,16 @@ public class PostgresWireProtocolConfig
     {
         this.authFile = authFile;
         return this;
+    }
+
+    @Config(PG_WIRE_PROTOCOL_ENABLED)
+    public void setPgWireProtocolEnabled(boolean pgWireProtocolEnabled)
+    {
+        this.pgWireProtocolEnabled = pgWireProtocolEnabled;
+    }
+
+    public boolean isPgWireProtocolEnabled()
+    {
+        return pgWireProtocolEnabled;
     }
 }

--- a/wren-cache/src/main/java/io/wren/cache/CacheManager.java
+++ b/wren-cache/src/main/java/io/wren/cache/CacheManager.java
@@ -15,425 +15,66 @@
 package io.wren.cache;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.inject.Inject;
-import io.airlift.log.Logger;
-import io.trino.sql.parser.SqlParser;
-import io.trino.sql.tree.Statement;
 import io.wren.base.AnalyzedMDL;
 import io.wren.base.CatalogSchemaTableName;
 import io.wren.base.ConnectorRecordIterator;
 import io.wren.base.Parameter;
-import io.wren.base.SessionContext;
 import io.wren.base.WrenException;
-import io.wren.base.WrenMDL;
-import io.wren.base.client.duckdb.CacheStorageConfig;
-import io.wren.base.client.duckdb.DuckDBConfig;
-import io.wren.base.config.ConfigManager;
 import io.wren.base.dto.CacheInfo;
-import io.wren.base.sql.SqlConverter;
-import io.wren.base.sqlrewrite.WrenPlanner;
-import io.wren.base.wireprotocol.PgMetastore;
-import io.wren.cache.dto.CachedTable;
 
-import java.io.Closeable;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.function.Predicate;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.concurrent.Threads.threadsNamed;
-import static io.trino.execution.sql.SqlFormatterUtil.getFormattedSql;
-import static io.wren.base.CatalogSchemaTableName.catalogSchemaTableName;
-import static io.wren.base.metadata.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_LIMIT;
 import static io.wren.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.wren.base.metadata.StandardErrorCode.GENERIC_USER_ERROR;
-import static io.wren.base.sqlrewrite.Utils.parseSql;
-import static io.wren.cache.EventLogger.Level.ERROR;
-import static io.wren.cache.EventLogger.Level.INFO;
-import static io.wren.cache.TaskInfo.TaskStatus.DONE;
-import static io.wren.cache.TaskInfo.TaskStatus.QUEUED;
-import static io.wren.cache.TaskInfo.TaskStatus.RUNNING;
-import static java.lang.String.format;
-import static java.lang.System.currentTimeMillis;
-import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
-import static java.util.concurrent.CompletableFuture.supplyAsync;
-import static java.util.concurrent.Executors.newCachedThreadPool;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
 
-public class CacheManager
-        implements Closeable
+public interface CacheManager
 {
-    private static final Logger LOG = Logger.get(CacheManager.class);
-    private final ExtraRewriter extraRewriter;
-    private final CacheService cacheService;
-    private final SqlParser sqlParser;
-    private final SqlConverter sqlConverter;
-    private final PgMetastore pgMetastore;
-    private final ConcurrentLinkedQueue<PathInfo> tempFileLocations = new ConcurrentLinkedQueue<>();
-    private final CachedTableMapping cachedTableMapping;
-    private final ConcurrentMap<CatalogSchemaTableName, ScheduledFuture<?>> cacheScheduledFutures = new ConcurrentHashMap<>();
-    private final ConcurrentMap<CatalogSchemaTableName, ScheduledFuture<?>> retryScheduledFutures = new ConcurrentHashMap<>();
-    private final ScheduledThreadPoolExecutor refreshExecutor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("cache-refresh-%s"));
-    private final ScheduledThreadPoolExecutor retryExecutor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("cache-retry-%s"));
-    private final ExecutorService executorService = newCachedThreadPool(threadsNamed("cache-manager-%s"));
-    private final ConcurrentHashMap<CatalogSchemaTableName, Task> tasks = new ConcurrentHashMap<>();
-    private final EventLogger eventLogger;
-    private final CacheTaskManager cacheTaskManager;
-    private final ConfigManager configManager;
-
-    @Inject
-    public CacheManager(
-            SqlConverter sqlConverter,
-            CacheService cacheService,
-            ExtraRewriter extraRewriter,
-            PgMetastore pgMetastore,
-            CachedTableMapping cachedTableMapping,
-            EventLogger eventLogger,
-            CacheTaskManager cacheTaskManager,
-            ConfigManager configManager)
+    default ConnectorRecordIterator query(String sql, List<Parameter> parameters)
     {
-        this.sqlParser = new SqlParser();
-        this.sqlConverter = requireNonNull(sqlConverter, "sqlConverter is null");
-        this.cacheService = requireNonNull(cacheService, "cacheService is null");
-        this.extraRewriter = requireNonNull(extraRewriter, "extraRewriter is null");
-        this.pgMetastore = requireNonNull(pgMetastore, "pgMetastore is null");
-        this.cacheTaskManager = requireNonNull(cacheTaskManager, "cacheTaskManager is null");
-        this.cachedTableMapping = requireNonNull(cachedTableMapping, "cachedTableMapping is null");
-        this.eventLogger = requireNonNull(eventLogger, "eventLogger is null");
-        this.configManager = requireNonNull(configManager, "configManager is null");
-        refreshExecutor.setRemoveOnCancelPolicy(true);
+        throw new WrenException(GENERIC_INTERNAL_ERROR, "Enable Wren Protocol to use this feature");
     }
 
-    private synchronized CompletableFuture<Void> refreshCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
+    default void removeCacheIfExist(String catalogName, String schemaName) {}
+
+    default void removeCacheIfExist(CatalogSchemaTableName catalogSchemaTableName) {}
+
+    default boolean cacheScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
     {
-        WrenMDL mdl = analyzedMDL.getWrenMDL();
-        CatalogSchemaTableName catalogSchemaTableName = catalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
-        Optional<Task> taskOptional = Optional.ofNullable(tasks.get(catalogSchemaTableName));
-        if (taskOptional.isPresent() && taskOptional.get().getTaskInfo().inProgress()) {
-            throw new WrenException(GENERIC_USER_ERROR, format("cache is already running; catalogName: %s, schemaName: %s, tableName: %s", mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName()));
-        }
-        removeCacheIfExist(catalogSchemaTableName);
-        return doCache(analyzedMDL, cacheInfo, taskInfo);
-    }
-
-    private CompletableFuture<Void> handleCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
-    {
-        WrenMDL mdl = analyzedMDL.getWrenMDL();
-        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
-        String duckdbTableName = format("%s_%s", cacheInfo.getName(), randomUUID().toString().replace("-", ""));
-        long createTime = currentTimeMillis();
-        return refreshCache(analyzedMDL, cacheInfo, taskInfo)
-                .thenRun(() -> {
-                    if (cacheInfo.getRefreshTime().toMillis() > 0) {
-                        cacheScheduledFutures.put(
-                                catalogSchemaTableName,
-                                refreshExecutor.scheduleWithFixedDelay(
-                                        () -> createTask(analyzedMDL, cacheInfo).join(),
-                                        cacheInfo.getRefreshTime().toMillis(),
-                                        cacheInfo.getRefreshTime().toMillis(),
-                                        MILLISECONDS));
-                    }
-                })
-                .exceptionally(e -> {
-                    String errMsg = format("Failed to do cache for cacheInfo %s; caused by %s", cacheInfo.getName(), e.getMessage());
-                    // If the cache fails because DuckDB doesn't have sufficient memory, we'll attempt to retry it later.
-                    if (e.getCause() instanceof WrenException && EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode().equals(((WrenException) e.getCause()).getErrorCode())) {
-                        long delay = configManager.getConfig(DuckDBConfig.class).getCacheTaskRetryDelay();
-                        retryScheduledFutures.put(
-                                catalogSchemaTableName,
-                                retryExecutor.schedule(
-                                        () -> createTask(analyzedMDL, cacheInfo).join(),
-                                        delay,
-                                        SECONDS));
-                        errMsg += "; will retry after " + delay + " seconds";
-                    }
-                    pgMetastore.dropTableIfExists(duckdbTableName);
-                    LOG.error(e, errMsg);
-                    cachedTableMapping.putCachedTableMapping(catalogSchemaTableName, new CacheInfoPair(cacheInfo, Optional.empty(), Optional.of(errMsg), createTime));
-                    return null;
-                });
-    }
-
-    public ConnectorRecordIterator query(String sql, List<Parameter> parameters)
-    {
-        return cacheTaskManager.addCacheQueryTask(() -> DuckdbRecordIterator.of(pgMetastore.getClient(), sql, parameters.stream().collect(toImmutableList())));
-    }
-
-    private CompletableFuture<Void> doCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
-    {
-        WrenMDL mdl = analyzedMDL.getWrenMDL();
-        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
-        String duckdbTableName = format("%s_%s", cacheInfo.getName(), randomUUID().toString().replace("-", ""));
-        long createTime = currentTimeMillis();
-        return cacheTaskManager.addCacheTask(() -> {
-            cacheTaskManager.checkCacheMemoryLimit();
-            taskInfo.setTaskStatus(RUNNING);
-            SessionContext sessionContext = SessionContext.builder()
-                    .setCatalog(mdl.getCatalog())
-                    .setSchema(mdl.getSchema())
-                    .build();
-            String wrenRewritten = WrenPlanner.rewrite(
-                    format("select * from %s", cacheInfo.getName()),
-                    sessionContext,
-                    analyzedMDL);
-            Statement parsedStatement = parseSql(wrenRewritten);
-            Statement rewrittenStatement = extraRewriter.rewrite(parsedStatement);
-
-            createCache(mdl, cacheInfo, sessionContext, rewrittenStatement, duckdbTableName);
-            cachedTableMapping.putCachedTableMapping(catalogSchemaTableName, new CacheInfoPair(cacheInfo, duckdbTableName, createTime));
-        });
-    }
-
-    private void createCache(
-            WrenMDL mdl,
-            CacheInfo cacheInfo,
-            SessionContext sessionContext,
-            Statement rewrittenStatement,
-            String duckdbTableName)
-    {
-        cacheService.createCache(
-                        mdl.getCatalog(),
-                        mdl.getSchema(),
-                        cacheInfo.getName(),
-                        sqlConverter.convert(getFormattedSql(rewrittenStatement, sqlParser), sessionContext))
-                .ifPresent(pathInfo -> {
-                    try {
-                        tempFileLocations.add(pathInfo);
-                        refreshCacheInDuckDB(pathInfo.getPath() + "/" + pathInfo.getFilePattern(), duckdbTableName);
-                    }
-                    finally {
-                        removeTempFile(pathInfo);
-                    }
-                });
-    }
-
-    private void refreshCacheInDuckDB(String path, String tableName)
-    {
-        pgMetastore.directDDL(configManager.getConfig(CacheStorageConfig.class).generateDuckdbParquetStatement(path, tableName));
-    }
-
-    public void removeCacheIfExist(String catalogName, String schemaName)
-    {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(schemaName, "schemaName is null");
-
-        cacheScheduledFutures.keySet().stream()
-                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
-                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
-                .forEach(catalogSchemaTableName -> {
-                    cacheScheduledFutures.get(catalogSchemaTableName).cancel(true);
-                    cacheScheduledFutures.remove(catalogSchemaTableName);
-                });
-
-        retryScheduledFutures.keySet().stream()
-                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
-                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
-                .forEach(catalogSchemaTableName -> {
-                    retryScheduledFutures.get(catalogSchemaTableName).cancel(true);
-                    retryScheduledFutures.remove(catalogSchemaTableName);
-                });
-
-        cachedTableMapping.entrySet().stream()
-                .filter(entry -> entry.getKey().getCatalogName().equals(catalogName)
-                        && entry.getKey().getSchemaTableName().getSchemaName().equals(schemaName))
-                .forEach(entry -> {
-                    entry.getValue().getTableName().ifPresent(pgMetastore::dropTableIfExists);
-                    cachedTableMapping.remove(entry.getKey());
-                });
-
-        tasks.keySet().stream()
-                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
-                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
-                .forEach(tasks::remove);
-    }
-
-    public void removeCacheIfExist(CatalogSchemaTableName catalogSchemaTableName)
-    {
-        if (cacheScheduledFutures.containsKey(catalogSchemaTableName)) {
-            cacheScheduledFutures.get(catalogSchemaTableName).cancel(true);
-            cacheScheduledFutures.remove(catalogSchemaTableName);
-        }
-
-        if (retryScheduledFutures.containsKey(catalogSchemaTableName)) {
-            retryScheduledFutures.get(catalogSchemaTableName).cancel(true);
-            retryScheduledFutures.remove(catalogSchemaTableName);
-        }
-
-        Optional.ofNullable(cachedTableMapping.get(catalogSchemaTableName)).ifPresent(cacheInfoPair -> {
-            cacheInfoPair.getTableName().ifPresent(pgMetastore::dropTableIfExists);
-            cachedTableMapping.remove(catalogSchemaTableName);
-        });
-
-        Task task = tasks.remove(catalogSchemaTableName);
-        if (task != null) {
-            eventLogger.logEvent(INFO, "REMOVE_TASK", "Remove cache: " + catalogSchemaTableName);
-        }
-    }
-
-    public boolean cacheScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
-    {
-        return cacheScheduledFutures.containsKey(catalogSchemaTableName);
+        return false;
     }
 
     @VisibleForTesting
-    public boolean retryScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
+    default boolean retryScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
     {
-        return retryScheduledFutures.containsKey(catalogSchemaTableName);
+        return false;
     }
 
-    @Override
-    public void close()
+    default CompletableFuture<List<TaskInfo>> createTask(AnalyzedMDL analyzedMDL)
     {
-        refreshExecutor.shutdownNow();
-        retryExecutor.shutdownNow();
-        executorService.shutdownNow();
-        cleanTempFiles();
+        return CompletableFuture.completedFuture(List.of());
     }
 
-    public void cleanTempFiles()
+    default CompletableFuture<TaskInfo> createTask(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo)
     {
-        try {
-            List<PathInfo> locations = ImmutableList.copyOf(tempFileLocations);
-            locations.forEach(this::removeTempFile);
-        }
-        catch (Exception e) {
-            LOG.error(e, "Failed to clean temp file");
-        }
+        throw new WrenException(GENERIC_INTERNAL_ERROR, "Enable Wren Protocol to use this feature");
     }
 
-    public void removeTempFile(PathInfo pathInfo)
+    default CompletableFuture<List<TaskInfo>> listTaskInfo(String catalogName, String schemaName)
     {
-        if (tempFileLocations.contains(pathInfo)) {
-            cacheService.deleteTarget(pathInfo);
-            tempFileLocations.remove(pathInfo);
-        }
+        throw new WrenException(GENERIC_INTERNAL_ERROR, "Enable Wren Protocol to use this feature");
     }
 
-    public List<TaskInfo> createTaskUntilDone(AnalyzedMDL analyzedMDL)
+    default CompletableFuture<Optional<TaskInfo>> getTaskInfo(CatalogSchemaTableName catalogSchemaTableName)
     {
-        return createTask(analyzedMDL)
-                .thenApply(taskInfos -> taskInfos.stream()
-                        .map(taskInfo -> {
-                            tasks.get(taskInfo.getCatalogSchemaTableName()).waitUntilDone();
-                            return getTaskInfo(taskInfo.getCatalogSchemaTableName()).join();
-                        })
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(toList()))
-                .join();
-    }
-
-    public CompletableFuture<List<TaskInfo>> createTask(AnalyzedMDL analyzedMDL)
-    {
-        return supplyAsync(() ->
-                analyzedMDL.getWrenMDL().listCached().stream().map(cacheInfo -> createTask(analyzedMDL, cacheInfo).join()).collect(toList()));
-    }
-
-    public CompletableFuture<TaskInfo> createTask(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo)
-    {
-        return supplyAsync(() -> {
-            WrenMDL mdl = analyzedMDL.getWrenMDL();
-            CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
-            TaskInfo taskInfo = new TaskInfo(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName(), QUEUED, Instant.now());
-            // To fix flaky test, we pass value to tasks instead of a reference;
-            Task task = new Task(TaskInfo.copyFrom(taskInfo), analyzedMDL, cacheInfo);
-            tasks.put(catalogSchemaTableName, task);
-            return taskInfo;
-        });
-    }
-
-    public CompletableFuture<List<TaskInfo>> listTaskInfo(String catalogName, String schemaName)
-    {
-        Predicate<TaskInfo> catalogNamePred = catalogName.isEmpty() ?
-                (t) -> true :
-                (t) -> catalogName.equals(t.getCatalogName());
-
-        Predicate<TaskInfo> schemaNamePred = schemaName.isEmpty() ?
-                (t) -> true :
-                (t) -> schemaName.equals(t.getSchemaName());
-
-        return supplyAsync(
-                () -> tasks.values().stream()
-                        .map(Task::getTaskInfo)
-                        .filter(catalogNamePred.and(schemaNamePred))
-                        .collect(toList()),
-                executorService);
-    }
-
-    public CompletableFuture<Optional<TaskInfo>> getTaskInfo(CatalogSchemaTableName catalogSchemaTableName)
-    {
-        requireNonNull(catalogSchemaTableName);
-        return supplyAsync(
-                () -> Optional.ofNullable(tasks.get(catalogSchemaTableName)).map(Task::getTaskInfo),
-                executorService);
+        throw new WrenException(GENERIC_INTERNAL_ERROR, "Enable Wren Protocol to use this feature");
     }
 
     @VisibleForTesting
-    public void untilTaskDone(CatalogSchemaTableName name)
+    default void untilTaskDone(CatalogSchemaTableName name) {}
+
+    default List<Object> getDuckDBSettings()
     {
-        Optional.ofNullable(tasks.get(name)).ifPresent(Task::waitUntilDone);
-    }
-
-    public List<Object> getDuckDBSettings()
-    {
-        try (ConnectorRecordIterator iter = query("SELECT * FROM duckdb_settings()", List.of())) {
-            return ImmutableList.copyOf(iter);
-        }
-        catch (Exception e) {
-            LOG.error(e, "Failed to get duckdb settings");
-            throw new WrenException(GENERIC_INTERNAL_ERROR, e);
-        }
-    }
-
-    private class Task
-    {
-        private final TaskInfo taskInfo;
-        private final CompletableFuture<?> completableFuture;
-
-        public Task(TaskInfo taskInfo, AnalyzedMDL analyzedMDL, CacheInfo cacheInfo)
-        {
-            this.taskInfo = taskInfo;
-            this.completableFuture = handleCache(analyzedMDL, cacheInfo, taskInfo)
-                    .thenRun(() -> {
-                        CacheInfoPair cacheInfoPair = cachedTableMapping.getCacheInfoPair(
-                                taskInfo.getCatalogName(),
-                                taskInfo.getSchemaName(), taskInfo.getTableName());
-                        taskInfo.setCachedTable(new CachedTable(
-                                cacheInfoPair.getCacheInfo().getName(),
-                                cacheInfoPair.getErrorMessage(),
-                                cacheInfoPair.getCacheInfo().getRefreshTime(),
-                                Instant.ofEpochMilli(cacheInfoPair.getCreateTime())));
-                        taskInfo.setTaskStatus(DONE);
-                        if (cacheInfoPair.getErrorMessage().isPresent()) {
-                            eventLogger.logEvent(ERROR, "CREATE_TASK", taskInfo);
-                        }
-                        else {
-                            eventLogger.logEvent(INFO, "CREATE_TASK", taskInfo);
-                        }
-                    });
-        }
-
-        public TaskInfo getTaskInfo()
-        {
-            return taskInfo;
-        }
-
-        public void waitUntilDone()
-        {
-            completableFuture.join();
-        }
+        throw new WrenException(GENERIC_INTERNAL_ERROR, "Enable Wren Protocol to use this feature");
     }
 }

--- a/wren-cache/src/main/java/io/wren/cache/CacheManagerImpl.java
+++ b/wren-cache/src/main/java/io/wren/cache/CacheManagerImpl.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.Statement;
+import io.wren.base.AnalyzedMDL;
+import io.wren.base.CatalogSchemaTableName;
+import io.wren.base.ConnectorRecordIterator;
+import io.wren.base.Parameter;
+import io.wren.base.SessionContext;
+import io.wren.base.WrenException;
+import io.wren.base.WrenMDL;
+import io.wren.base.client.duckdb.CacheStorageConfig;
+import io.wren.base.client.duckdb.DuckDBConfig;
+import io.wren.base.config.ConfigManager;
+import io.wren.base.dto.CacheInfo;
+import io.wren.base.sql.SqlConverter;
+import io.wren.base.sqlrewrite.WrenPlanner;
+import io.wren.base.wireprotocol.PgMetastore;
+import io.wren.cache.dto.CachedTable;
+
+import java.io.Closeable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.trino.execution.sql.SqlFormatterUtil.getFormattedSql;
+import static io.wren.base.CatalogSchemaTableName.catalogSchemaTableName;
+import static io.wren.base.metadata.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_LIMIT;
+import static io.wren.base.metadata.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.wren.base.metadata.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.wren.base.sqlrewrite.Utils.parseSql;
+import static io.wren.cache.EventLogger.Level.ERROR;
+import static io.wren.cache.EventLogger.Level.INFO;
+import static io.wren.cache.TaskInfo.TaskStatus.DONE;
+import static io.wren.cache.TaskInfo.TaskStatus.QUEUED;
+import static io.wren.cache.TaskInfo.TaskStatus.RUNNING;
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+
+public class CacheManagerImpl
+        implements CacheManager, Closeable
+{
+    private static final Logger LOG = Logger.get(CacheManager.class);
+    private final ExtraRewriter extraRewriter;
+    private final CacheService cacheService;
+    private final SqlParser sqlParser;
+    private final SqlConverter sqlConverter;
+    private final PgMetastore pgMetastore;
+    private final ConcurrentLinkedQueue<PathInfo> tempFileLocations = new ConcurrentLinkedQueue<>();
+    private final CachedTableMapping cachedTableMapping;
+    private final ConcurrentMap<CatalogSchemaTableName, ScheduledFuture<?>> cacheScheduledFutures = new ConcurrentHashMap<>();
+    private final ConcurrentMap<CatalogSchemaTableName, ScheduledFuture<?>> retryScheduledFutures = new ConcurrentHashMap<>();
+    private final ScheduledThreadPoolExecutor refreshExecutor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("cache-refresh-%s"));
+    private final ScheduledThreadPoolExecutor retryExecutor = new ScheduledThreadPoolExecutor(5, daemonThreadsNamed("cache-retry-%s"));
+    private final ExecutorService executorService = newCachedThreadPool(threadsNamed("cache-manager-%s"));
+    private final ConcurrentHashMap<CatalogSchemaTableName, Task> tasks = new ConcurrentHashMap<>();
+    private final EventLogger eventLogger;
+    private final CacheTaskManager cacheTaskManager;
+    private final ConfigManager configManager;
+
+    @Inject
+    public CacheManagerImpl(
+            SqlConverter sqlConverter,
+            CacheService cacheService,
+            ExtraRewriter extraRewriter,
+            PgMetastore pgMetastore,
+            CachedTableMapping cachedTableMapping,
+            EventLogger eventLogger,
+            CacheTaskManager cacheTaskManager,
+            ConfigManager configManager)
+    {
+        this.sqlParser = new SqlParser();
+        this.sqlConverter = requireNonNull(sqlConverter, "sqlConverter is null");
+        this.cacheService = requireNonNull(cacheService, "cacheService is null");
+        this.extraRewriter = requireNonNull(extraRewriter, "extraRewriter is null");
+        this.pgMetastore = requireNonNull(pgMetastore, "pgMetastore is null");
+        this.cacheTaskManager = requireNonNull(cacheTaskManager, "cacheTaskManager is null");
+        this.cachedTableMapping = requireNonNull(cachedTableMapping, "cachedTableMapping is null");
+        this.eventLogger = requireNonNull(eventLogger, "eventLogger is null");
+        this.configManager = requireNonNull(configManager, "configManager is null");
+        refreshExecutor.setRemoveOnCancelPolicy(true);
+    }
+
+    private synchronized CompletableFuture<Void> refreshCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
+    {
+        WrenMDL mdl = analyzedMDL.getWrenMDL();
+        CatalogSchemaTableName catalogSchemaTableName = catalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
+        Optional<Task> taskOptional = Optional.ofNullable(tasks.get(catalogSchemaTableName));
+        if (taskOptional.isPresent() && taskOptional.get().getTaskInfo().inProgress()) {
+            throw new WrenException(GENERIC_USER_ERROR, format("cache is already running; catalogName: %s, schemaName: %s, tableName: %s", mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName()));
+        }
+        removeCacheIfExist(catalogSchemaTableName);
+        return doCache(analyzedMDL, cacheInfo, taskInfo);
+    }
+
+    private CompletableFuture<Void> handleCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
+    {
+        WrenMDL mdl = analyzedMDL.getWrenMDL();
+        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
+        String duckdbTableName = format("%s_%s", cacheInfo.getName(), randomUUID().toString().replace("-", ""));
+        long createTime = currentTimeMillis();
+        return refreshCache(analyzedMDL, cacheInfo, taskInfo)
+                .thenRun(() -> {
+                    if (cacheInfo.getRefreshTime().toMillis() > 0) {
+                        cacheScheduledFutures.put(
+                                catalogSchemaTableName,
+                                refreshExecutor.scheduleWithFixedDelay(
+                                        () -> createTask(analyzedMDL, cacheInfo).join(),
+                                        cacheInfo.getRefreshTime().toMillis(),
+                                        cacheInfo.getRefreshTime().toMillis(),
+                                        MILLISECONDS));
+                    }
+                })
+                .exceptionally(e -> {
+                    String errMsg = format("Failed to do cache for cacheInfo %s; caused by %s", cacheInfo.getName(), e.getMessage());
+                    // If the cache fails because DuckDB doesn't have sufficient memory, we'll attempt to retry it later.
+                    if (e.getCause() instanceof WrenException && EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode().equals(((WrenException) e.getCause()).getErrorCode())) {
+                        long delay = configManager.getConfig(DuckDBConfig.class).getCacheTaskRetryDelay();
+                        retryScheduledFutures.put(
+                                catalogSchemaTableName,
+                                retryExecutor.schedule(
+                                        () -> createTask(analyzedMDL, cacheInfo).join(),
+                                        delay,
+                                        SECONDS));
+                        errMsg += "; will retry after " + delay + " seconds";
+                    }
+                    pgMetastore.dropTableIfExists(duckdbTableName);
+                    LOG.error(e, errMsg);
+                    cachedTableMapping.putCachedTableMapping(catalogSchemaTableName, new CacheInfoPair(cacheInfo, Optional.empty(), Optional.of(errMsg), createTime));
+                    return null;
+                });
+    }
+
+    @Override
+    public ConnectorRecordIterator query(String sql, List<Parameter> parameters)
+    {
+        return cacheTaskManager.addCacheQueryTask(() -> DuckdbRecordIterator.of(pgMetastore.getClient(), sql, parameters.stream().collect(toImmutableList())));
+    }
+
+    private CompletableFuture<Void> doCache(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo, TaskInfo taskInfo)
+    {
+        WrenMDL mdl = analyzedMDL.getWrenMDL();
+        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
+        String duckdbTableName = format("%s_%s", cacheInfo.getName(), randomUUID().toString().replace("-", ""));
+        long createTime = currentTimeMillis();
+        return cacheTaskManager.addCacheTask(() -> {
+            cacheTaskManager.checkCacheMemoryLimit();
+            taskInfo.setTaskStatus(RUNNING);
+            SessionContext sessionContext = SessionContext.builder()
+                    .setCatalog(mdl.getCatalog())
+                    .setSchema(mdl.getSchema())
+                    .build();
+            String wrenRewritten = WrenPlanner.rewrite(
+                    format("select * from %s", cacheInfo.getName()),
+                    sessionContext,
+                    analyzedMDL);
+            Statement parsedStatement = parseSql(wrenRewritten);
+            Statement rewrittenStatement = extraRewriter.rewrite(parsedStatement);
+
+            createCache(mdl, cacheInfo, sessionContext, rewrittenStatement, duckdbTableName);
+            cachedTableMapping.putCachedTableMapping(catalogSchemaTableName, new CacheInfoPair(cacheInfo, duckdbTableName, createTime));
+        });
+    }
+
+    private void createCache(
+            WrenMDL mdl,
+            CacheInfo cacheInfo,
+            SessionContext sessionContext,
+            Statement rewrittenStatement,
+            String duckdbTableName)
+    {
+        cacheService.createCache(
+                        mdl.getCatalog(),
+                        mdl.getSchema(),
+                        cacheInfo.getName(),
+                        sqlConverter.convert(getFormattedSql(rewrittenStatement, sqlParser), sessionContext))
+                .ifPresent(pathInfo -> {
+                    try {
+                        tempFileLocations.add(pathInfo);
+                        refreshCacheInDuckDB(pathInfo.getPath() + "/" + pathInfo.getFilePattern(), duckdbTableName);
+                    }
+                    finally {
+                        removeTempFile(pathInfo);
+                    }
+                });
+    }
+
+    private void refreshCacheInDuckDB(String path, String tableName)
+    {
+        pgMetastore.directDDL(configManager.getConfig(CacheStorageConfig.class).generateDuckdbParquetStatement(path, tableName));
+    }
+
+    @Override
+    public void removeCacheIfExist(String catalogName, String schemaName)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(schemaName, "schemaName is null");
+
+        cacheScheduledFutures.keySet().stream()
+                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
+                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
+                .forEach(catalogSchemaTableName -> {
+                    cacheScheduledFutures.get(catalogSchemaTableName).cancel(true);
+                    cacheScheduledFutures.remove(catalogSchemaTableName);
+                });
+
+        retryScheduledFutures.keySet().stream()
+                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
+                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
+                .forEach(catalogSchemaTableName -> {
+                    retryScheduledFutures.get(catalogSchemaTableName).cancel(true);
+                    retryScheduledFutures.remove(catalogSchemaTableName);
+                });
+
+        cachedTableMapping.entrySet().stream()
+                .filter(entry -> entry.getKey().getCatalogName().equals(catalogName)
+                        && entry.getKey().getSchemaTableName().getSchemaName().equals(schemaName))
+                .forEach(entry -> {
+                    entry.getValue().getTableName().ifPresent(pgMetastore::dropTableIfExists);
+                    cachedTableMapping.remove(entry.getKey());
+                });
+
+        tasks.keySet().stream()
+                .filter(catalogSchemaTableName -> catalogSchemaTableName.getCatalogName().equals(catalogName)
+                        && catalogSchemaTableName.getSchemaTableName().getSchemaName().equals(schemaName))
+                .forEach(tasks::remove);
+    }
+
+    @Override
+    public void removeCacheIfExist(CatalogSchemaTableName catalogSchemaTableName)
+    {
+        if (cacheScheduledFutures.containsKey(catalogSchemaTableName)) {
+            cacheScheduledFutures.get(catalogSchemaTableName).cancel(true);
+            cacheScheduledFutures.remove(catalogSchemaTableName);
+        }
+
+        if (retryScheduledFutures.containsKey(catalogSchemaTableName)) {
+            retryScheduledFutures.get(catalogSchemaTableName).cancel(true);
+            retryScheduledFutures.remove(catalogSchemaTableName);
+        }
+
+        Optional.ofNullable(cachedTableMapping.get(catalogSchemaTableName)).ifPresent(cacheInfoPair -> {
+            cacheInfoPair.getTableName().ifPresent(pgMetastore::dropTableIfExists);
+            cachedTableMapping.remove(catalogSchemaTableName);
+        });
+
+        Task task = tasks.remove(catalogSchemaTableName);
+        if (task != null) {
+            eventLogger.logEvent(INFO, "REMOVE_TASK", "Remove cache: " + catalogSchemaTableName);
+        }
+    }
+
+    @Override
+    public boolean cacheScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
+    {
+        return cacheScheduledFutures.containsKey(catalogSchemaTableName);
+    }
+
+    @Override
+    public boolean retryScheduledFutureExists(CatalogSchemaTableName catalogSchemaTableName)
+    {
+        return retryScheduledFutures.containsKey(catalogSchemaTableName);
+    }
+
+    @Override
+    public void close()
+    {
+        refreshExecutor.shutdownNow();
+        retryExecutor.shutdownNow();
+        executorService.shutdownNow();
+        cleanTempFiles();
+    }
+
+    private void cleanTempFiles()
+    {
+        try {
+            List<PathInfo> locations = ImmutableList.copyOf(tempFileLocations);
+            locations.forEach(this::removeTempFile);
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to clean temp file");
+        }
+    }
+
+    private void removeTempFile(PathInfo pathInfo)
+    {
+        if (tempFileLocations.contains(pathInfo)) {
+            cacheService.deleteTarget(pathInfo);
+            tempFileLocations.remove(pathInfo);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<TaskInfo>> createTask(AnalyzedMDL analyzedMDL)
+    {
+        return supplyAsync(() ->
+                analyzedMDL.getWrenMDL().listCached().stream().map(cacheInfo -> createTask(analyzedMDL, cacheInfo).join()).collect(toList()));
+    }
+
+    @Override
+    public CompletableFuture<TaskInfo> createTask(AnalyzedMDL analyzedMDL, CacheInfo cacheInfo)
+    {
+        return supplyAsync(() -> {
+            WrenMDL mdl = analyzedMDL.getWrenMDL();
+            CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName());
+            TaskInfo taskInfo = new TaskInfo(mdl.getCatalog(), mdl.getSchema(), cacheInfo.getName(), QUEUED, Instant.now());
+            // To fix flaky test, we pass value to tasks instead of a reference;
+            Task task = new Task(TaskInfo.copyFrom(taskInfo), analyzedMDL, cacheInfo);
+            tasks.put(catalogSchemaTableName, task);
+            return taskInfo;
+        });
+    }
+
+    @Override
+    public CompletableFuture<List<TaskInfo>> listTaskInfo(String catalogName, String schemaName)
+    {
+        Predicate<TaskInfo> catalogNamePred = catalogName.isEmpty() ?
+                (t) -> true :
+                (t) -> catalogName.equals(t.getCatalogName());
+
+        Predicate<TaskInfo> schemaNamePred = schemaName.isEmpty() ?
+                (t) -> true :
+                (t) -> schemaName.equals(t.getSchemaName());
+
+        return supplyAsync(
+                () -> tasks.values().stream()
+                        .map(Task::getTaskInfo)
+                        .filter(catalogNamePred.and(schemaNamePred))
+                        .collect(toList()),
+                executorService);
+    }
+
+    @Override
+    public CompletableFuture<Optional<TaskInfo>> getTaskInfo(CatalogSchemaTableName catalogSchemaTableName)
+    {
+        requireNonNull(catalogSchemaTableName);
+        return supplyAsync(
+                () -> Optional.ofNullable(tasks.get(catalogSchemaTableName)).map(Task::getTaskInfo),
+                executorService);
+    }
+
+    @VisibleForTesting
+    @Override
+    public void untilTaskDone(CatalogSchemaTableName name)
+    {
+        Optional.ofNullable(tasks.get(name)).ifPresent(Task::waitUntilDone);
+    }
+
+    public List<Object> getDuckDBSettings()
+    {
+        try (ConnectorRecordIterator iter = query("SELECT * FROM duckdb_settings()", List.of())) {
+            return ImmutableList.copyOf(iter);
+        }
+        catch (Exception e) {
+            LOG.error(e, "Failed to get duckdb settings");
+            throw new WrenException(GENERIC_INTERNAL_ERROR, e);
+        }
+    }
+
+    private class Task
+    {
+        private final TaskInfo taskInfo;
+        private final CompletableFuture<?> completableFuture;
+
+        public Task(TaskInfo taskInfo, AnalyzedMDL analyzedMDL, CacheInfo cacheInfo)
+        {
+            this.taskInfo = taskInfo;
+            this.completableFuture = handleCache(analyzedMDL, cacheInfo, taskInfo)
+                    .thenRun(() -> {
+                        CacheInfoPair cacheInfoPair = cachedTableMapping.getCacheInfoPair(
+                                taskInfo.getCatalogName(),
+                                taskInfo.getSchemaName(), taskInfo.getTableName());
+                        taskInfo.setCachedTable(new CachedTable(
+                                cacheInfoPair.getCacheInfo().getName(),
+                                cacheInfoPair.getErrorMessage(),
+                                cacheInfoPair.getCacheInfo().getRefreshTime(),
+                                Instant.ofEpochMilli(cacheInfoPair.getCreateTime())));
+                        taskInfo.setTaskStatus(DONE);
+                        if (cacheInfoPair.getErrorMessage().isPresent()) {
+                            eventLogger.logEvent(ERROR, "CREATE_TASK", taskInfo);
+                        }
+                        else {
+                            eventLogger.logEvent(INFO, "CREATE_TASK", taskInfo);
+                        }
+                    });
+        }
+
+        public TaskInfo getTaskInfo()
+        {
+            return taskInfo;
+        }
+
+        public void waitUntilDone()
+        {
+            completableFuture.join();
+        }
+    }
+}

--- a/wren-cache/src/main/java/io/wren/cache/CacheModule.java
+++ b/wren-cache/src/main/java/io/wren/cache/CacheModule.java
@@ -17,10 +17,6 @@ package io.wren.cache;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.wren.base.client.duckdb.DuckDBConfig;
-import io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig;
-
-import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class CacheModule
         extends AbstractConfigurationAwareModule
@@ -28,8 +24,6 @@ public class CacheModule
     @Override
     protected void setup(Binder binder)
     {
-        configBinder(binder).bindConfig(DuckdbS3StyleStorageConfig.class);
-        configBinder(binder).bindConfig(DuckDBConfig.class);
         binder.bind(CacheManager.class).in(Scopes.SINGLETON);
         binder.bind(CacheTaskManager.class).in(Scopes.SINGLETON);
         binder.bind(EventLogger.class).to(Log4jEventLogger.class).in(Scopes.SINGLETON);

--- a/wren-cache/src/main/java/io/wren/cache/CacheModule.java
+++ b/wren-cache/src/main/java/io/wren/cache/CacheModule.java
@@ -24,7 +24,7 @@ public class CacheModule
     @Override
     protected void setup(Binder binder)
     {
-        binder.bind(CacheManager.class).in(Scopes.SINGLETON);
+        binder.bind(CacheManager.class).to(CacheManagerImpl.class).in(Scopes.SINGLETON);
         binder.bind(CacheTaskManager.class).in(Scopes.SINGLETON);
         binder.bind(EventLogger.class).to(Log4jEventLogger.class).in(Scopes.SINGLETON);
         binder.bind(CachedTableMapping.class).to(DefaultCachedTableMapping.class).in(Scopes.SINGLETON);

--- a/wren-cache/src/main/java/io/wren/cache/NoOpCacheManager.java
+++ b/wren-cache/src/main/java/io/wren/cache/NoOpCacheManager.java
@@ -12,26 +12,9 @@
  * limitations under the License.
  */
 
-package io.wren.main.pgcatalog;
+package io.wren.cache;
 
-import io.wren.main.pgcatalog.exception.DeployException;
-
-public interface PgCatalogManager
+public class NoOpCacheManager
+        implements CacheManager
 {
-    default void initPgCatalog()
-            throws DeployException
-    {}
-
-    default void initPgFunctions() {}
-
-    default void dropSchema(String name) {}
-
-    default boolean checkRequired()
-    {
-        return true;
-    }
-
-    default void syncPgMetastore()
-            throws DeployException
-    {}
 }

--- a/wren-main/src/main/java/io/wren/main/WrenModule.java
+++ b/wren-main/src/main/java/io/wren/main/WrenModule.java
@@ -17,7 +17,14 @@ package io.wren.main;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.wren.base.config.PostgresWireProtocolConfig;
 import io.wren.base.config.WrenConfig;
+import io.wren.cache.CacheManager;
+import io.wren.cache.CacheManagerImpl;
+import io.wren.cache.NoOpCacheManager;
+import io.wren.main.pgcatalog.NoOpPgCatalogManager;
+import io.wren.main.pgcatalog.PgCatalogManager;
+import io.wren.main.pgcatalog.PgCatalogManagerImpl;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
@@ -27,8 +34,17 @@ public class WrenModule
     @Override
     protected void setup(Binder binder)
     {
+        PostgresWireProtocolConfig config = buildConfigObject(PostgresWireProtocolConfig.class);
         configBinder(binder).bindConfig(WrenConfig.class);
         binder.bind(WrenManager.class).in(Scopes.SINGLETON);
         binder.bind(WrenMetastore.class).in(Scopes.SINGLETON);
+        if (config.isPgWireProtocolEnabled()) {
+            binder.bind(CacheManager.class).to(CacheManagerImpl.class).in(Scopes.SINGLETON);
+            binder.bind(PgCatalogManager.class).to(PgCatalogManagerImpl.class).in(Scopes.SINGLETON);
+        }
+        else {
+            binder.bind(CacheManager.class).to(NoOpCacheManager.class).in(Scopes.SINGLETON);
+            binder.bind(PgCatalogManager.class).to(NoOpPgCatalogManager.class).in(Scopes.SINGLETON);
+        }
     }
 }

--- a/wren-main/src/main/java/io/wren/main/pgcatalog/NoOpPgCatalogManager.java
+++ b/wren-main/src/main/java/io/wren/main/pgcatalog/NoOpPgCatalogManager.java
@@ -14,24 +14,7 @@
 
 package io.wren.main.pgcatalog;
 
-import io.wren.main.pgcatalog.exception.DeployException;
-
-public interface PgCatalogManager
+public class NoOpPgCatalogManager
+        implements PgCatalogManager
 {
-    default void initPgCatalog()
-            throws DeployException
-    {}
-
-    default void initPgFunctions() {}
-
-    default void dropSchema(String name) {}
-
-    default boolean checkRequired()
-    {
-        return true;
-    }
-
-    default void syncPgMetastore()
-            throws DeployException
-    {}
 }

--- a/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManagerImpl.java
+++ b/wren-main/src/main/java/io/wren/main/pgcatalog/PgCatalogManagerImpl.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.main.pgcatalog;
+
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.wren.base.Column;
+import io.wren.base.WrenMDL;
+import io.wren.base.pgcatalog.function.DataSourceFunctionRegistry;
+import io.wren.base.pgcatalog.function.PgMetastoreFunctionRegistry;
+import io.wren.base.wireprotocol.PgMetastore;
+import io.wren.main.PreviewService;
+import io.wren.main.WrenMetastore;
+import io.wren.main.metadata.Metadata;
+import io.wren.main.pgcatalog.builder.PgFunctionBuilderManager;
+import io.wren.main.pgcatalog.builder.PgMetastoreFunctionBuilder;
+import io.wren.main.pgcatalog.exception.DeployException;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class PgCatalogManagerImpl
+        implements PgCatalogManager
+{
+    private static final Logger LOG = Logger.get(PgCatalogManager.class);
+
+    protected final String pgCatalogName;
+
+    private final Metadata connector;
+    private final DataSourceFunctionRegistry dataSourceFunctionRegistry;
+    private final PgMetastoreFunctionRegistry metastoreFunctionRegistry;
+    private final PgFunctionBuilderManager pgFunctionBuilderManager;
+    private final PgMetastoreFunctionBuilder pgMetastoreFunctionBuilder;
+    private final PgMetastore pgMetastore;
+    private final WrenMetastore wrenMetastore;
+    private final PreviewService previewService;
+
+    @Inject
+    public PgCatalogManagerImpl(
+            Metadata connector,
+            PgFunctionBuilderManager pgFunctionBuilderManager,
+            PgMetastore pgMetastore,
+            WrenMetastore wrenMetastore,
+            PreviewService previewService)
+    {
+        this.connector = requireNonNull(connector, "connector is null");
+        this.pgFunctionBuilderManager = requireNonNull(pgFunctionBuilderManager, "pgFunctionBuilderManager is null");
+        this.pgCatalogName = requireNonNull(connector.getPgCatalogName());
+        this.dataSourceFunctionRegistry = new DataSourceFunctionRegistry();
+        this.metastoreFunctionRegistry = new PgMetastoreFunctionRegistry();
+        this.pgMetastore = requireNonNull(pgMetastore, "pgMetastore is null");
+        this.pgMetastoreFunctionBuilder = new PgMetastoreFunctionBuilder(pgMetastore);
+        this.wrenMetastore = requireNonNull(wrenMetastore, "wrenMetastore is null");
+        this.previewService = requireNonNull(previewService, "previewService is null");
+    }
+
+    public void initPgCatalog()
+            throws DeployException
+    {
+        if (!connector.isPgCompatible()) {
+            createOrReplaceSchema(pgCatalogName);
+        }
+        initPgFunctions();
+        syncPgMetastore();
+    }
+
+    public void initPgFunctions()
+    {
+        metastoreFunctionRegistry.getFunctions()
+                .stream()
+                .filter(f -> !f.isImplemented())
+                .forEach(pgMetastoreFunctionBuilder::createPgFunction);
+        if (!connector.isPgCompatible()) {
+            dataSourceFunctionRegistry.getFunctions()
+                    .stream()
+                    .filter(f -> !f.isImplemented())
+                    .forEach(pgFunctionBuilderManager::createPgFunction);
+        }
+    }
+
+    public void dropSchema(String name)
+    {
+        pgMetastore.directDDL(format("DROP SCHEMA IF EXISTS \"%s\" CASCADE;", name));
+    }
+
+    private void createOrReplaceSchema(String name)
+    {
+        connector.dropSchemaIfExists(name);
+        connector.createSchema(name);
+    }
+
+    public boolean checkRequired()
+    {
+        WrenMDL mdl = wrenMetastore.getAnalyzedMDL().getWrenMDL();
+        if (!(pgMetastore.isSchemaExist(mdl.getSchema()))) {
+            LOG.warn("PgCatalog is not initialized");
+            return false;
+        }
+        return true;
+    }
+
+    public void syncPgMetastore()
+            throws DeployException
+    {
+        try {
+            WrenMDL mdl = wrenMetastore.getAnalyzedMDL().getWrenMDL();
+            StringBuilder sb = new StringBuilder();
+            if (StringUtils.isNotEmpty(mdl.getSchema())) {
+                sb.append(format("DROP SCHEMA IF EXISTS \"%s\" CASCADE;\n", mdl.getSchema()));
+                sb.append(format("CREATE SCHEMA IF NOT EXISTS \"%s\";\n", mdl.getSchema()));
+            }
+            mdl.listModels().forEach(model -> {
+                String cols = model.getColumns().stream()
+                        .filter(column -> column.getRelationship().isEmpty())
+                        .map(column -> format("\"%s\" %s", column.getName(), pgMetastore.handlePgType(column.getType())))
+                        .collect(joining(","));
+                sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), model.getName(), cols));
+            });
+            mdl.listMetrics().forEach(metric -> {
+                String cols = metric.getColumns().stream().map(column -> format("\"%s\" %s", column.getName(), pgMetastore.handlePgType(column.getType()))).collect(joining(","));
+                sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), metric.getName(), cols));
+            });
+            mdl.listCumulativeMetrics().forEach(metric -> {
+                String cols = format("\"%s\" %s, \"%s\" %s",
+                        metric.getMeasure().getName(),
+                        pgMetastore.handlePgType(metric.getMeasure().getType()),
+                        metric.getWindow().getName(),
+                        mdl.getColumnType(metric.getName(), metric.getWindow().getName())
+                                .orElseThrow(() -> new IllegalArgumentException("Unknown window column type")));
+                sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), metric.getName(), cols));
+            });
+            mdl.listViews()
+                    .stream()
+                    .map(view -> {
+                        try {
+                            return Optional.of(new DescribedView(view.getName(), previewService.dryRun(mdl, view.getStatement()).join()));
+                        }
+                        catch (Exception e) {
+                            LOG.error(e, "Failed to describe view %s", view.getName());
+                            return Optional.empty();
+                        }
+                    })
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .map(describedView -> (DescribedView) describedView)
+                    .forEach(describedView -> {
+                        String cols = describedView.columns.stream().map(column -> format("\"%s\" %s", column.getName(), column.getType().typName())).collect(joining(","));
+                        sb.append(format("CREATE TABLE IF NOT EXISTS \"%s\".\"%s\" (%s);\n", mdl.getSchema(), describedView.name, cols));
+                    });
+            String syncSql = sb.toString();
+            LOG.info("Sync PG Metastore DDL:\n %s", syncSql);
+            if (!syncSql.isEmpty()) {
+                pgMetastore.directDDL(syncSql);
+            }
+        }
+        catch (Exception e) {
+            // won't throw exception to avoid the sever start failed.
+            LOG.error(e, "Failed to sync PG Metastore");
+            throw new DeployException("Failed to sync PG Metastore", e);
+        }
+    }
+
+    static class DescribedView
+    {
+        private final String name;
+        private final List<Column> columns;
+
+        public DescribedView(String name, List<Column> columns)
+        {
+            this.name = name;
+            this.columns = columns;
+        }
+    }
+}

--- a/wren-server/src/main/java/io/wren/server/WrenServer.java
+++ b/wren-server/src/main/java/io/wren/server/WrenServer.java
@@ -21,6 +21,7 @@ import io.airlift.http.server.HttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
 import io.airlift.node.NodeModule;
+import io.wren.base.config.PostgresWireProtocolConfig;
 import io.wren.cache.CacheModule;
 import io.wren.main.WrenModule;
 import io.wren.main.server.Server;
@@ -33,6 +34,8 @@ import io.wren.server.module.PostgresWireProtocolModule;
 import io.wren.server.module.SQLGlotModule;
 import io.wren.server.module.SnowflakeConnectorModule;
 import io.wren.server.module.WebModule;
+
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 
 public class WrenServer
         extends Server
@@ -52,13 +55,13 @@ public class WrenServer
                 new JaxrsModule(),
                 new EventModule(),
                 new MainModule(),
-                new PostgresWireProtocolModule(new EmptyTlsDataProvider()),
                 new BigQueryConnectorModule(),
                 new PostgresConnectorModule(),
                 new DuckDBConnectorModule(),
                 new SnowflakeConnectorModule(),
                 new WrenModule(),
-                new CacheModule(),
+                conditionalModule(PostgresWireProtocolConfig.class, PostgresWireProtocolConfig::isPgWireProtocolEnabled, new CacheModule()),
+                conditionalModule(PostgresWireProtocolConfig.class, PostgresWireProtocolConfig::isPgWireProtocolEnabled, new PostgresWireProtocolModule(new EmptyTlsDataProvider())),
                 new WebModule(),
                 new SQLGlotModule());
     }

--- a/wren-server/src/main/java/io/wren/server/module/BigQueryConnectorModule.java
+++ b/wren-server/src/main/java/io/wren/server/module/BigQueryConnectorModule.java
@@ -17,6 +17,7 @@ package io.wren.server.module;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.wren.base.client.duckdb.DuckdbS3StyleStorageConfig;
 import io.wren.base.config.BigQueryConfig;
 import io.wren.main.connector.bigquery.BigQueryCacheService;
 import io.wren.main.connector.bigquery.BigQueryMetadata;
@@ -31,6 +32,7 @@ public class BigQueryConnectorModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(BigQueryConfig.class);
+        configBinder(binder).bindConfig(DuckdbS3StyleStorageConfig.class);
         binder.bind(BigQuerySqlConverter.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryCacheService.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);

--- a/wren-server/src/main/java/io/wren/server/module/DuckDBConnectorModule.java
+++ b/wren-server/src/main/java/io/wren/server/module/DuckDBConnectorModule.java
@@ -17,6 +17,7 @@ package io.wren.server.module;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.wren.base.client.duckdb.DuckDBConfig;
 import io.wren.base.client.duckdb.DuckDBConnectorConfig;
 import io.wren.main.connector.duckdb.DuckDBMetadata;
 import io.wren.main.connector.duckdb.DuckDBSqlConverter;
@@ -30,6 +31,7 @@ public class DuckDBConnectorModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(DuckDBConnectorConfig.class);
+        configBinder(binder).bindConfig(DuckDBConfig.class);
         binder.bind(DuckDBSqlConverter.class).in(Scopes.SINGLETON);
         binder.bind(DuckDBMetadata.class).in(Scopes.SINGLETON);
     }

--- a/wren-server/src/main/java/io/wren/server/module/PostgresWireProtocolModule.java
+++ b/wren-server/src/main/java/io/wren/server/module/PostgresWireProtocolModule.java
@@ -23,6 +23,7 @@ import io.wren.base.wireprotocol.PgMetastore;
 import io.wren.cache.ExtraRewriter;
 import io.wren.main.PostgresNettyProvider;
 import io.wren.main.pgcatalog.PgCatalogManager;
+import io.wren.main.pgcatalog.PgCatalogManagerImpl;
 import io.wren.main.pgcatalog.regtype.PgMetadata;
 import io.wren.main.pgcatalog.regtype.PostgresPgMetadata;
 import io.wren.main.pgcatalog.regtype.RegObjectFactory;
@@ -52,7 +53,7 @@ public class PostgresWireProtocolModule
         binder.bind(SqlParser.class).in(Scopes.SINGLETON);
         binder.bind(TlsDataProvider.class).toInstance(tlsDataProvider);
         binder.bind(SslContextProvider.class).in(Scopes.SINGLETON);
-        binder.bind(PgCatalogManager.class).in(Scopes.SINGLETON);
+        binder.bind(PgCatalogManager.class).to(PgCatalogManagerImpl.class).in(Scopes.SINGLETON);
         binder.bind(RegObjectFactory.class).in((Scopes.SINGLETON));
         binder.bind(PostgresNetty.class).toProvider(PostgresNettyProvider.class).in(Scopes.SINGLETON);
         // for cache extra rewrite

--- a/wren-tests/pom.xml
+++ b/wren-tests/pom.xml
@@ -66,6 +66,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>event</artifactId>
         </dependency>
 

--- a/wren-tests/src/main/java/io/wren/testing/TestingWrenServer.java
+++ b/wren-tests/src/main/java/io/wren/testing/TestingWrenServer.java
@@ -29,6 +29,7 @@ import io.airlift.http.server.testing.TestingHttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
 import io.airlift.node.NodeModule;
+import io.wren.base.config.PostgresWireProtocolConfig;
 import io.wren.cache.CacheModule;
 import io.wren.main.WrenModule;
 import io.wren.main.connector.duckdb.DuckDBMetadata;
@@ -53,6 +54,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.wren.base.config.PostgresWireProtocolConfig.PG_WIRE_PROTOCOL_PORT;
 
 public class TestingWrenServer
@@ -85,13 +87,13 @@ public class TestingWrenServer
                 new JaxrsModule(),
                 new EventModule(),
                 new MainModule(),
-                new PostgresWireProtocolModule(new EmptyTlsDataProvider()),
                 new BigQueryConnectorModule(),
                 new PostgresConnectorModule(),
                 new DuckDBConnectorModule(),
                 new SnowflakeConnectorModule(),
                 new WrenModule(),
-                new CacheModule(),
+                conditionalModule(PostgresWireProtocolConfig.class, PostgresWireProtocolConfig::isPgWireProtocolEnabled, new CacheModule()),
+                conditionalModule(PostgresWireProtocolConfig.class, PostgresWireProtocolConfig::isPgWireProtocolEnabled, new PostgresWireProtocolModule(new EmptyTlsDataProvider())),
                 new WebModule(),
                 new SQLGlotModule()));
 

--- a/wren-tests/src/test/java/io/wren/testing/TestConfigResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestConfigResource.java
@@ -72,7 +72,8 @@ public class TestConfigResource
 
         ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
                 .put(WREN_DIRECTORY, mdlDir.toAbsolutePath().toString())
-                .put(WREN_DATASOURCE_TYPE, DUCKDB.name());
+                .put(WREN_DATASOURCE_TYPE, DUCKDB.name())
+                .put("pg-wire-protocol.enabled", "true");
 
         return TestingWrenServer.builder()
                 .setRequiredConfigs(properties.build())

--- a/wren-tests/src/test/java/io/wren/testing/TestMetadataQuery.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestMetadataQuery.java
@@ -79,7 +79,8 @@ public class TestMetadataQuery
         }
         ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("wren.datasource.type", "DUCKDB")
-                .put("wren.directory", dir.toString());
+                .put("wren.directory", dir.toString())
+                .put("pg-wire-protocol.enabled", "true");
 
         return TestingWrenServer.builder()
                 .setRequiredConfigs(properties.build())

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractCacheTest.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractCacheTest.java
@@ -92,7 +92,8 @@ public abstract class AbstractCacheTest
                 .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
                 .put("duckdb.storage.access-key", getenv("TEST_DUCKDB_STORAGE_ACCESS_KEY"))
                 .put("duckdb.storage.secret-key", getenv("TEST_DUCKDB_STORAGE_SECRET_KEY"))
-                .put("wren.datasource.type", "bigquery");
+                .put("wren.datasource.type", "bigquery")
+                .put("pg-wire-protocol.enabled", "true");
 
         return properties;
     }

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/AbstractWireProtocolTestWithBigQuery.java
@@ -52,7 +52,8 @@ public abstract class AbstractWireProtocolTestWithBigQuery
                 .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
                 .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
                 .put("pg-wire-protocol.auth.file", requireNonNull(getClass().getClassLoader().getResource("accounts")).getPath())
-                .put("wren.datasource.type", "bigquery");
+                .put("wren.datasource.type", "bigquery")
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             Path dir = Files.createTempDirectory(getWrenDirectory());

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestDeployBigQueryRuntime.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestDeployBigQueryRuntime.java
@@ -50,6 +50,7 @@ public class TestDeployBigQueryRuntime
                 Files.write(dir.resolve("manifest.json"), Manifest.MANIFEST_JSON_CODEC.toJsonBytes(DEFAULT_MANIFEST));
             }
             properties.put("wren.directory", dir.toString());
+            properties.put("pg-wire-protocol.enabled", "true");
         }
         catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestDuckdbRetryCacheTask.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestDuckdbRetryCacheTask.java
@@ -60,8 +60,7 @@ public class TestDuckdbRetryCacheTask
     {
         return ImmutableMap.<String, String>builder()
                 .putAll(super.getProperties().build())
-                .put("duckdb.max-cache-table-size-ratio", "0")
-                .put("pg-wire-protocol.enabled", "true");
+                .put("duckdb.max-cache-table-size-ratio", "0");
     }
 
     @Test

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestDuckdbRetryCacheTask.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestDuckdbRetryCacheTask.java
@@ -60,7 +60,8 @@ public class TestDuckdbRetryCacheTask
     {
         return ImmutableMap.<String, String>builder()
                 .putAll(super.getProperties().build())
-                .put("duckdb.max-cache-table-size-ratio", "0");
+                .put("duckdb.max-cache-table-size-ratio", "0")
+                .put("pg-wire-protocol.enabled", "true");
     }
 
     @Test

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestDynamicFields.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestDynamicFields.java
@@ -45,7 +45,8 @@ public class TestDynamicFields
                 .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
                 .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
                 .put("wren.datasource.type", "bigquery")
-                .put("wren.experimental-enable-dynamic-fields", "true");
+                .put("wren.experimental-enable-dynamic-fields", "true")
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             Path dir = Files.createTempDirectory(getWrenDirectory());

--- a/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
+++ b/wren-tests/src/test/java/io/wren/testing/bigquery/TestWireProtocolTypeWithBigQuery.java
@@ -80,7 +80,8 @@ public class TestWireProtocolTypeWithBigQuery
                 .put("bigquery.location", "asia-east1")
                 .put("bigquery.credentials-key", getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"))
                 .put("bigquery.metadata.schema.prefix", format("test_%s_", randomIntString()))
-                .put("wren.datasource.type", "bigquery");
+                .put("wren.datasource.type", "bigquery")
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             Path dir = Files.createTempDirectory(getWrenDirectory());

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/AbstractWireProtocolTestWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/AbstractWireProtocolTestWithDuckDB.java
@@ -54,6 +54,7 @@ public abstract class AbstractWireProtocolTestWithDuckDB
                     Manifest.MANIFEST_JSON_CODEC.toJsonBytes(getManifest().orElse(WrenMDL.EMPTY.getManifest())));
         }
         propBuilder.put("wren.directory", dir.toString());
+        propBuilder.put("pg-wire-protocol.enabled", "true");
 
         Map<String, String> properties = new HashMap<>(propBuilder.build());
         properties.putAll(properties());

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolTypeWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWireProtocolTypeWithDuckDB.java
@@ -68,7 +68,8 @@ public class TestWireProtocolTypeWithDuckDB
     {
         ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("wren.datasource.type", DUCKDB.name())
-                .put("wren.directory", Files.createTempDirectory(getWrenDirectory()).toString());
+                .put("wren.directory", Files.createTempDirectory(getWrenDirectory()).toString())
+                .put("pg-wire-protocol.enabled", "true");
 
         return TestingWrenServer.builder()
                 .setRequiredConfigs(properties.build())

--- a/wren-tests/src/test/java/io/wren/testing/postgres/AbstractWireProtocolTestWithPostgres.java
+++ b/wren-tests/src/test/java/io/wren/testing/postgres/AbstractWireProtocolTestWithPostgres.java
@@ -40,7 +40,8 @@ public abstract class AbstractWireProtocolTestWithPostgres
                 .put("postgres.jdbc.url", testingPostgreSqlServer.getJdbcUrl())
                 .put("postgres.user", testingPostgreSqlServer.getUser())
                 .put("postgres.password", testingPostgreSqlServer.getPassword())
-                .put("wren.datasource.type", "POSTGRES");
+                .put("wren.datasource.type", "POSTGRES")
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             prepareData();

--- a/wren-tests/src/test/java/io/wren/testing/postgres/TestDeployPostgresRuntime.java
+++ b/wren-tests/src/test/java/io/wren/testing/postgres/TestDeployPostgresRuntime.java
@@ -51,6 +51,7 @@ public class TestDeployPostgresRuntime
                 Files.write(dir.resolve("manifest.json"), Manifest.MANIFEST_JSON_CODEC.toJsonBytes(DEFAULT_MANIFEST));
             }
             properties.put("wren.directory", dir.toString());
+            properties.put("pg-wire-protocol.enabled", "true");
         }
         catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/wren-tests/src/test/java/io/wren/testing/postgres/TestWireProtocolTypeWithPostgres.java
+++ b/wren-tests/src/test/java/io/wren/testing/postgres/TestWireProtocolTypeWithPostgres.java
@@ -39,7 +39,8 @@ public class TestWireProtocolTypeWithPostgres
                 .put("postgres.jdbc.url", testingPostgreSqlServer.getJdbcUrl())
                 .put("postgres.user", testingPostgreSqlServer.getUser())
                 .put("postgres.password", testingPostgreSqlServer.getPassword())
-                .put("wren.datasource.type", "POSTGRES");
+                .put("wren.datasource.type", "POSTGRES")
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             Path dir = Files.createTempDirectory(getWrenDirectory());

--- a/wren-tests/src/test/java/io/wren/testing/snowflake/AbstractWireProtocolTestWithSnowflake.java
+++ b/wren-tests/src/test/java/io/wren/testing/snowflake/AbstractWireProtocolTestWithSnowflake.java
@@ -65,7 +65,8 @@ public abstract class AbstractWireProtocolTestWithSnowflake
                 .put(SNOWFLAKE_PASSWORD, getenv("SNOWFLAKE_PASSWORD"))
                 .put(SNOWFLAKE_DATABASE, "SNOWFLAKE_SAMPLE_DATA")
                 .put(SNOWFLAKE_SCHEMA, "TPCH_SF1")
-                .put(SQLGLOT_PORT, String.valueOf(testingSQLGlotServer.getPort()));
+                .put(SQLGLOT_PORT, String.valueOf(testingSQLGlotServer.getPort()))
+                .put("pg-wire-protocol.enabled", "true");
 
         try {
             Path dir = Files.createTempDirectory("wren-snowflake-test");

--- a/wren-tests/src/test/java/io/wren/testing/snowflake/TestWireProtocolTypeWithSnowflake.java
+++ b/wren-tests/src/test/java/io/wren/testing/snowflake/TestWireProtocolTypeWithSnowflake.java
@@ -112,7 +112,8 @@ public class TestWireProtocolTypeWithSnowflake
                 .put(SNOWFLAKE_PASSWORD, getenv("SNOWFLAKE_PASSWORD"))
                 .put(SNOWFLAKE_DATABASE, "SNOWFLAKE_SAMPLE_DATA")
                 .put(SNOWFLAKE_SCHEMA, "TPCH_SF1")
-                .put(SQLGLOT_PORT, String.valueOf(testingSQLGlotServer.getPort()));
+                .put(SQLGLOT_PORT, String.valueOf(testingSQLGlotServer.getPort()))
+                .put("pg-wire-protocol.enabled", "true");
 
         return TestingWrenServer.builder()
                 .setRequiredConfigs(properties.build())


### PR DESCRIPTION
# Description
The Wren protocol and cache aren't necessary for the WrenAI user. Some logs or the internal DuckDB may make them be confused. Let's make Wren Protocol be configurable and disable in default.
We can use the new config to enable it.
- `pg-wire-protocol.enabled`: enable the wren protocol and cache layer. Default is false.