### PR TITLE
Run v1-engine test when labeled `v1-engine-changed` only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - main
   pull_request:
+    types: [ labeled ]
     branches:
       - '**'
 
 jobs:
   build:
+    if: ${{ github.event.label.name }} == 'v1-engine-changed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [ labeled ]
   repository_dispatch:
     types: [ test-with-secrets-command ]
 
@@ -13,7 +14,10 @@ jobs:
   # Branch-based in origin repo pull request
   integration-trusted:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ${{ github.event.label.name }} == 'v1-engine-changed'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 21


### PR DESCRIPTION
# Description
We're going to redesign wren engine. The tests of Engine V1 (implemented by pure java) will only be triggered by the PR labeled `v1-engine-changed`.