### PR TITLE
Fix the table qualified name and executable plan for DataFusion

### DIFF
--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -21,4 +21,4 @@ petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1.80"
-log = {workspace = true}
+log = { workspace = true }

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -13,10 +13,11 @@ name = "wren_core"
 path = "src/lib.rs"
 
 [dependencies]
-arrow-schema = { workspace = true }
 datafusion = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+arrow-schema = { workspace = true }
 petgraph = "0.6.5"
 petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+async-trait = "0.1.80"

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -21,3 +21,4 @@ petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1.80"
+log = {workspace = true}

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -13,12 +13,12 @@ name = "wren_core"
 path = "src/lib.rs"
 
 [dependencies]
-datafusion = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 arrow-schema = { workspace = true }
+async-trait = "0.1.80"
+datafusion = { workspace = true }
+log = { workspace = true }
 petgraph = "0.6.5"
 petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
-async-trait = "0.1.80"
-log = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -25,8 +25,10 @@ impl WrenContextProvider {
     pub fn new(mdl: &WrenMDL) -> Self {
         let mut tables = HashMap::new();
         mdl.manifest.models.iter().for_each(|model| {
-            let name = model.name.clone();
-            tables.insert(name.clone(), create_table_source(model));
+            tables.insert(
+                format!("{}.{}.{}", mdl.catalog(), mdl.schema(), model.name()),
+                create_table_source(model),
+            );
         });
         Self {
             tables,
@@ -37,9 +39,10 @@ impl WrenContextProvider {
 
 impl ContextProvider for WrenContextProvider {
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
-        match self.tables.get(name.table()) {
+        let table_name = name.to_string();
+        match self.tables.get(&table_name) {
             Some(table) => Ok(table.clone()),
-            _ => plan_err!("Table not found: {}", name.table()),
+            _ => plan_err!("Table not found: {}", &table_name),
         }
     }
 

--- a/wren-modeling-rs/core/src/logical_plan/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/rule.rs
@@ -1,17 +1,17 @@
+use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialEq};
 use std::collections::{BTreeSet, HashSet};
-use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 
 use arrow_schema::Field;
+use datafusion::common::{DFSchema, DFSchemaRef, Result};
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion::common::{DFSchema, DFSchemaRef, Result};
-use datafusion::logical_expr::logical_plan::tree_node::unwrap_arc;
 use datafusion::logical_expr::{
-    col, Expr, Join, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
+    col, Expr, Join, LogicalPlan, LogicalPlanBuilder, TableScan, UserDefinedLogicalNodeCore,
 };
-use datafusion::logical_expr::{utils, Extension};
+use datafusion::logical_expr::{Extension, utils};
+use datafusion::logical_expr::logical_plan::tree_node::unwrap_arc;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use datafusion::prelude::Column;
 use datafusion::sql::TableReference;
@@ -19,12 +19,12 @@ use petgraph::Graph;
 
 use crate::logical_plan::rule::RelationChain::Nil;
 use crate::mdl;
+use crate::mdl::{AnalyzedWrenMDL, Dataset, WrenMDL};
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::{JoinType, Model};
 use crate::mdl::utils::{create_remote_expr_for_model, is_dag};
-use crate::mdl::{AnalyzedWrenMDL, Dataset};
 
-use super::utils::{create_remote_table_source, format_qualified_name, map_data_type};
+use super::utils::{create_remote_table_source, from_qualified_name, map_data_type};
 
 /// Recognized the model. Turn TableScan from a model to a ModelPlanNode.
 /// We collect the required fields from the projection, filter, aggregation, and join,
@@ -77,11 +77,14 @@ impl ModelAnalyzeRule {
                 Ok(Transformed::no(LogicalPlan::Aggregate(aggregate)))
             }
             LogicalPlan::TableScan(table_scan) => {
-                if let Some(model) = self
-                    .analyzed_wren_mdl
-                    .wren_mdl
-                    .get_model(table_scan.table_name.to_string().as_str())
-                {
+                if belong_to_mdl(
+                    &self.analyzed_wren_mdl.wren_mdl,
+                    table_scan.table_name.clone(),
+                ) {
+                    return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
+                }
+                let table_name = table_scan.table_name.table();
+                if let Some(model) = self.analyzed_wren_mdl.wren_mdl.get_model(table_name) {
                     let model = LogicalPlan::Extension(Extension {
                         node: Arc::new(ModelPlanNode::new(
                             model,
@@ -111,46 +114,20 @@ impl ModelAnalyzeRule {
                 });
 
                 let left = match unwrap_arc(join.left) {
-                    LogicalPlan::TableScan(table_scan) => {
-                        if let Some(model) = self
-                            .analyzed_wren_mdl
-                            .wren_mdl
-                            .get_model(table_scan.table_name.to_string().as_str())
-                        {
-                            LogicalPlan::Extension(Extension {
-                                node: Arc::new(ModelPlanNode::new(
-                                    model,
-                                    buffer.iter().cloned().collect(),
-                                    Some(LogicalPlan::TableScan(table_scan.clone())),
-                                    Arc::clone(&self.analyzed_wren_mdl),
-                                )),
-                            })
-                        } else {
-                            LogicalPlan::TableScan(table_scan)
-                        }
-                    }
+                    LogicalPlan::TableScan(table_scan) => analyze_table_scan(
+                        Arc::clone(&self.analyzed_wren_mdl),
+                        table_scan,
+                        buffer.iter().cloned().collect(),
+                    ),
                     ignore => ignore,
                 };
 
                 let right = match unwrap_arc(join.right) {
-                    LogicalPlan::TableScan(table_scan) => {
-                        if let Some(model) = self
-                            .analyzed_wren_mdl
-                            .wren_mdl
-                            .get_model(table_scan.table_name.to_string().as_str())
-                        {
-                            LogicalPlan::Extension(Extension {
-                                node: Arc::new(ModelPlanNode::new(
-                                    model,
-                                    buffer.iter().cloned().collect(),
-                                    Some(LogicalPlan::TableScan(table_scan.clone())),
-                                    Arc::clone(&self.analyzed_wren_mdl),
-                                )),
-                            })
-                        } else {
-                            LogicalPlan::TableScan(table_scan)
-                        }
-                    }
+                    LogicalPlan::TableScan(table_scan) => analyze_table_scan(
+                        Arc::clone(&self.analyzed_wren_mdl),
+                        table_scan,
+                        buffer.iter().cloned().collect(),
+                    ),
                     ignore => ignore,
                 };
                 buffer.clear();
@@ -166,6 +143,40 @@ impl ModelAnalyzeRule {
                 })))
             }
             _ => Ok(Transformed::no(plan)),
+        }
+    }
+}
+
+fn belong_to_mdl(mdl: &WrenMDL, table_reference: TableReference) -> bool {
+    let catalog_mismatch = table_reference
+        .catalog()
+        .map_or(true, |c| c != mdl.catalog());
+
+    let schema_mismatch = table_reference.schema().map_or(true, |s| s != mdl.schema());
+
+    catalog_mismatch || schema_mismatch
+}
+
+fn analyze_table_scan(
+    analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
+    table_scan: TableScan,
+    required_field: Vec<Expr>,
+) -> LogicalPlan {
+    if belong_to_mdl(&analyzed_wren_mdl.wren_mdl, table_scan.table_name.clone()) {
+        LogicalPlan::TableScan(table_scan)
+    } else {
+        let table_name = table_scan.table_name.table();
+        if let Some(model) = analyzed_wren_mdl.wren_mdl.get_model(table_name) {
+            LogicalPlan::Extension(Extension {
+                node: Arc::new(ModelPlanNode::new(
+                    model,
+                    required_field,
+                    Some(LogicalPlan::TableScan(table_scan.clone())),
+                    Arc::clone(&analyzed_wren_mdl),
+                )),
+            })
+        } else {
+            LogicalPlan::TableScan(table_scan)
         }
     }
 }
@@ -202,15 +213,19 @@ impl ModelPlanNode {
     ) -> Self {
         let mut required_exprs_buffer = BTreeSet::new();
         let mut directed_graph: Graph<Dataset, DatasetLink> = Graph::new();
-        let mut model_required_fields: HashMap<String, BTreeSet<Column>> = HashMap::new();
+        let mut model_required_fields: HashMap<TableReference, BTreeSet<Column>> = HashMap::new();
         let fields = model
             .get_physical_columns()
             .iter()
             .filter(|column| {
                 requried_fields.iter().any(|expr| {
                     if let Expr::Column(column_expr) = expr {
-                        column_expr.flat_name()
-                            == format_qualified_name(&model.name, &column.name)
+                        *column_expr
+                            == from_qualified_name(
+                                &analyzed_wren_mdl.wren_mdl,
+                                model.name(),
+                                column.name(),
+                            )
                     } else {
                         false
                     }
@@ -222,18 +237,24 @@ impl ModelPlanNode {
                         let column_rf = analyzed_wren_mdl
                             .wren_mdl
                             .qualified_references
-                            .get(&format_qualified_name(&model.name, &column.name))
+                            .get(&from_qualified_name(
+                                &analyzed_wren_mdl.wren_mdl,
+                                model.name(),
+                                column.name(),
+                            ))
                             .unwrap();
                         let expr = mdl::utils::create_wren_calculated_field_expr(
                             column_rf.clone(),
                             Arc::clone(&analyzed_wren_mdl),
                         );
-                        let expr_plan = expr.alias(column.name.clone());
+                        let expr_plan = expr.alias(column.name());
                         required_exprs_buffer.insert(OrdExpr::new(expr_plan));
                     };
 
-                    let qualified_column = Column::from_qualified_name(
-                        format_qualified_name(&model.name, &column.name),
+                    let qualified_column = from_qualified_name(
+                        &analyzed_wren_mdl.wren_mdl,
+                        model.name(),
+                        column.name(),
                     );
 
                     match analyzed_wren_mdl
@@ -255,14 +276,11 @@ impl ModelPlanNode {
                         .unwrap()
                         .iter()
                         .for_each(|c| {
-                            let relation_name = match &c.relation {
-                                Some(r) => r.to_string(),
-                                None => {
-                                    panic!("Source dataset not found for column {}", c)
-                                }
+                            let Some(relation_ref) = &c.relation else {
+                                panic!("Source dataset not found for {}", c)
                             };
                             model_required_fields
-                                .entry(relation_name)
+                                .entry(relation_ref.clone())
                                 .or_default()
                                 .insert(c.clone());
                         });
@@ -280,9 +298,13 @@ impl ModelPlanNode {
                     required_exprs_buffer.insert(OrdExpr::new(expr_plan));
                 }
                 (
-                    Some(TableReference::bare(model.name.clone())),
+                    Some(TableReference::full(
+                        analyzed_wren_mdl.wren_mdl.catalog(),
+                        analyzed_wren_mdl.wren_mdl.schema(),
+                        model.name(),
+                    )),
                     Arc::new(Field::new(
-                        &column.name,
+                        column.name(),
                         map_data_type(&column.r#type),
                         column.no_null,
                     )),
@@ -291,7 +313,7 @@ impl ModelPlanNode {
             .collect();
 
         if !is_dag(&directed_graph) {
-            panic!("cyclic dependency detected: {}", model.name);
+            panic!("cyclic dependency detected: {}", model.name());
         }
 
         let schema_ref = DFSchemaRef::new(
@@ -306,12 +328,17 @@ impl ModelPlanNode {
             // check if the chain is valid
             match &relation_chain {
                 Nil => {
-                    if link.source.get_name() != model.name {
+                    if link.source.name() != model.name() {
                         panic!("Relation chain should start with source model");
                     }
+                    let model_ref = TableReference::full(
+                        analyzed_wren_mdl.wren_mdl.catalog(),
+                        analyzed_wren_mdl.wren_mdl.schema(),
+                        model.name(),
+                    );
                     let required_filed = model_required_fields
-                        .get(model.name.as_str())
-                        .unwrap()
+                        .get(&model_ref)
+                        .unwrap_or_else(|| panic!("Required fields not found {}", model.name()))
                         .iter()
                         .map(|c| Expr::Column(c.clone()))
                         .collect();
@@ -335,16 +362,21 @@ impl ModelPlanNode {
                     }
                 }
                 RelationChain::Chain(plan, ..) => {
-                    if link.source.get_name() != plan.model_name {
+                    if link.source.name() != plan.model_name {
                         panic!("Relation chain should start with model");
                     }
                 }
             }
 
             if let Dataset::Model(target_model) = &link.target {
+                let table_ref = TableReference::full(
+                    analyzed_wren_mdl.wren_mdl.catalog(),
+                    analyzed_wren_mdl.wren_mdl.schema(),
+                    target_model.name(),
+                );
                 let required_filed = model_required_fields
-                    .get(target_model.name.as_str())
-                    .unwrap()
+                    .get(&table_ref)
+                    .unwrap_or_else(|| panic!("Required fields not found {}", table_ref))
                     .iter()
                     .map(|c| Expr::Column(c.clone()))
                     .collect();

--- a/wren-modeling-rs/core/src/logical_plan/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/rule.rs
@@ -1,17 +1,18 @@
-use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialEq};
 use std::collections::{BTreeSet, HashSet};
+use std::{collections::HashMap, fmt, fmt::Debug, sync::Arc};
 
 use arrow_schema::Field;
-use datafusion::common::{DFSchema, DFSchemaRef, Result};
 use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion::logical_expr::{
-    col, Expr, Join, LogicalPlan, LogicalPlanBuilder, TableScan, UserDefinedLogicalNodeCore,
-};
-use datafusion::logical_expr::{Extension, utils};
+use datafusion::common::{DFSchema, DFSchemaRef, Result};
 use datafusion::logical_expr::logical_plan::tree_node::unwrap_arc;
+use datafusion::logical_expr::{
+    col, Expr, Join, LogicalPlan, LogicalPlanBuilder, TableScan,
+    UserDefinedLogicalNodeCore,
+};
+use datafusion::logical_expr::{utils, Extension};
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use datafusion::prelude::Column;
 use datafusion::sql::TableReference;
@@ -19,10 +20,10 @@ use petgraph::Graph;
 
 use crate::logical_plan::rule::RelationChain::Nil;
 use crate::mdl;
-use crate::mdl::{AnalyzedWrenMDL, Dataset, WrenMDL};
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::{JoinType, Model};
 use crate::mdl::utils::{create_remote_expr_for_model, is_dag};
+use crate::mdl::{AnalyzedWrenMDL, Dataset, WrenMDL};
 
 use super::utils::{create_remote_table_source, from_qualified_name, map_data_type};
 
@@ -84,7 +85,8 @@ impl ModelAnalyzeRule {
                     return Ok(Transformed::no(LogicalPlan::TableScan(table_scan)));
                 }
                 let table_name = table_scan.table_name.table();
-                if let Some(model) = self.analyzed_wren_mdl.wren_mdl.get_model(table_name) {
+                if let Some(model) = self.analyzed_wren_mdl.wren_mdl.get_model(table_name)
+                {
                     let model = LogicalPlan::Extension(Extension {
                         node: Arc::new(ModelPlanNode::new(
                             model,
@@ -213,7 +215,8 @@ impl ModelPlanNode {
     ) -> Self {
         let mut required_exprs_buffer = BTreeSet::new();
         let mut directed_graph: Graph<Dataset, DatasetLink> = Graph::new();
-        let mut model_required_fields: HashMap<TableReference, BTreeSet<Column>> = HashMap::new();
+        let mut model_required_fields: HashMap<TableReference, BTreeSet<Column>> =
+            HashMap::new();
         let fields = model
             .get_physical_columns()
             .iter()
@@ -338,7 +341,9 @@ impl ModelPlanNode {
                     );
                     let required_filed = model_required_fields
                         .get(&model_ref)
-                        .unwrap_or_else(|| panic!("Required fields not found {}", model.name()))
+                        .unwrap_or_else(|| {
+                            panic!("Required fields not found {}", model.name())
+                        })
                         .iter()
                         .map(|c| Expr::Column(c.clone()))
                         .collect();

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -60,7 +60,12 @@ pub fn create_remote_table_source(model: &Model, mdl: &WrenMDL) -> Arc<dyn Table
     }
 }
 
-pub fn format_qualified_name(catalog: &str, schema: &str, dataset: &str, column: &str) -> String {
+pub fn format_qualified_name(
+    catalog: &str,
+    schema: &str,
+    dataset: &str,
+    column: &str,
+) -> String {
     format!("{}.{}.{}.{}", catalog, schema, dataset, column)
 }
 

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -54,6 +54,25 @@ pub fn create_remote_table_source(model: &Model, _: &WrenMDL) -> Arc<dyn TableSo
     Arc::new(LogicalTableSource::new(schema))
 }
 
-pub fn format_qualified_name(model: &str, column: &str) -> String {
-    format!("{}.{}", model, column)
+pub fn format_qualified_name(catalog: &str, schema: &str, dataset: &str, column: &str) -> String {
+    format!("{}.{}.{}.{}", catalog, schema, dataset, column)
+}
+
+pub fn from_qualified_name(
+    wren_mdl: &WrenMDL,
+    dataset: &str,
+    column: &str,
+) -> datafusion::common::Column {
+    from_qualified_name_str(wren_mdl.catalog(), wren_mdl.schema(), dataset, column)
+}
+
+pub fn from_qualified_name_str(
+    catalog: &str,
+    schema: &str,
+    dataset: &str,
+    column: &str,
+) -> datafusion::common::Column {
+    datafusion::common::Column::from_qualified_name(format_qualified_name(
+        catalog, schema, dataset, column,
+    ))
 }

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::{builder::LogicalTableSource, TableSource};
 
 use crate::mdl::{
@@ -35,23 +36,28 @@ pub fn create_schema(columns: Vec<Arc<Column>>) -> SchemaRef {
     SchemaRef::new(Schema::new_with_metadata(fields, HashMap::new()))
 }
 
-pub fn create_remote_table_source(model: &Model, _: &WrenMDL) -> Arc<dyn TableSource> {
-    let fields: Vec<Field> = model
-        .columns
-        .iter()
-        .map(|column| {
-            let column = Arc::clone(column);
-            let name = if let Some(ref expression) = column.expression {
-                expression.clone()
-            } else {
-                column.name.clone()
-            };
-            // We don't know the data type of the remote table, so we just mock a Int32 type here
-            Field::new(name, DataType::Int32, column.no_null)
-        })
-        .collect();
-    let schema = SchemaRef::new(Schema::new_with_metadata(fields, HashMap::new()));
-    Arc::new(LogicalTableSource::new(schema))
+pub fn create_remote_table_source(model: &Model, mdl: &WrenMDL) -> Arc<dyn TableSource> {
+    if let Some(table_provider) = mdl.get_table(&model.table_reference) {
+        Arc::new(DefaultTableSource::new(table_provider))
+    } else {
+        let fields: Vec<Field> = model
+            .columns
+            .iter()
+            .map(|column| {
+                let column = Arc::clone(column);
+                let name = if let Some(ref expression) = column.expression {
+                    expression.clone()
+                } else {
+                    column.name.clone()
+                };
+                // We don't know the data type of the remote table, so we just mock a Int32 type here
+                Field::new(name, DataType::Int32, column.no_null)
+            })
+            .collect();
+
+        let schema = SchemaRef::new(Schema::new_with_metadata(fields, HashMap::new()));
+        Arc::new(LogicalTableSource::new(schema))
+    }
 }
 
 pub fn format_qualified_name(catalog: &str, schema: &str, dataset: &str, column: &str) -> String {

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -9,9 +9,9 @@ use petgraph::Graph;
 use crate::logical_plan::utils::from_qualified_name;
 use crate::mdl::{utils, WrenMDL};
 
-use super::Dataset;
 use super::manifest::{JoinType, Relationship};
 use super::utils::to_expr_queue;
+use super::Dataset;
 
 pub struct Lineage {
     pub source_columns_map: HashMap<Column, HashSet<Column>>,
@@ -44,7 +44,8 @@ impl Lineage {
                         None => return,
                     };
                     let source_columns = utils::collect_identifiers(expr);
-                    let qualified_name = from_qualified_name(mdl, model.name(), column.name());
+                    let qualified_name =
+                        from_qualified_name(mdl, model.name(), column.name());
                     source_columns.iter().for_each(|source_column| {
                         source_columns_map
                             .entry(qualified_name.clone())
@@ -60,7 +61,8 @@ impl Lineage {
                     });
                 // relationship columns are not a physical column
                 } else if column.relationship.is_none() {
-                    let qualified_name = from_qualified_name(mdl, model.name(), column.name());
+                    let qualified_name =
+                        from_qualified_name(mdl, model.name(), column.name());
                     source_columns_map.insert(qualified_name, HashSet::new());
                 }
             });
@@ -95,7 +97,9 @@ impl Lineage {
                 };
 
                 let column_ref = mdl.get_column_reference(column);
-                if !column_ref.column.is_calculated || column_ref.column.relationship.is_some() {
+                if !column_ref.column.is_calculated
+                    || column_ref.column.relationship.is_some()
+                {
                     return;
                 }
 
@@ -125,7 +129,8 @@ impl Lineage {
                                                 .find(|m| m != &current_relation.table())
                                                 .cloned()
                                                 .unwrap();
-                                            if related_model_name != source_column_ref.column.r#type
+                                            if related_model_name
+                                                != source_column_ref.column.r#type
                                             {
                                                 panic!(
                                                     "invalid relationship type: {}",
@@ -140,18 +145,21 @@ impl Lineage {
                                                     required_fields_map
                                                         .entry(column.clone())
                                                         .or_default()
-                                                        .insert(Column::from_qualified_name(
-                                                            format!(
-                                                                "{}.{}.{}",
-                                                                mdl.catalog(),
-                                                                mdl.schema(),
-                                                                ident.flat_name()
+                                                        .insert(
+                                                            Column::from_qualified_name(
+                                                                format!(
+                                                                    "{}.{}.{}",
+                                                                    mdl.catalog(),
+                                                                    mdl.schema(),
+                                                                    ident.flat_name()
+                                                                ),
                                                             ),
-                                                        ));
+                                                        );
                                                 });
 
-                                            let related_model =
-                                                mdl.get_model(&related_model_name).unwrap();
+                                            let related_model = mdl
+                                                .get_model(&related_model_name)
+                                                .unwrap();
 
                                             let right_vertex = *node_index_map
                                                 .entry(Dataset::Model(Arc::clone(
@@ -277,11 +285,11 @@ fn get_dataset_link_revers_if_need(
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
     use std::{
         fs,
         path::{self, PathBuf},
     };
-    use std::collections::HashSet;
 
     use datafusion::common::Column;
     use datafusion::sql::TableReference;

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -77,7 +77,9 @@ impl Lineage {
         source_colums_map
             .iter()
             .for_each(|(column, source_columns)| {
-                let relation = column.clone().relation.unwrap();
+                let Some(relation) = column.clone().relation else {
+                    return;
+                };
                 let mut current_relation = match relation {
                     TableReference::Bare { table } => {
                         TableReference::full(mdl.catalog(), mdl.schema(), table)

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -6,11 +6,12 @@ use datafusion::common::Column;
 use datafusion::sql::TableReference;
 use petgraph::Graph;
 
+use crate::logical_plan::utils::from_qualified_name;
 use crate::mdl::{utils, WrenMDL};
 
+use super::Dataset;
 use super::manifest::{JoinType, Relationship};
 use super::utils::to_expr_queue;
-use super::Dataset;
 
 pub struct Lineage {
     pub source_columns_map: HashMap<Column, HashSet<Column>>,
@@ -43,22 +44,23 @@ impl Lineage {
                         None => return,
                     };
                     let source_columns = utils::collect_identifiers(expr);
-                    let qualified_name = Column::from_qualified_name(format!(
-                        "{}.{}",
-                        model.name, column.name
-                    ));
+                    let qualified_name = from_qualified_name(mdl, model.name(), column.name());
                     source_columns.iter().for_each(|source_column| {
                         source_columns_map
                             .entry(qualified_name.clone())
                             .or_insert(HashSet::new())
-                            .insert(source_column.clone());
+                            .insert(Column::new(
+                                Some(TableReference::full(
+                                    mdl.catalog(),
+                                    mdl.schema(),
+                                    model.name(),
+                                )),
+                                &source_column.name,
+                            ));
                     });
                 // relationship columns are not a physical column
                 } else if column.relationship.is_none() {
-                    let qualified_name = Column::from_qualified_name(format!(
-                        "{}.{}",
-                        model.name, column.name
-                    ));
+                    let qualified_name = from_qualified_name(mdl, model.name(), column.name());
                     source_columns_map.insert(qualified_name, HashSet::new());
                 }
             });
@@ -76,17 +78,22 @@ impl Lineage {
             .iter()
             .for_each(|(column, source_columns)| {
                 let relation = column.clone().relation.unwrap();
-                let mut model_name = if let TableReference::Bare { table } = relation {
-                    table.clone()
-                } else {
-                    panic!("Expected a bare table reference, got {:?}", column.relation);
+                let mut current_relation = match relation {
+                    TableReference::Bare { table } => {
+                        TableReference::full(mdl.catalog(), mdl.schema(), table)
+                    }
+                    TableReference::Partial { schema, table } => {
+                        TableReference::full(mdl.catalog(), schema, table)
+                    }
+                    TableReference::Full {
+                        catalog,
+                        schema,
+                        table,
+                    } => TableReference::full(catalog, schema, table),
                 };
 
-                let column_ref =
-                    mdl.get_column_reference(model_name.as_ref(), &column.name);
-                if !column_ref.column.is_calculated
-                    || column_ref.column.relationship.is_some()
-                {
+                let column_ref = mdl.get_column_reference(column);
+                if !column_ref.column.is_calculated || column_ref.column.relationship.is_some() {
                     return;
                 }
 
@@ -96,8 +103,10 @@ impl Lineage {
                     let mut expr_parts = to_expr_queue(source_column.clone());
                     while !expr_parts.is_empty() {
                         let ident = expr_parts.pop_front().unwrap();
-                        let source_column_ref =
-                            mdl.get_column_reference(&model_name, &ident);
+                        let source_column_ref = mdl.get_column_reference(&Column::new(
+                            Some(current_relation.clone()),
+                            ident.clone(),
+                        ));
                         let left_vertex = *node_index_map
                             .entry(column_ref.dataset.clone())
                             .or_insert_with(|| {
@@ -108,19 +117,13 @@ impl Lineage {
                                 match source_column_ref.column.relationship.clone() {
                                     Some(rs) => {
                                         if let Some(rs_rf) = mdl.get_relationship(&rs) {
-                                            let related_model_name: Arc<str> = rs_rf
+                                            let related_model_name = rs_rf
                                                 .models
                                                 .iter()
-                                                .find(|m| {
-                                                    m.as_str() != model_name.as_ref()
-                                                })
-                                                .map(|m| m.as_str().into())
+                                                .find(|m| m != &current_relation.table())
+                                                .cloned()
                                                 .unwrap();
-                                            if related_model_name.as_ref()
-                                                != source_column_ref
-                                                    .column
-                                                    .r#type
-                                                    .as_str()
+                                            if related_model_name != source_column_ref.column.r#type
                                             {
                                                 panic!(
                                                     "invalid relationship type: {}",
@@ -135,16 +138,18 @@ impl Lineage {
                                                     required_fields_map
                                                         .entry(column.clone())
                                                         .or_default()
-                                                        .insert(
-                                                            Column::from_qualified_name(
-                                                                ident.flat_name(),
+                                                        .insert(Column::from_qualified_name(
+                                                            format!(
+                                                                "{}.{}.{}",
+                                                                mdl.catalog(),
+                                                                mdl.schema(),
+                                                                ident.flat_name()
                                                             ),
-                                                        );
+                                                        ));
                                                 });
 
-                                            let related_model = mdl
-                                                .get_model(related_model_name.as_ref())
-                                                .unwrap();
+                                            let related_model =
+                                                mdl.get_model(&related_model_name).unwrap();
 
                                             let right_vertex = *node_index_map
                                                 .entry(Dataset::Model(Arc::clone(
@@ -169,7 +174,11 @@ impl Lineage {
                                                 ),
                                             );
 
-                                            model_name = related_model_name;
+                                            current_relation = TableReference::full(
+                                                mdl.catalog(),
+                                                mdl.schema(),
+                                                related_model_name,
+                                            );
                                         } else {
                                             panic!(
                                                 "relationship not found: {}",
@@ -184,10 +193,10 @@ impl Lineage {
                                                 source_column
                                             );
                                         }
-                                        let value = Column::from_qualified_name(format!(
-                                            "{}.{}",
-                                            model_name, source_column_ref.column.name
-                                        ));
+                                        let value = Column::new(
+                                            Some(current_relation.clone()),
+                                            source_column_ref.column.name().to_string(),
+                                        );
                                         if source_column_ref.column.is_calculated {
                                             todo!(
                                                 "calculated source column not supported"
@@ -252,7 +261,7 @@ fn get_dataset_link_revers_if_need(
     target: Dataset,
     rs: Arc<Relationship>,
 ) -> DatasetLink {
-    let join_type = if rs.models[0] == source.get_name() {
+    let join_type = if rs.models[0] == source.name() {
         rs.join_type
     } else {
         match rs.join_type {
@@ -266,13 +275,14 @@ fn get_dataset_link_revers_if_need(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
     use std::{
         fs,
         path::{self, PathBuf},
     };
+    use std::collections::HashSet;
 
     use datafusion::common::Column;
+    use datafusion::sql::TableReference;
 
     use crate::mdl::{Dataset, WrenMDL};
 
@@ -292,7 +302,9 @@ mod test {
         assert_eq!(
             lineage
                 .source_columns_map
-                .get(&Column::from_qualified_name("customer.custkey_plus"))
+                .get(&Column::from_qualified_name(
+                    "test.test.customer.custkey_plus"
+                ))
                 .unwrap()
                 .len(),
             1
@@ -300,7 +312,9 @@ mod test {
         assert_eq!(
             lineage
                 .source_columns_map
-                .get(&Column::from_qualified_name("orders.orderkey_plus_custkey"))
+                .get(&Column::from_qualified_name(
+                    "test.test.orders.orderkey_plus_custkey"
+                ))
                 .unwrap()
                 .len(),
             2
@@ -308,20 +322,30 @@ mod test {
         assert_eq!(
             lineage
                 .source_columns_map
-                .get(&Column::from_qualified_name("orders.hash_orderkey"))
+                .get(&Column::from_qualified_name(
+                    "test.test.orders.hash_orderkey"
+                ))
                 .unwrap()
                 .len(),
             1
         );
         let customer_name: Vec<Column> = lineage
             .source_columns_map
-            .get(&Column::from_qualified_name("orders.customer_name"))
+            .get(&Column::from_qualified_name(
+                "test.test.orders.customer_name",
+            ))
             .unwrap()
             .iter()
             .cloned()
             .collect();
         assert_eq!(customer_name.len(), 1);
-        assert_eq!(customer_name[0], Column::new_unqualified("customer.name"));
+        assert_eq!(
+            customer_name[0],
+            Column {
+                relation: Some(TableReference::full("test", "test", "orders")),
+                name: "customer.name".to_string()
+            }
+        );
     }
 
     #[test]
@@ -340,7 +364,9 @@ mod test {
         assert_eq!(
             lineage
                 .required_fields_map
-                .get(&Column::from_qualified_name("Customer.custkey_plus"))
+                .get(&Column::from_qualified_name(
+                    "test.test.customer.custkey_plus"
+                ))
                 .unwrap()
                 .len(),
             1
@@ -348,7 +374,9 @@ mod test {
         assert_eq!(
             lineage
                 .required_fields_map
-                .get(&Column::from_qualified_name("orders.orderkey_plus_custkey"))
+                .get(&Column::from_qualified_name(
+                    "test.test.orders.orderkey_plus_custkey"
+                ))
                 .unwrap()
                 .len(),
             2
@@ -356,7 +384,9 @@ mod test {
         assert_eq!(
             lineage
                 .required_fields_map
-                .get(&Column::from_qualified_name("orders.hash_orderkey"))
+                .get(&Column::from_qualified_name(
+                    "test.test.orders.hash_orderkey"
+                ))
                 .unwrap()
                 .len(),
             1
@@ -364,12 +394,14 @@ mod test {
 
         let customer_name = lineage
             .required_fields_map
-            .get(&Column::from_qualified_name("orders.customer_name"))
+            .get(&Column::from_qualified_name(
+                "test.test.orders.customer_name",
+            ))
             .unwrap();
         let expected: HashSet<Column> = HashSet::from([
-            Column::from_qualified_name("customer.name"),
-            Column::from_qualified_name("orders.custkey"),
-            Column::from_qualified_name("customer.custkey"),
+            Column::from_qualified_name("test.test.customer.name"),
+            Column::from_qualified_name("test.test.orders.custkey"),
+            Column::from_qualified_name("test.test.customer.custkey"),
         ]);
 
         assert_eq!(customer_name.len(), 3);
@@ -391,7 +423,9 @@ mod test {
         assert_eq!(lineage.required_dataset_topo.len(), 4);
         let customer_name = lineage
             .required_dataset_topo
-            .get(&Column::from_qualified_name("orders.customer_name"))
+            .get(&Column::from_qualified_name(
+                "test.test.orders.customer_name",
+            ))
             .unwrap();
         assert_eq!(customer_name.node_count(), 2);
         assert_eq!(customer_name.edge_count(), 1);

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -48,6 +48,10 @@ impl Model {
             .map(Arc::clone)
             .collect()
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]
@@ -65,6 +69,12 @@ pub struct Column {
     pub expression: Option<String>,
     #[serde(default)]
     pub properties: Vec<(String, String)>,
+}
+
+impl Column {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
@@ -99,6 +109,12 @@ pub struct Metric {
     pub cached: bool,
     pub refresh_time: String,
     pub properties: Vec<(String, String)>,
+}
+
+impl Metric {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash)]

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -10,6 +10,7 @@ use datafusion::{
         unparser::plan_to_sql,
     },
 };
+use log::{debug, info};
 
 use manifest::Relationship;
 
@@ -166,8 +167,7 @@ pub fn transform_sql(
     analyzed_mdl: Arc<AnalyzedWrenMDL>,
     sql: &str,
 ) -> Result<String, DataFusionError> {
-    println!("SQL: {}", sql);
-    println!("********");
+    info!("wren-core received SQL: {}", sql);
 
     // parse the SQL
     let dialect = GenericDialect {};
@@ -184,8 +184,7 @@ pub fn transform_sql(
             return Err(e);
         }
     };
-    println!("Original LogicalPlan:\n {plan:?}");
-    println!("********");
+    debug!("wren-core got the origin plan:\n {plan:?}");
 
     let analyzer = Analyzer::with_rules(vec![
         Arc::new(ModelAnalyzeRule::new(Arc::clone(&analyzed_mdl))),
@@ -201,12 +200,14 @@ pub fn transform_sql(
             return Err(e);
         }
     };
-    println!("Do some modeling:\n {analyzed:?}");
-    println!("********");
+    debug!("wren-core final planned:\n {analyzed:?}");
 
     // show the planned sql
     match plan_to_sql(&analyzed) {
-        Ok(sql) => Ok(sql.to_string()),
+        Ok(sql) => {
+            info!("wren-core planned SQL: {}", sql.to_string());
+            Ok(sql.to_string())
+        },
         Err(e) => Err(e),
     }
 }

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -207,7 +207,7 @@ pub fn transform_sql(
         Ok(sql) => {
             info!("wren-core planned SQL: {}", sql.to_string());
             Ok(sql.to_string())
-        },
+        }
         Err(e) => Err(e),
     }
 }

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -228,6 +228,9 @@ mod tests {
             .unwrap();
         let expr =
             super::create_wren_calculated_field_expr(column_rf.clone(), analyzed_mdl.clone());
-        assert_eq!(expr.to_string(), "test.test.orders.orderkey + test.test.orders.custkey");
+        assert_eq!(
+            expr.to_string(),
+            "test.test.orders.orderkey + test.test.orders.custkey"
+        );
     }
 }

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -194,17 +194,11 @@ mod tests {
                 "customer_name",
             ))
             .unwrap();
-<<<<<<< HEAD
         let expr = super::create_wren_calculated_field_expr(
             column_rf.clone(),
             analyzed_mdl.clone(),
         );
-        assert_eq!(expr.to_string(), "customer.name");
-=======
-        let expr =
-            super::create_wren_calculated_field_expr(column_rf.clone(), analyzed_mdl.clone());
         assert_eq!(expr.to_string(), "test.test.customer.name");
->>>>>>> 182a398 (fix test)
     }
 
     #[test]
@@ -226,8 +220,10 @@ mod tests {
                 "orderkey_plus_custkey",
             ))
             .unwrap();
-        let expr =
-            super::create_wren_calculated_field_expr(column_rf.clone(), analyzed_mdl.clone());
+        let expr = super::create_wren_calculated_field_expr(
+            column_rf.clone(),
+            analyzed_mdl.clone(),
+        );
         assert_eq!(
             expr.to_string(),
             "test.test.orders.orderkey + test.test.orders.custkey"

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -194,11 +194,17 @@ mod tests {
                 "customer_name",
             ))
             .unwrap();
+<<<<<<< HEAD
         let expr = super::create_wren_calculated_field_expr(
             column_rf.clone(),
             analyzed_mdl.clone(),
         );
         assert_eq!(expr.to_string(), "customer.name");
+=======
+        let expr =
+            super::create_wren_calculated_field_expr(column_rf.clone(), analyzed_mdl.clone());
+        assert_eq!(expr.to_string(), "test.test.customer.name");
+>>>>>>> 182a398 (fix test)
     }
 
     #[test]
@@ -220,10 +226,8 @@ mod tests {
                 "orderkey_plus_custkey",
             ))
             .unwrap();
-        let expr = super::create_wren_calculated_field_expr(
-            column_rf.clone(),
-            analyzed_mdl.clone(),
-        );
-        assert_eq!(expr.to_string(), "orders.orderkey + orders.custkey");
+        let expr =
+            super::create_wren_calculated_field_expr(column_rf.clone(), analyzed_mdl.clone());
+        assert_eq!(expr.to_string(), "test.test.orders.orderkey + test.test.orders.custkey");
     }
 }

--- a/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
@@ -1,2 +1,8 @@
 statement ok
-SELECT * from orders
+SELECT * from wrenai.default.orders
+
+statement ok
+select cast(freight_value as int) + cast(price as int) from wrenai.default.order_items
+
+statement ok
+select product_id from wrenai.default.order_items where cast(freight_value as double) > 10

--- a/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/customers.csv
+++ b/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/customers.csv
@@ -1,4 +1,4 @@
-Id,City,State
+id,city,state
 06b8999e2fba1a1fbc88172c00ba8bc7,Los Angeles,CA
 18955e83d337fd6b2def6b18a428ac77,San Francisco,CA
 4e7b3e00288586ebd08712fdd0374a03,San Francisco,CA

--- a/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/order_items.csv
+++ b/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/order_items.csv
@@ -1,4 +1,4 @@
-Id,OrderId,ItemNumber,ProductId,ShippingLimitDate,Price,FreightValue
+id,order_id,item_number,product_id,shipping_limit_date,price,freight_value
 1,03c83b31dbc387f83f1b5579b53182fb,1,a04087ab6a96ffa041f8a2701a72b616,2023/1/15 7:26,119.8,14.68
 2,048e6e4623dbf118c43e0f5572016faa,1,a04087ab6a96ffa041f8a2701a72b616,2023/1/5 18:09,119.8,11.73
 3,05d61bb749461f4805dbda51f767fa47,1,bc4cd4da98dd128c39bf0b8c2674032f,2022/9/4 19:15,240,4

--- a/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/orders.csv
+++ b/wren-modeling-rs/sqllogictest/tests/resources/ecommerce/orders.csv
@@ -1,4 +1,4 @@
-OrderId,CustomerId,Status,PurchaseTimestamp,ApprovedTimestamp,DeliveredCarrierDate,DeliveredCustomerDate,EstimatedDeliveryDate
+order_id,customer_id,status,purchase_timestamp,approved_timestamp,delivered_carrier_date,delivered_customer_date,estimated_delivery_date
 76754c0e642c8f99a8c3fcb8a14ac700,f6c39f83de772dd502809cee2fee4c41,delivered,2022/10/26 9:31:00,2022/10/26 9:49:00,2022/10/26 21:33,2022/11/1 21:17,2022/11/22 0:00
 607911c4ac62f9038b4ec434673e486e,7cec2ad3ecf1b10ce543161225a13a97,delivered,2023/8/6 16:41:00,2023/8/6 16:50:00,2023/8/8 11:09,2023/8/13 17:57,2023/8/22 0:00
 0af28d87520565eb3b57c9b2abe1a2cc,0a209a88c2e3dc2981c79ad85c558059,delivered,2022/10/5 19:23:00,2022/10/5 20:28:00,2022/10/6 17:15,2022/10/17 20:58,2022/11/6 0:00


### PR DESCRIPTION
# Description
- In this PR, instead of bare table reference,  we uses full table reference to analyze MDL.
- If physical table resource is exists, we should `DefaultTableSource` instead of `LogicalTableSource`. Refer to [TableSource](https://datafusion.apache.org/library-user-guide/building-logical-plans.html#table-sources)

# Known issue
- Column expression can't work well.