### PR TITLE
Analyze the source dataset of the expression in the join criteria in the decision point API

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/Utils.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/Utils.java
@@ -317,6 +317,7 @@ public final class Utils
                 .columnName(column.getName())
                 .name(column.getName())
                 .relationAlias(relation.getAlias().map(QualifiedName::of).orElse(null))
+                .sourceModelName(modelName)
                 .build();
     }
 

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
@@ -32,18 +32,21 @@ public class Field
     private final Optional<QualifiedName> relationAlias;
     private final CatalogSchemaTableName tableName;
     private final String columnName;
+    private final Optional<String> sourceDatasetName;
     private final Optional<String> name;
 
     private Field(
             QualifiedName relationAlias,
             CatalogSchemaTableName tableName,
             String columnName,
-            String name)
+            String name,
+            String sourceDatasetName)
     {
         this.relationAlias = Optional.ofNullable(relationAlias);
         this.tableName = requireNonNull(tableName, "modelName is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.name = Optional.ofNullable(name);
+        this.sourceDatasetName = Optional.ofNullable(sourceDatasetName);
     }
 
     public Optional<QualifiedName> getRelationAlias()
@@ -64,6 +67,11 @@ public class Field
     public Optional<String> getName()
     {
         return name;
+    }
+
+    public Optional<String> getSourceDatasetName()
+    {
+        return sourceDatasetName;
     }
 
     public boolean matchesPrefix(Optional<QualifiedName> prefix)
@@ -110,6 +118,7 @@ public class Field
                 ", tableName=" + tableName +
                 ", columnName='" + columnName + '\'' +
                 ", name=" + name +
+                ", sourceDatasetName=" + sourceDatasetName +
                 '}';
     }
 
@@ -124,6 +133,7 @@ public class Field
         private CatalogSchemaTableName tableName;
         private String columnName;
         private String name;
+        private String sourceModelName;
 
         public Builder() {}
 
@@ -133,6 +143,7 @@ public class Field
             this.tableName = field.tableName;
             this.columnName = field.columnName;
             this.name = field.name.orElse(null);
+            this.sourceModelName = field.sourceDatasetName.orElse(null);
             return this;
         }
 
@@ -160,9 +171,15 @@ public class Field
             return this;
         }
 
+        public Builder sourceModelName(String sourceModelName)
+        {
+            this.sourceModelName = sourceModelName;
+            return this;
+        }
+
         public Field build()
         {
-            return new Field(relationAlias, tableName, columnName, name);
+            return new Field(relationAlias, tableName, columnName, name, sourceModelName);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -254,21 +254,23 @@ public final class StatementAnalyzer
                                 .or(() -> Optional.ofNullable(QueryUtil.getQualifiedName(singleColumn.getExpression())).map(QualifiedName::toString))
                                 .orElse(singleColumn.getExpression().toString());
                         if (scope.isPresent()) {
-                            scope.get().getRelationType().resolveAnyField(QueryUtil.getQualifiedName(singleColumn.getExpression()))
-                                    .ifPresent(f -> fields.add(Field.builder()
-                                            .columnName(name)
-                                            .name(name)
-                                            .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
-                                            .sourceModelName(f.getSourceDatasetName().orElse(null))
-                                            .build()));
+                            Optional<Field> fieldOptional = scope.get().getRelationType().resolveAnyField(QueryUtil.getQualifiedName(singleColumn.getExpression()));
+                            if (fieldOptional.isPresent()) {
+                                Field f = fieldOptional.get();
+                                fields.add(Field.builder()
+                                        .columnName(name)
+                                        .name(name)
+                                        .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
+                                        .sourceModelName(f.getSourceDatasetName().orElse(null))
+                                        .build());
+                                continue;
+                            }
                         }
-                        else {
-                            fields.add(Field.builder()
-                                    .columnName(name)
-                                    .name(name)
-                                    .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
-                                    .build());
-                        }
+                        fields.add(Field.builder()
+                                .columnName(name)
+                                .name(name)
+                                .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
+                                .build());
                     }
                 }
             }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
@@ -28,12 +28,13 @@ import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.QuerySpecification;
 import io.trino.sql.tree.SingleColumn;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.TableSubquery;
+import io.trino.sql.tree.With;
 import io.wren.base.CatalogSchemaTableName;
 import io.wren.base.SessionContext;
 import io.wren.base.WrenMDL;
 import io.wren.base.sqlrewrite.analyzer.Analysis;
 import io.wren.base.sqlrewrite.analyzer.Field;
-import io.wren.base.sqlrewrite.analyzer.Scope;
 import io.wren.base.sqlrewrite.analyzer.StatementAnalyzer;
 
 import java.util.ArrayList;
@@ -43,6 +44,8 @@ import java.util.Optional;
 import static io.trino.sql.ExpressionFormatter.formatExpression;
 import static io.wren.base.sqlrewrite.Utils.toCatalogSchemaTableName;
 import static io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionExpressionAnalyzer.DEFAULT_ANALYSIS;
+import static io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionPointContext.isSubqueryOrCte;
+import static io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionPointContext.withSubqueryOrCte;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -60,7 +63,7 @@ public class DecisionPointAnalyzer
     }
 
     static class Visitor
-            extends DefaultTraversalVisitor<Context>
+            extends DefaultTraversalVisitor<DecisionPointContext>
     {
         private final Analysis analysis;
         private final SessionContext sessionContext;
@@ -75,52 +78,65 @@ public class DecisionPointAnalyzer
         }
 
         @Override
-        protected Void visitQuerySpecification(QuerySpecification node, Context ignored)
+        protected Void visitWith(With node, DecisionPointContext decisionPointContext)
+        {
+            return super.visitWith(node, withSubqueryOrCte(decisionPointContext, true));
+        }
+
+        @Override
+        protected Void visitTableSubquery(TableSubquery node, DecisionPointContext decisionPointContext)
+        {
+            return super.visitTableSubquery(node, withSubqueryOrCte(decisionPointContext, true));
+        }
+
+        @Override
+        protected Void visitQuerySpecification(QuerySpecification node, DecisionPointContext decisionPointContext)
         {
             QueryAnalysis.Builder builder = QueryAnalysis.builder();
-            Context context = new Context(builder, analysis.getScope(node));
-            process(node.getSelect(), context);
+            DecisionPointContext selfDecisionPointContext = new DecisionPointContext(builder, analysis.getScope(node), isSubqueryOrCte(decisionPointContext));
+            process(node.getSelect(), selfDecisionPointContext);
             node.getFrom().ifPresent(from -> builder.setRelation(RelationAnalyzer.analyze(from, sessionContext, mdl, analysis)));
             node.getWhere().ifPresent(where -> builder.setFilter(FilterAnalyzer.analyze(where)));
 
             if (node.getGroupBy().isPresent()) {
-                process(node.getGroupBy().get(), context);
+                process(node.getGroupBy().get(), selfDecisionPointContext);
             }
 
             if (node.getOrderBy().isPresent()) {
-                process(node.getOrderBy().get(), context);
+                process(node.getOrderBy().get(), selfDecisionPointContext);
             }
+            builder.setSubqueryOrCte(isSubqueryOrCte(decisionPointContext));
             queries.add(builder.build());
             return null;
         }
 
         @Override
-        protected Void visitAllColumns(AllColumns node, Context context)
+        protected Void visitAllColumns(AllColumns node, DecisionPointContext decisionPointContext)
         {
-            List<Field> scopedFields = context.scope.getRelationType().getFields();
+            List<Field> scopedFields = decisionPointContext.getScope().getRelationType().getFields();
             if (node.getTarget().isPresent()) {
                 String target = formatExpression(node.getTarget().get(), SqlFormatter.Dialect.DEFAULT);
                 CatalogSchemaTableName catalogSchemaTableName = toCatalogSchemaTableName(sessionContext, QualifiedName.of(List.of(target.split("\\."))));
                 if (scopedFields.isEmpty()) {
                     // relation scope can't be analyzed, so we can't determine the fields. It may be a remote table.
-                    context.builder.addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), format("%s.*", target), DEFAULT_ANALYSIS.toMap()));
+                    decisionPointContext.getBuilder().addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), format("%s.*", target), DEFAULT_ANALYSIS.toMap()));
                 }
                 else {
                     scopedFields.stream()
                             .filter(field -> field.getRelationAlias().filter(alias -> alias.toString().equals(target)).isPresent() || field.getTableName().equals(catalogSchemaTableName))
                             .forEach(field -> {
-                                context.builder.addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), field.getName().orElse(field.getColumnName()), DEFAULT_ANALYSIS.toMap()));
+                                decisionPointContext.getBuilder().addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), field.getName().orElse(field.getColumnName()), DEFAULT_ANALYSIS.toMap()));
                             });
                 }
             }
             else {
                 if (scopedFields.isEmpty()) {
                     // relation scope can't be analyzed, so we can't determine the fields. It may be a remote table.
-                    context.builder.addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), "*", DEFAULT_ANALYSIS.toMap()));
+                    decisionPointContext.getBuilder().addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), "*", DEFAULT_ANALYSIS.toMap()));
                 }
                 else {
                     scopedFields.forEach(field -> {
-                        context.builder.addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), field.getName().orElse(field.getColumnName()), DEFAULT_ANALYSIS.toMap()));
+                        decisionPointContext.getBuilder().addSelectItem(new QueryAnalysis.ColumnAnalysis(Optional.empty(), field.getName().orElse(field.getColumnName()), DEFAULT_ANALYSIS.toMap()));
                     });
                 }
             }
@@ -128,23 +144,23 @@ public class DecisionPointAnalyzer
         }
 
         @Override
-        protected Void visitSingleColumn(SingleColumn node, Context context)
+        protected Void visitSingleColumn(SingleColumn node, DecisionPointContext decisionPointContext)
         {
             DecisionExpressionAnalyzer.DecisionExpressionAnalysis expressionAnalysis = DecisionExpressionAnalyzer.analyze(node.getExpression());
             String expression = formatExpression(node.getExpression(), SqlFormatter.Dialect.DEFAULT);
-            context.builder.addSelectItem(new QueryAnalysis.ColumnAnalysis(node.getAlias().map(Identifier::getValue), expression, expressionAnalysis.toMap()));
+            decisionPointContext.getBuilder().addSelectItem(new QueryAnalysis.ColumnAnalysis(node.getAlias().map(Identifier::getValue), expression, expressionAnalysis.toMap()));
             return null;
         }
 
         @Override
-        protected Void visitGroupBy(GroupBy node, Context context)
+        protected Void visitGroupBy(GroupBy node, DecisionPointContext decisionPointContext)
         {
             ImmutableList.Builder<List<String>> groups = ImmutableList.builder();
             for (GroupingElement groupingElement : node.getGroupingElements()) {
                 ImmutableList.Builder<String> keys = ImmutableList.builder();
                 for (Expression expression : groupingElement.getExpressions()) {
                     if (expression instanceof LongLiteral) {
-                        QueryAnalysis.ColumnAnalysis field = context.builder.getSelectItems().get((int) ((LongLiteral) expression).getValue() - 1);
+                        QueryAnalysis.ColumnAnalysis field = decisionPointContext.getBuilder().getSelectItems().get((int) ((LongLiteral) expression).getValue() - 1);
                         keys.add(field.getAliasName().orElse(field.getExpression()));
                     }
                     else {
@@ -153,17 +169,17 @@ public class DecisionPointAnalyzer
                 }
                 groups.add(keys.build());
             }
-            context.builder.setGroupByKeys(groups.build());
+            decisionPointContext.getBuilder().setGroupByKeys(groups.build());
             return null;
         }
 
         @Override
-        protected Void visitOrderBy(OrderBy node, Context context)
+        protected Void visitOrderBy(OrderBy node, DecisionPointContext decisionPointContext)
         {
-            context.builder.setSortings(
+            decisionPointContext.getBuilder().setSortings(
                     node.getSortItems().stream().map(sortItem -> {
                         if (sortItem.getSortKey() instanceof LongLiteral) {
-                            QueryAnalysis.ColumnAnalysis field = context.builder.getSelectItems().get((int) ((LongLiteral) sortItem.getSortKey()).getValue() - 1);
+                            QueryAnalysis.ColumnAnalysis field = decisionPointContext.getBuilder().getSelectItems().get((int) ((LongLiteral) sortItem.getSortKey()).getValue() - 1);
                             return new QueryAnalysis.SortItemAnalysis(field.getAliasName().orElse(field.getExpression()), sortItem.getOrdering());
                         }
                         return new QueryAnalysis.SortItemAnalysis(formatExpression(sortItem.getSortKey(), SqlFormatter.Dialect.DEFAULT), sortItem.getOrdering());
@@ -171,6 +187,4 @@ public class DecisionPointAnalyzer
             return null;
         }
     }
-
-    record Context(QueryAnalysis.Builder builder, Scope scope) {}
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
@@ -80,7 +80,7 @@ public class DecisionPointAnalyzer
             QueryAnalysis.Builder builder = QueryAnalysis.builder();
             Context context = new Context(builder, analysis.getScope(node));
             process(node.getSelect(), context);
-            node.getFrom().ifPresent(from -> builder.setRelation(RelationAnalyzer.analyze(from, sessionContext, mdl)));
+            node.getFrom().ifPresent(from -> builder.setRelation(RelationAnalyzer.analyze(from, sessionContext, mdl, analysis)));
             node.getWhere().ifPresent(where -> builder.setFilter(FilterAnalyzer.analyze(where)));
 
             if (node.getGroupBy().isPresent()) {

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointContext.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointContext.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.base.sqlrewrite.analyzer.decisionpoint;
+
+import io.wren.base.sqlrewrite.analyzer.Scope;
+
+import java.util.Optional;
+
+public class DecisionPointContext
+{
+    private final QueryAnalysis.Builder builder;
+    private final Scope scope;
+    private final boolean isSubqueryOrCte;
+
+    public static DecisionPointContext withSubqueryOrCte(DecisionPointContext decisionPointContext, boolean isSubqueryOrCte)
+    {
+        return Optional.ofNullable(decisionPointContext)
+                .map(c -> new DecisionPointContext(c.builder, c.scope, isSubqueryOrCte))
+                .orElse(new DecisionPointContext(null, null, isSubqueryOrCte));
+    }
+
+    /**
+     * Because the context could be null, use this method to get the value of isSubqueryOrCte safely.
+     */
+    public static boolean isSubqueryOrCte(DecisionPointContext decisionPointContext)
+    {
+        return Optional.ofNullable(decisionPointContext).map(c -> c.isSubqueryOrCte).orElse(false);
+    }
+
+    public DecisionPointContext(QueryAnalysis.Builder builder, Scope scope, boolean isSubqueryOrCte)
+    {
+        this.builder = builder;
+        this.scope = scope;
+        this.isSubqueryOrCte = isSubqueryOrCte;
+    }
+
+    public QueryAnalysis.Builder getBuilder()
+    {
+        return builder;
+    }
+
+    public Scope getScope()
+    {
+        return scope;
+    }
+}

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/QueryAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/QueryAnalysis.java
@@ -34,19 +34,22 @@ public class QueryAnalysis
     private final FilterAnalysis filter;
     private final List<List<String>> groupByKeys;
     private final List<SortItemAnalysis> sortings;
+    private final boolean isSubqueryOrCte;
 
     public QueryAnalysis(
             List<ColumnAnalysis> selectItems,
             RelationAnalysis relation,
             FilterAnalysis filter,
             List<List<String>> groupByKeys,
-            List<SortItemAnalysis> sortings)
+            List<SortItemAnalysis> sortings,
+            boolean isSubqueryOrCte)
     {
         this.selectItems = selectItems == null ? List.of() : List.copyOf(selectItems);
         this.relation = relation;
         this.filter = filter;
         this.groupByKeys = groupByKeys == null ? List.of() : List.copyOf(groupByKeys);
         this.sortings = sortings == null ? List.of() : List.copyOf(sortings);
+        this.isSubqueryOrCte = isSubqueryOrCte;
     }
 
     public List<ColumnAnalysis> getSelectItems()
@@ -72,6 +75,11 @@ public class QueryAnalysis
     public List<SortItemAnalysis> getSortings()
     {
         return sortings;
+    }
+
+    public boolean isSubqueryOrCte()
+    {
+        return isSubqueryOrCte;
     }
 
     public static class ColumnAnalysis
@@ -133,6 +141,19 @@ public class QueryAnalysis
         private FilterAnalysis filter;
         private List<List<String>> groupByKeys;
         private List<SortItemAnalysis> sortings;
+        private boolean isSubqueryOrCte;
+
+        public static Builder from(QueryAnalysis queryAnalysis)
+        {
+            Builder builder = new Builder();
+            builder.selectItems.addAll(queryAnalysis.selectItems);
+            builder.relation = queryAnalysis.relation;
+            builder.filter = queryAnalysis.filter;
+            builder.groupByKeys = queryAnalysis.groupByKeys;
+            builder.sortings = queryAnalysis.sortings;
+            builder.isSubqueryOrCte = queryAnalysis.isSubqueryOrCte;
+            return builder;
+        }
 
         public Builder addSelectItem(ColumnAnalysis selectItem)
         {
@@ -164,6 +185,12 @@ public class QueryAnalysis
             return this;
         }
 
+        public Builder setSubqueryOrCte(boolean subqueryOrCte)
+        {
+            isSubqueryOrCte = subqueryOrCte;
+            return this;
+        }
+
         public List<ColumnAnalysis> getSelectItems()
         {
             return selectItems;
@@ -171,7 +198,7 @@ public class QueryAnalysis
 
         public QueryAnalysis build()
         {
-            return new QueryAnalysis(selectItems, relation, filter, groupByKeys, sortings);
+            return new QueryAnalysis(selectItems, relation, filter, groupByKeys, sortings, isSubqueryOrCte);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
@@ -15,16 +15,17 @@
 package io.wren.base.sqlrewrite.analyzer.decisionpoint;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.wren.base.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public abstract class RelationAnalysis
 {
-    static JoinRelation join(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria)
+    static JoinRelation join(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria, List<ExprSource> exprSources)
     {
         checkArgument(type != Type.TABLE && type != Type.SUBQUERY, "type should be a join type");
-        return new JoinRelation(type, alias, left, right, criteria);
+        return new JoinRelation(type, alias, left, right, criteria, exprSources);
     }
 
     static TableRelation table(String tableName, String alias)
@@ -74,13 +75,15 @@ public abstract class RelationAnalysis
         private final RelationAnalysis left;
         private final RelationAnalysis right;
         private final String criteria;
+        private final List<ExprSource> exprSources;
 
-        public JoinRelation(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria)
+        public JoinRelation(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria, List<ExprSource> exprSources)
         {
             super(type, alias);
             this.left = requireNonNull(left, "left is null");
             this.right = requireNonNull(right, "right is null");
             this.criteria = criteria;
+            this.exprSources = exprSources == null ? List.of() : exprSources;
         }
 
         public RelationAnalysis getLeft()
@@ -96,6 +99,11 @@ public abstract class RelationAnalysis
         public String getCriteria()
         {
             return criteria;
+        }
+
+        public List<ExprSource> getExprSources()
+        {
+            return exprSources;
         }
     }
 
@@ -130,6 +138,30 @@ public abstract class RelationAnalysis
         public List<QueryAnalysis> getBody()
         {
             return body;
+        }
+    }
+
+    public record ExprSource(String expression, String sourceDataset)
+    {
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ExprSource that = (ExprSource) o;
+            return Objects.equals(expression, that.expression) && Objects.equals(sourceDataset, that.sourceDataset);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression, sourceDataset);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -107,7 +107,9 @@ public class RelationAnalyzer
         @Override
         protected RelationAnalysis visitTableSubquery(TableSubquery node, Void context)
         {
-            List<QueryAnalysis> analyses = DecisionPointAnalyzer.analyze(node.getQuery(), sessionContext, wrenMDL);
+            List<QueryAnalysis> analyses = DecisionPointAnalyzer.analyze(node.getQuery(), sessionContext, wrenMDL)
+                    .stream().map(analysis -> QueryAnalysis.Builder.from(analysis).setSubqueryOrCte(true).build())
+                    .toList();
             return new RelationAnalysis.SubqueryRelation(null, analyses);
         }
 

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -239,7 +239,8 @@ public class RelationAnalyzer
         protected Void visitIdentifier(Identifier node, Void context)
         {
             scope.getRelationType().resolveFields(QualifiedName.of(node.getValue()))
-                    .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(node.getValue(), field.getTableName().getSchemaTableName().getTableName())));
+                    .stream().filter(field -> field.getSourceDatasetName().isPresent())
+                    .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(node.getValue(), field.getSourceDatasetName().get())));
             return null;
         }
 
@@ -248,7 +249,8 @@ public class RelationAnalyzer
         {
             Optional.ofNullable(getQualifiedName(node)).ifPresent(qualifiedName ->
                     scope.getRelationType().resolveFields(qualifiedName)
-                            .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(qualifiedName.toString(), field.getTableName().getSchemaTableName().getTableName()))));
+                            .stream().filter(field -> field.getSourceDatasetName().isPresent())
+                            .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get()))));
             return null;
         }
     }

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestStatementAnalyzer.java
@@ -199,6 +199,14 @@ public class TestStatementAnalyzer
         assertThat(scope.get().getRelationType().getFields()).hasSize(2);
         assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
         assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("max_c2");
+
+        scope = Optional.ofNullable(analyzeSql.apply("""
+                WITH t1 as (SELECT "c1", "c2" FROM (select * from test.test.foo) table_1) select * from t1
+                """));
+        Assertions.assertThat(scope).isPresent();
+        assertThat(scope.get().getRelationType().getFields()).hasSize(2);
+        assertThat(scope.get().getRelationType().getFields().get(0).getName().get()).isEqualTo("c1");
+        assertThat(scope.get().getRelationType().getFields().get(1).getName().get()).isEqualTo("c2");
     }
 
     private static Column varcharColumn(String name)

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -113,7 +113,7 @@ public class AnalysisResource
     {
         return switch (relationAnalysis) {
             case RelationAnalysis.TableRelation tableRelation ->
-                    new RelationAnalysisDto(tableRelation.getType().name(), tableRelation.getAlias(), null, null, null, tableRelation.getTableName(), null);
+                    new RelationAnalysisDto(tableRelation.getType().name(), tableRelation.getAlias(), null, null, null, tableRelation.getTableName(), null, null);
             case RelationAnalysis.JoinRelation joinRelation -> new RelationAnalysisDto(
                     joinRelation.getType().name(),
                     joinRelation.getAlias(),
@@ -121,7 +121,8 @@ public class AnalysisResource
                     toRelationAnalysisDto(joinRelation.getRight()),
                     joinRelation.getCriteria(),
                     null,
-                    null);
+                    null,
+                    joinRelation.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
             case RelationAnalysis.SubqueryRelation subqueryRelation -> new RelationAnalysisDto(
                     subqueryRelation.getType().name(),
                     subqueryRelation.getAlias(),
@@ -129,7 +130,8 @@ public class AnalysisResource
                     null,
                     null,
                     null,
-                    subqueryRelation.getBody().stream().map(AnalysisResource::toQueryAnalysisDto).toList());
+                    subqueryRelation.getBody().stream().map(AnalysisResource::toQueryAnalysisDto).toList(),
+                    null);
             case null -> null;
             default -> throw new IllegalArgumentException("Unsupported relation analysis: " + relationAnalysis);
         };
@@ -138,5 +140,10 @@ public class AnalysisResource
     private static SortItemAnalysisDto toSortItemAnalysisDto(QueryAnalysis.SortItemAnalysis sortItemAnalysis)
     {
         return new SortItemAnalysisDto(sortItemAnalysis.getExpression(), sortItemAnalysis.getOrdering().name());
+    }
+
+    private static QueryAnalysisDto.ExprSourceDto toExprSourceDto(RelationAnalysis.ExprSource exprSource)
+    {
+        return new QueryAnalysisDto.ExprSourceDto(exprSource.expression(), exprSource.sourceDataset());
     }
 }

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -90,7 +90,8 @@ public class AnalysisResource
                 toRelationAnalysisDto(queryAnalysis.getRelation()),
                 toFilterAnalysisDto(queryAnalysis.getFilter()),
                 queryAnalysis.getGroupByKeys(),
-                queryAnalysis.getSortings().stream().map(AnalysisResource::toSortItemAnalysisDto).toList());
+                queryAnalysis.getSortings().stream().map(AnalysisResource::toSortItemAnalysisDto).toList(),
+                queryAnalysis.isSubqueryOrCte());
     }
 
     private static ColumnAnalysisDto toColumnAnalysisDto(QueryAnalysis.ColumnAnalysis columnAnalysis)

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -115,9 +116,18 @@ public class QueryAnalysisDto
         private String criteria;
         private String tableName;
         private List<QueryAnalysisDto> body;
+        private List<ExprSourceDto> exprSources;
 
         @JsonCreator
-        public RelationAnalysisDto(String type, String alias, RelationAnalysisDto left, RelationAnalysisDto right, String criteria, String tableName, List<QueryAnalysisDto> body)
+        public RelationAnalysisDto(
+                String type,
+                String alias,
+                RelationAnalysisDto left,
+                RelationAnalysisDto right,
+                String criteria,
+                String tableName,
+                List<QueryAnalysisDto> body,
+                List<ExprSourceDto> exprSources)
         {
             this.type = type;
             this.alias = alias;
@@ -126,6 +136,7 @@ public class QueryAnalysisDto
             this.criteria = criteria;
             this.tableName = tableName;
             this.body = body;
+            this.exprSources = exprSources;
         }
 
         @JsonProperty
@@ -168,6 +179,12 @@ public class QueryAnalysisDto
         public List<QueryAnalysisDto> getBody()
         {
             return body;
+        }
+
+        @JsonProperty
+        public List<ExprSourceDto> getExprSources()
+        {
+            return exprSources;
         }
     }
 
@@ -236,6 +253,50 @@ public class QueryAnalysisDto
         public String getOrdering()
         {
             return ordering;
+        }
+    }
+
+    public static class ExprSourceDto
+    {
+        private String expression;
+        private String sourceDataset;
+
+        @JsonCreator
+        public ExprSourceDto(String expression, String sourceDataset)
+        {
+            this.expression = expression;
+            this.sourceDataset = sourceDataset;
+        }
+
+        @JsonProperty
+        public String getExpression()
+        {
+            return expression;
+        }
+
+        @JsonProperty
+        public String getSourceDataset()
+        {
+            return sourceDataset;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ExprSourceDto that = (ExprSourceDto) o;
+            return Objects.equals(expression, that.expression) && Objects.equals(sourceDataset, that.sourceDataset);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression, sourceDataset);
         }
     }
 }

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -31,15 +31,23 @@ public class QueryAnalysisDto
     private FilterAnalysisDto filter;
     private List<List<String>> groupByKeys;
     private List<SortItemAnalysisDto> sortings;
+    private boolean isSubqueryOrCte;
 
     @JsonCreator
-    public QueryAnalysisDto(List<ColumnAnalysisDto> selectItems, RelationAnalysisDto relation, FilterAnalysisDto filter, List<List<String>> groupByKeys, List<SortItemAnalysisDto> sortings)
+    public QueryAnalysisDto(
+            List<ColumnAnalysisDto> selectItems,
+            RelationAnalysisDto relation,
+            FilterAnalysisDto filter,
+            List<List<String>> groupByKeys,
+            List<SortItemAnalysisDto> sortings,
+            boolean isSubqueryOrCte)
     {
         this.selectItems = selectItems;
         this.relation = relation;
         this.filter = filter;
         this.groupByKeys = groupByKeys;
         this.sortings = sortings;
+        this.isSubqueryOrCte = isSubqueryOrCte;
     }
 
     @JsonProperty
@@ -70,6 +78,12 @@ public class QueryAnalysisDto
     public List<SortItemAnalysisDto> getSortings()
     {
         return sortings;
+    }
+
+    @JsonProperty("isSubqueryOrCte")
+    public boolean isSubqueryOrCte()
+    {
+        return isSubqueryOrCte;
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import static io.wren.base.dto.Manifest.MANIFEST_JSON_CODEC;
 import static io.wren.base.dto.Model.onTableReference;
@@ -140,6 +141,9 @@ public class TestAnalysisResource
         assertThat(result.get(0).getRelation().getLeft().getType()).isEqualTo(RelationAnalysis.Type.TABLE.name());
         assertThat(result.get(0).getRelation().getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE.name());
         assertThat(result.get(0).getRelation().getCriteria()).isEqualTo("ON (c.custkey = o.custkey)");
+        assertThat(Set.copyOf(result.get(0).getRelation().getExprSources()))
+                .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer"),
+                        new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders")));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(null, "SELECT * FROM customer WHERE custkey = 1 OR (name = 'test' AND address = 'test')"));
         assertThat(result.size()).isEqualTo(1);


### PR DESCRIPTION
# Description
To provide more clear information of the join relation, analysis API provide the source dataset(e.g. model or metric) for all expression used by the join criteria. If an expression doesn't belong any dataset, it won't be added in the list.

# Sample Result
`GET` /v1/analysis/sql
## Input
```json
{
  "manifest": {
    "catalog": "test",
    "schema": "test",
    "models": [
      {
        "name": "Customer",
        "refSql": "select * from tpch.customer",
        "columns": [
          {
            "name": "custkey",
            "type": "integer",
            "expression": "c_orderkey"
          },
          {
            "name": "name",
            "type": "varchar",
            "expression": "c_name"
          }
        ],
        "primaryKey": "custkey"
      },
      {
        "name": "Orders",
        "refSql": "select * from tpch.orders",
        "columns": [
          {
            "name": "orderkey",
            "type": "integer",
            "expression": "o_orderkey"
          },
          {
            "name": "custkey",
            "type": "integer",
            "expression": "o_custkey"
          },
          {
            "name": "totalprice",
            "type": "integer",
            "expression": "o_totalprice"
          },
          {
            "name": "customer",
            "type": "Customer",
            "relationship": "CustomerOrders"
          },
          {
            "name": "customer_name",
            "type": "varchar",
            "isCalculated": true,
            "expression": "customer.name"
          },
          {
            "name": "customer_name_lowercase",
            "type": "varchar",
            "isCalculated": true,
            "expression": "lower(customer.name)"
          }
        ],
        "primaryKey": "orderkey"
      }
    ],
    "relationships": [
      {
        "name": "CustomerOrders",
        "models": ["Customer", "Orders"],
        "joinType": "ONE_TO_MANY",
        "condition": "Customer.custkey = Orders.custkey"
      }
    ]
  },
  "sql": "SELECT c.name, count(*) FROM Customer c JOIN Orders o ON c.custkey = o.custkey JOIN (SELECT 1 custkey, 2 price) out_dataset ON c.custkey = out_dataset.custkey GROUP BY c.name ORDER BY c.name"
}
```

## Output
```json
[
    {
        "groupByKeys": [
            [
                "c.name"
            ]
        ],
        "isSubqueryOrCte": true,
        "relation": {
            "criteria": "ON (c.custkey = out_dataset.custkey)",
            "exprSources": [
                {
                    "expression": "c.custkey",
                    "sourceDataset": "Customer"
                }
            ],
            "left": {
                "criteria": "ON (c.custkey = o.custkey)",
                "exprSources": [
                    {
                        "expression": "c.custkey",
                        "sourceDataset": "Customer"
                    },
                    {
                        "expression": "o.custkey",
                        "sourceDataset": "Orders"
                    }
                ],
                "left": {
                    "alias": "c",
                    "tableName": "Customer",
                    "type": "TABLE"
                },
                "right": {
                    "alias": "o",
                    "tableName": "Orders",
                    "type": "TABLE"
                },
                "type": "INNER_JOIN"
            },
            "right": {
                "alias": "out_dataset",
                "body": [
                    {
                        "groupByKeys": [],
                        "selectItems": [
                            {
                                "alias": "custkey",
                                "expression": "1",
                                "properties": {
                                    "includeFunctionCall": "false",
                                    "includeMathematicalOperation": "false"
                                }
                            },
                            {
                                "alias": "price",
                                "expression": "2",
                                "properties": {
                                    "includeFunctionCall": "false",
                                    "includeMathematicalOperation": "false"
                                }
                            }
                        ],
                        "sortings": []
                    }
                ],
                "type": "SUBQUERY"
            },
            "type": "INNER_JOIN"
        },
        "selectItems": [
            {
                "alias": null,
                "expression": "c.name",
                "properties": {
                    "includeFunctionCall": "false",
                    "includeMathematicalOperation": "false"
                }
            },
            {
                "alias": null,
                "expression": "count(*)",
                "properties": {
                    "includeFunctionCall": "true",
                    "includeMathematicalOperation": "false"
                }
            }
        ],
        "sortings": [
            {
                "expression": "c.name",
                "ordering": "ASCENDING"
            }
        ]
    }
]
```

