### PR TITLE
Add GroupByKey without index literal in DecisionPointAnalyzer Result

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
@@ -147,7 +147,9 @@ public class DecisionPointAnalyzer
                         QueryAnalysis.ColumnAnalysis field = context.builder.getSelectItems().get((int) ((LongLiteral) expression).getValue() - 1);
                         keys.add(field.getAliasName().orElse(field.getExpression()));
                     }
-                    keys.add(formatExpression(expression, SqlFormatter.Dialect.DEFAULT));
+                    else {
+                        keys.add(formatExpression(expression, SqlFormatter.Dialect.DEFAULT));
+                    }
                 }
                 groups.add(keys.build());
             }

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
@@ -416,12 +416,16 @@ public class TestDecisionPointAnalyzer
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().size()).isEqualTo(1);
+        assertThat(result.get(0).getGroupByKeys().get(0).size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo("c.custkey");
 
         statement = parseSql("SELECT custkey, count(*), name FROM customer GROUP BY 1, 3, nationkey");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().size()).isEqualTo(3);
+        assertThat(result.get(0).getGroupByKeys().get(0).size()).isEqualTo(1);
+        assertThat(result.get(0).getGroupByKeys().get(1).size()).isEqualTo(1);
+        assertThat(result.get(0).getGroupByKeys().get(2).size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo("custkey");
         assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo("name");
         assertThat(result.get(0).getGroupByKeys().get(2).get(0)).isEqualTo("nationkey");


### PR DESCRIPTION
# Description
Previously, submit the sql:
```
select name, count(*) from customer group by 1
```
We will get
```
{
    "groupByKeys": [1, "name"]
}
```
However, we expected to get only `name`.