### PR TITLE
fix(Ibis-server): add database to connection info

### DIFF
--- a/ibis-server/data_source.py
+++ b/ibis-server/data_source.py
@@ -29,6 +29,7 @@ class DataSource(StrEnum):
         return ibis.postgres.connect(
             user=dto.user,
             password=dto.password,
+            database=dto.database,
             host=dto.host,
             port=dto.port,
         )

--- a/ibis-server/dto.py
+++ b/ibis-server/dto.py
@@ -9,6 +9,7 @@ class IbisDTO(BaseModel):
 class PostgresDTO(IbisDTO):
     host: str = Field(examples=["localhost"])
     port: int = Field(default=5432)
+    database: str
     user: str
     password: str
 


### PR DESCRIPTION
Encounter error when executed the sql statement generated from dry-plan API
`psycopg2.errors.UndefinedTable: relation "public.orders" does not exist
LINE 1: ...totalprice" AS "o_totalprice" FROM (SELECT * FROM "public"."...`

The statement dry-plan generated
`WITH "public_orders" AS (SELECT "public_orders"."o_clerk" AS "o_clerk", "public_orders"."o_comment" AS "o_comment", "public_orders"."o_custkey" AS "o_custkey", "public_orders"."o_orderdate" AS "o_orderdate", "public_orders"."o_orderkey" AS "o_orderkey", "public_orders"."o_orderpriority" AS "o_orderpriority", "public_orders"."o_orderstatus" AS "o_orderstatus", "public_orders"."o_shippriority" AS "o_shippriority", "public_orders"."o_totalprice" AS "o_totalprice" FROM (SELECT "public_orders"."o_clerk" AS "o_clerk", "public_orders"."o_comment" AS "o_comment", "public_orders"."o_custkey" AS "o_custkey", "public_orders"."o_orderdate" AS "o_orderdate", "public_orders"."o_orderkey" AS "o_orderkey", "public_orders"."o_orderpriority" AS "o_orderpriority", "public_orders"."o_orderstatus" AS "o_orderstatus", "public_orders"."o_shippriority" AS "o_shippriority", "public_orders"."o_totalprice" AS "o_totalprice" FROM (SELECT "o_clerk" AS "o_clerk", "o_comment" AS "o_comment", "o_custkey" AS "o_custkey", "o_orderdate" AS "o_orderdate", "o_orderkey" AS "o_orderkey", "o_orderpriority" AS "o_orderpriority", "o_orderstatus" AS "o_orderstatus", "o_shippriority" AS "o_shippriority", "o_totalprice" AS "o_totalprice" FROM (SELECT * FROM "public"."orders") AS "public_orders") AS "public_orders") AS "public_orders") SELECT * FROM public_orders`

After specifying pg database, the query works fine.
<img width="625" alt="image" src="https://github.com/Canner/wren-engine/assets/38731840/94b4e830-0c85-4370-9950-39d66ff353d5">
