### PR TITLE
Adjust with fastapi cli

### DIFF
--- a/ibis-server/Makefile
+++ b/ibis-server/Makefile
@@ -1,11 +1,11 @@
 install:
 	poetry install
 
-start:
-	poetry run start
+run:
+	poetry run fastapi run
 
 dev:
-	poetry run start --dev
+	poetry run fastapi dev
 
 test:
 	poetry run pytest

--- a/ibis-server/README.md
+++ b/ibis-server/README.md
@@ -7,6 +7,6 @@
 - Execute `make test` to run the tests
 
 ## Start the server
-- Execute `make start` to start the server
+- Execute `make run` to start the server
 - Execute `make dev` to start the server in development mode. It will auto-reload after the code is edited.
 - Default port is `8000`, you can change it by setting the environment variable `IBIS_PORT`

--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -1,5 +1,3 @@
-import os
-
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse, RedirectResponse
 
@@ -25,10 +23,3 @@ async def exception_handler(request, exc: Exception):
         status_code=500,
         content=str(exc),
     )
-
-
-def start():
-    import sys
-    reload = True if '--dev' in sys.argv else False
-    import uvicorn
-    uvicorn.run("app.main:app", host='0.0.0.0', port=int(os.getenv('IBIS_PORT', 8000)), reload=reload)

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -18,9 +18,6 @@ httpx = "0.27.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "8.2.0"
 
-[tool.poetry.scripts]
-start = "app.main:start"
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Because fastapi release [0.111.0](https://github.com/tiangolo/fastapi/releases/tag/0.111.0) include the [FastAPI CLI](https://fastapi.tiangolo.com/fastapi-cli/). We can use the CLI to start the fastapi service.