### PR TITLE
Fix v1-engine-changed label event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ edited, labeled ]
+    types: [ synchronize, edited, labeled ]
     branches:
       - '**'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,13 @@ on:
     branches:
       - main
   pull_request:
-    types: [ labeled ]
+    types: [ synchronize, labeled ]
     branches:
       - '**'
 
 jobs:
   build:
-    if: ${{ github.event.label.name }} == 'v1-engine-changed'
+    if: github.event.label.name == 'v1-engine-changed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ synchronize, labeled ]
+    types: [ edited, labeled ]
     branches:
       - '**'
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ edited, labeled ]
+    types: [ synchronize, edited, labeled ]
   repository_dispatch:
     types: [ test-with-secrets-command ]
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ synchronize, labeled ]
+    types: [ edited, labeled ]
   repository_dispatch:
     types: [ test-with-secrets-command ]
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ labeled ]
+    types: [ synchronize, labeled ]
   repository_dispatch:
     types: [ test-with-secrets-command ]
 
@@ -17,7 +17,7 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      ${{ github.event.label.name }} == 'v1-engine-changed'
+      github.event.label.name == 'v1-engine-changed'
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 21


### PR DESCRIPTION
The workflow `build.yml` was not triggered at PR updated.

The workflow `integration-tests.yml` was triggered no matter what label name because the syntax was wrong.