### PR TITLE
Add logger

### DIFF
--- a/ibis-server/app/config.py
+++ b/ibis-server/app/config.py
@@ -8,6 +8,7 @@ class Config:
         load_dotenv(override=True)
         self.wren_engine_endpoint = os.getenv('WREN_ENGINE_ENDPOINT')
         self.validate_wren_engine_endpoint(self.wren_engine_endpoint)
+        self.log_level = os.getenv('LOG_LEVEL', 'INFO')
 
     @staticmethod
     def validate_wren_engine_endpoint(endpoint):

--- a/ibis-server/app/logger.py
+++ b/ibis-server/app/logger.py
@@ -1,0 +1,9 @@
+import logging
+
+from app.config import get_config
+
+logging.basicConfig(level=get_config().log_level)
+
+
+def get_logger(name):
+    return logging.getLogger(name)

--- a/ibis-server/app/routers/ibis.py
+++ b/ibis-server/app/routers/ibis.py
@@ -1,13 +1,13 @@
-import logging
 from json import loads
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
+from app.logger import get_logger
 from app.mdl.rewriter import Rewriter
 from app.model.data_source import DataSource
 from app.model.dto import IbisDTO
 
-logger = logging.getLogger()
+logger = get_logger(__name__)
 router = APIRouter(prefix="/v2/ibis")
 
 
@@ -19,7 +19,7 @@ def to_json(df) -> dict:
 
 
 @router.post("/{data_source}/query")
-def query(data_source: DataSource, dto: IbisDTO) -> dict:
-    logger.debug(f'DTO: {dto}')
+def query(data_source: DataSource, dto: IbisDTO, request: Request) -> dict:
+    logger.debug(f'{request.method} {request.url.path}, DTO: {dto}')
     rewritten_sql = Rewriter.rewrite(dto.manifest_str, dto.sql)
     return to_json(data_source.get_connection(dto.connection_info).sql(rewritten_sql, dialect='trino').to_pandas())


### PR DESCRIPTION
I added a `logger.py` to wrap the `logging` for basic config like log level could be one side.

Before we import logging then use `getLogger(name)`, we should from `app.logger` import `get_logger` instead of it.