### PR TITLE
Fix the macro parameter can't accept a function call string

### DIFF
--- a/wren-base/src/test/java/io/wren/base/dto/TestMacro.java
+++ b/wren-base/src/test/java/io/wren/base/dto/TestMacro.java
@@ -78,6 +78,7 @@ public class TestMacro
                                         Column.column("custkey_callAddOne", WrenTypes.INTEGER, null, true, "{{callAddOne('custkey')}}"),
                                         Column.column("custkey_pass1Macro", WrenTypes.INTEGER, null, true, "{{pass1Macro('custkey', addOne)}}"),
                                         Column.column("custkey_pass2Macro", WrenTypes.INTEGER, null, true, "{{pass2Macro('custkey', addOne, addTwo)}}"),
+                                        Column.column("custkey_sum_addOne", WrenTypes.INTEGER, null, true, "{{addOne('sum(custkey)')}}"),
                                         Column.column("name", WrenTypes.VARCHAR, null, true)),
                                 "pk")))
                 .setMacros(List.of(
@@ -96,6 +97,7 @@ public class TestMacro
         assertThat(modelOptional.get().getColumns().get(3).getExpression().get()).isEqualTo("custkey + 1");
         assertThat(modelOptional.get().getColumns().get(4).getExpression().get()).isEqualTo("custkey + 1");
         assertThat(modelOptional.get().getColumns().get(5).getExpression().get()).isEqualTo("custkey + 1 + custkey + 2");
+        assertThat(modelOptional.get().getColumns().get(6).getExpression().get()).isEqualTo("sum(custkey) + 1");
     }
 
     @Test

--- a/wren-base/src/test/java/io/wren/base/jinjava/TestJinjavaExpressionProcessor.java
+++ b/wren-base/src/test/java/io/wren/base/jinjava/TestJinjavaExpressionProcessor.java
@@ -32,8 +32,8 @@ public class TestJinjavaExpressionProcessor
             Macro.macro("addTwo", "(a: Expression) => {{ a }} + 2"),
             Macro.macro("callAddOne", "(a: Expression) => {{ addOne(a) }} + 3"),
             Macro.macro("passMacro", "(a: Expression, f: Macro) => {{ f(a) }} + 4"),
-            Macro.macro("pass2Macro", "(a: Expression, f1: Macro, f2: Macro) => {{ f1(a) + f2(a) }} + 5"),
-            Macro.macro("pass3Macro", "(a: Expression, b: Expression, f1: Macro, f2: Macro) => {{ f1(a) + f2(b) }} + 6"),
+            Macro.macro("pass2Macro", "(a: Expression, f1: Macro, f2: Macro) => {{ f1(a) }} + {{ f2(a) }} + 5"),
+            Macro.macro("pass3Macro", "(a: Expression, b: Expression, f1: Macro, f2: Macro) => {{ f1(a) }} + {{ f2(b) }} + 6"),
             Macro.macro("pass4Macro", "(a: Expression, b: Expression, f1: Macro, f2: Macro) => {{ f1(a) }} + {{ f2(b)}}"));
 
     @DataProvider
@@ -41,17 +41,19 @@ public class TestJinjavaExpressionProcessor
     {
         return new Object[][] {
                 {"{{ addOne(1) }}", "{{ addOne(1) }}"},
+                {"{{ addOne('sum(id)') }}", "{{ addOne('sum(id)') }}"},
                 {"{{ callAddOne(1) }}", "{{ callAddOne(1) }}"},
-                {"{{ passMacro(1, addOne) }}", "{{addOne(1)}} + 4"},
-                {"{{ pass2Macro(1, addOne, addTwo) }}", "{{(addOne(1) + addTwo(1))}} + 5"},
-                {"{{ pass3Macro(1, 2, addOne, addTwo) }}", "{{(addOne(1) + addTwo(2))}} + 6"},
-                {"{{ pass4Macro(1, 2, addOne, addTwo) }}", "{{addOne(1)}} + {{addTwo(2)}}"},
+                {"{{ passMacro(1, addOne) }}", "{{ addOne(1) }} + 4"},
+                {"{{ pass2Macro(1, addOne, addTwo) }}", "{{ addOne(1) }} + {{ addTwo(1) }} + 5"},
+                {"{{ pass3Macro(1, 2, addOne, addTwo) }}", "{{ addOne(1) }} + {{ addTwo(2) }} + 6"},
+                {"{{ pass4Macro(1, 2, addOne, addTwo) }}", "{{ addOne(1) }} + {{ addTwo(2) }}"},
                 // TODO: trim the redundant space character
-                {"{{ passMacro(1, addOne) }} + {{ passMacro(2, addTwo) }}", "{{addOne(1)}} + 4  +  {{addTwo(2)}} + 4"},
-                {"{{ passMacro(1, addOne) }} + {{ addOne(1) }}", "{{addOne(1)}} + 4  + {{ addOne(1) }}"},
+                {"{{ passMacro(1, addOne) }} + {{ passMacro(2, addTwo) }}", "{{ addOne(1) }} + 4 + {{ addTwo(2) }} + 4"},
+                {"{{ passMacro(1, addOne) }} + {{ addOne(1) }}", "{{ addOne(1) }} + 4 + {{ addOne(1) }}"},
                 {"{{ standardTime() }}", "{{ standardTime() }}"},
                 {"{{ callStandardTime() }}", "{{ callStandardTime() }}"},
-                {"{{ passMacroWithoutParam(standardTime) }}", "{{standardTime()}}"}};
+                {"{{ passMacroWithoutParam(standardTime) }}", "{{ standardTime() }}"},
+        };
         // TODO: unsupported cases: A jinjava expression includes multiple macro calls
         // {"{{ passMacro(1, addOne) + addOne(1) }}", "{{addOne(1)}} + 4 + {{addOne(1)}}"}
         // {"{{ passMacro(1, addOne) + passMacro(2, addTwo) }}", "{{addOne(1)}} + 4 + {{addTwo(2)}} + 4"}


### PR DESCRIPTION
# Description
- Fix the issue about macro can't accept a function call. Defining a column with an expression below will be failed.
```
{{ MoM('sum(order_items.Price)') }}
```
Some spec is changed. Currently, a Jinjava expression only accept `Identifier` and `FunctionCall`. 
Some acceptable cases:
- `{{ para_1 }}`
- `{{ fn(para_1) }}`
- `{{ fn('col_1') }}`
- `{{ fn('sum(co_1)') }}`

Some unacceptable case:
- `{{ para_1 + para2 }}` should be `{{ para_1 }} + {{ para_2 }}`
- `{{ fn1() + fn2() }}` should be `{{ fn1() }} + {{ fn2() }}`

# Changed
- Used SQL parser to handle the jinjava expression.
- Enhance the error message.