### PR TITLE
Support new data source MySQL

### DIFF
--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -4,11 +4,14 @@ import pandas as pd
 from pydantic import BaseModel, Field
 
 from app.mdl.rewriter import rewrite
-from app.model.data_source import DataSource, ConnectionInfo
 from app.model.data_source import (
+    BigQueryConnectionInfo,
+    ConnectionInfo,
+    DataSource,
+    MySqlConnectionUrl,
+    MySqlConnectionInfo,
     PostgresConnectionUrl,
     PostgresConnectionInfo,
-    BigQueryConnectionInfo,
     SnowflakeConnectionInfo,
 )
 
@@ -74,14 +77,20 @@ class QueryDTO(BaseModel):
     )
 
 
-class QueryPostgresDTO(QueryDTO):
-    connection_info: PostgresConnectionUrl | PostgresConnectionInfo = Field(
+class QueryBigQueryDTO(QueryDTO):
+    connection_info: BigQueryConnectionInfo = Field(alias="connectionInfo")
+
+
+class QueryMySqlDTO(QueryDTO):
+    connection_info: MySqlConnectionUrl | MySqlConnectionInfo = Field(
         alias="connectionInfo"
     )
 
 
-class QueryBigQueryDTO(QueryDTO):
-    connection_info: BigQueryConnectionInfo = Field(alias="connectionInfo")
+class QueryPostgresDTO(QueryDTO):
+    connection_info: PostgresConnectionUrl | PostgresConnectionInfo = Field(
+        alias="connectionInfo"
+    )
 
 
 class QuerySnowflakeDTO(QueryDTO):

--- a/ibis-server/app/routers/v2/ibis/__init__.py
+++ b/ibis-server/app/routers/v2/ibis/__init__.py
@@ -1,13 +1,12 @@
 from fastapi import APIRouter
 
-import app.routers.v2.ibis.bigquery as bigquery
-import app.routers.v2.ibis.postgres as postgres
-import app.routers.v2.ibis.snowflake as snowflake
+from app.routers.v2.ibis import bigquery, mysql, postgres, snowflake
 
 prefix = "/ibis"
 
 router = APIRouter(prefix=prefix)
 
 router.include_router(bigquery.router)
+router.include_router(mysql.router)
 router.include_router(postgres.router)
 router.include_router(snowflake.router)

--- a/ibis-server/app/routers/v2/ibis/bigquery.py
+++ b/ibis-server/app/routers/v2/ibis/bigquery.py
@@ -38,12 +38,12 @@ def validate(rule_name: str, dto: ValidateDTO) -> Response:
 @router.post("/metadata/tables", response_model=list[Table])
 @log_dto
 def get_bigquery_table_list(dto: MetadataDTO) -> list[Table]:
-    metadata = MetadataFactory(DataSource.bigquery, dto.connection_info)
+    metadata = MetadataFactory(data_source, dto.connection_info)
     return metadata.get_table_list()
 
 
 @router.post("/metadata/constraints", response_model=list[Constraint])
 @log_dto
 def get_bigquery_constraints(dto: MetadataDTO) -> list[Constraint]:
-    metadata = MetadataFactory(DataSource.bigquery, dto.connection_info)
+    metadata = MetadataFactory(data_source, dto.connection_info)
     return metadata.get_constraints()

--- a/ibis-server/app/routers/v2/ibis/mysql.py
+++ b/ibis-server/app/routers/v2/ibis/mysql.py
@@ -1,0 +1,33 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Query, Response
+from fastapi.responses import JSONResponse
+
+from app.logger import log_dto
+from app.model.connector import Connector, to_json, QueryMySqlDTO
+from app.model.data_source import DataSource
+from app.model.validator import ValidateDTO, Validator
+
+router = APIRouter(prefix="/mysql", tags=["mysql"])
+
+data_source = DataSource.mysql
+
+
+@router.post("/query")
+@log_dto
+def query(
+    dto: QueryMySqlDTO, dry_run: Annotated[bool, Query(alias="dryRun")] = False
+) -> Response:
+    connector = Connector(data_source, dto.connection_info, dto.manifest_str)
+    if dry_run:
+        connector.dry_run(dto.sql)
+        return Response(status_code=204)
+    return JSONResponse(to_json(connector.query(dto.sql), dto.column_dtypes))
+
+
+@router.post("/validate/{rule_name}")
+@log_dto
+def validate(rule_name: str, dto: ValidateDTO) -> Response:
+    validator = Validator(Connector(data_source, dto.connection_info, dto.manifest_str))
+    validator.validate(rule_name, dto.parameters)
+    return Response(status_code=204)

--- a/ibis-server/app/routers/v2/ibis/postgres.py
+++ b/ibis-server/app/routers/v2/ibis/postgres.py
@@ -38,12 +38,12 @@ def validate(rule_name: str, dto: ValidateDTO) -> Response:
 @router.post("/metadata/tables", response_model=list[Table])
 @log_dto
 def get_postgres_table_list(dto: MetadataDTO) -> list[Table]:
-    metadata = MetadataFactory(DataSource.postgres, dto.connection_info)
+    metadata = MetadataFactory(data_source, dto.connection_info)
     return metadata.get_table_list()
 
 
 @router.post("/metadata/constraints", response_model=list[Constraint])
 @log_dto
 def get_postgres_constraints(dto: MetadataDTO) -> list[Constraint]:
-    metadata = MetadataFactory(DataSource.postgres, dto.connection_info)
+    metadata = MetadataFactory(data_source, dto.connection_info)
     return metadata.get_constraints()

--- a/ibis-server/poetry.lock
+++ b/ibis-server/poetry.lock
@@ -470,18 +470,18 @@ standard = ["fastapi", "uvicorn[standard] (>=0.15.0)"]
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.15.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.15.1-py3-none-any.whl", hash = "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"},
+    {file = "filelock-3.15.1.tar.gz", hash = "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -703,13 +703,13 @@ testing = ["pytest"]
 
 [[package]]
 name = "google-resumable-media"
-version = "2.7.0"
+version = "2.7.1"
 description = "Utilities for Google Media Downloads and Resumable Uploads"
 optional = false
-python-versions = ">= 3.7"
+python-versions = ">=3.7"
 files = [
-    {file = "google-resumable-media-2.7.0.tar.gz", hash = "sha256:5f18f5fa9836f4b083162064a1c2c98c17239bfda9ca50ad970ccf905f3e625b"},
-    {file = "google_resumable_media-2.7.0-py2.py3-none-any.whl", hash = "sha256:79543cfe433b63fd81c0844b7803aba1bb8950b47bedf7d980c38fa123937e08"},
+    {file = "google-resumable-media-2.7.1.tar.gz", hash = "sha256:eae451a7b2e2cdbaaa0fd2eb00cc8a1ee5e95e16b55597359cbc3d27d7d90e33"},
+    {file = "google_resumable_media-2.7.1-py2.py3-none-any.whl", hash = "sha256:103ebc4ba331ab1bfdac0250f8033627a2cd7cde09e7ccff9181e31ba4315b2c"},
 ]
 
 [package.dependencies]
@@ -1009,6 +1009,7 @@ psycopg2 = {version = ">=2.8.4,<3", optional = true, markers = "extra == \"postg
 pyarrow = ">=10.0.1,<17"
 pyarrow-hotfix = ">=0.4,<1"
 pydata-google-auth = {version = ">=1.4.0,<2", optional = true, markers = "extra == \"bigquery\""}
+pymysql = {version = ">=1,<2", optional = true, markers = "extra == \"mysql\""}
 python-dateutil = ">=2.8.2,<3"
 pytz = ">=2022.7"
 rich = ">=12.4.4,<14"
@@ -1329,13 +1330,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -1777,6 +1778,24 @@ crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
+name = "pymysql"
+version = "1.1.1"
+description = "Pure Python MySQL Driver"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "PyMySQL-1.1.1-py3-none-any.whl", hash = "sha256:4de15da4c61dc132f4fb9ab763063e693d521a80fd0e87943b9a453dd4c19d6c"},
+    {file = "pymysql-1.1.1.tar.gz", hash = "sha256:e127611aaf2b417403c60bf4dc570124aeb4a57f5f37b8e95ae399a42f904cd0"},
+]
+
+[package.dependencies]
+cryptography = {version = "*", optional = true, markers = "extra == \"rsa\""}
+
+[package.extras]
+ed25519 = ["PyNaCl (>=1.4.0)"]
+rsa = ["cryptography"]
 
 [[package]]
 name = "pyopenssl"
@@ -2298,6 +2317,8 @@ files = [
 
 [package.dependencies]
 docker = "*"
+pymysql = {version = "*", extras = ["rsa"], optional = true, markers = "extra == \"mysql\""}
+sqlalchemy = {version = "*", optional = true, markers = "extra == \"mssql\" or extra == \"mysql\" or extra == \"oracle\" or extra == \"oracle-free\""}
 typing-extensions = "*"
 urllib3 = "*"
 wrapt = "*"
@@ -2369,13 +2390,13 @@ typing-extensions = ">=3.7.4.3"
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.1"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
-    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -2832,4 +2853,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "cb7507d88826d6cd5165913d33b5e99946b3d260c80766a0094fb11278b83866"
+content-hash = "52bdc9ec5ebc316527fbfde40c572d27c1aca08375052b7c18df3ccad83d93fe"

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -11,16 +11,17 @@ python = ">=3.11,<3.12"
 fastapi = "0.111.0"
 pydantic = "2.6.4"
 uvicorn = {extras = ["standard"], version = "0.29.0"}
-ibis-framework = {extras = ["bigquery", "postgres", "snowflake"], version = "9.0.0"}
+ibis-framework = {extras = ["mysql", "bigquery", "postgres", "snowflake"], version = "9.0.0"}
 google-auth = "2.29.0"
 httpx = "0.27.0"
 python-dotenv = "1.0.1"
 orjson = "3.10.3"
 pandas = "2.2.2"
+pymysql = "^1.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.2.0"
-testcontainers = {extras = ["postgres"], version = "4.5.0"}
+testcontainers = {extras = ["mysql", "postgres"], version = "4.5.0"}
 sqlalchemy = "2.0.30"
 pre-commit = "3.7.1"
 ruff = "0.4.8"
@@ -28,8 +29,9 @@ ruff = "0.4.8"
 [tool.pytest.ini_options]
 addopts = "--strict-markers"
 markers = [
-    "postgres: mark a test as a postgres test",
     "bigquery: mark a test as a bigquery test",
+    "mysql: mark a test as a mysql test",
+    "postgres: mark a test as a postgres test",
     "snowflake: mark a test as a snowflake test",
 ]
 

--- a/ibis-server/tests/routers/ibis/test_mysql.py
+++ b/ibis-server/tests/routers/ibis/test_mysql.py
@@ -1,0 +1,370 @@
+import base64
+
+import orjson
+import pytest
+from fastapi.testclient import TestClient
+from testcontainers.mysql import MySqlContainer
+
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(scope="class")
+def mysql(request) -> MySqlContainer:
+    def file_path(path: str) -> str:
+        import os
+
+        return os.path.join(os.path.dirname(__file__), path)
+
+    import sqlalchemy
+    import pandas as pd
+
+    mysql = MySqlContainer("mysql:8.0")
+    mysql.start()
+    connection_url = mysql.get_connection_url()
+    engine = sqlalchemy.create_engine(connection_url)
+    pd.read_parquet(file_path("../../resource/tpch/data/orders.parquet")).to_sql(
+        "orders", engine, index=False
+    )
+    pd.read_parquet(file_path("../../resource/tpch/data/customer.parquet")).to_sql(
+        "customer", engine, index=False
+    )
+
+    def stop_pg():
+        mysql.stop()
+
+    request.addfinalizer(stop_pg)
+
+    return mysql
+
+
+@pytest.mark.mysql
+class TestMySql:
+    manifest = {
+        "catalog": "my_catalog",
+        "schema": "my_schema",
+        "models": [
+            {
+                "name": "Orders",
+                "refSql": "select * from orders",
+                "columns": [
+                    {"name": "orderkey", "expression": "o_orderkey", "type": "integer"},
+                    {"name": "custkey", "expression": "o_custkey", "type": "integer"},
+                    {
+                        "name": "orderstatus",
+                        "expression": "o_orderstatus",
+                        "type": "varchar",
+                    },
+                    {
+                        "name": "totalprice",
+                        "expression": "o_totalprice",
+                        "type": "float",
+                    },
+                    {"name": "orderdate", "expression": "o_orderdate", "type": "date"},
+                    {
+                        "name": "order_cust_key",
+                        "expression": "concat(o_orderkey, '_', o_custkey)",
+                        "type": "varchar",
+                    },
+                    {
+                        "name": "timestamp",
+                        "expression": "cast('2024-01-01T23:59:59' as timestamp)",
+                        "type": "timestamp",
+                    },
+                    {
+                        "name": "timestamptz",
+                        "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
+                        "type": "timestamp",
+                    },
+                ],
+                "primaryKey": "orderkey",
+            },
+            {
+                "name": "Customer",
+                "refSql": "select * from customer",
+                "columns": [
+                    {"name": "custkey", "expression": "c_custkey", "type": "integer"},
+                    {"name": "name", "expression": "c_name", "type": "varchar"},
+                ],
+                "primaryKey": "custkey",
+            },
+        ],
+    }
+
+    manifest_str = base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
+
+    @staticmethod
+    def to_connection_info(mysql: MySqlContainer):
+        return {
+            "host": mysql.get_container_host_ip(),
+            "port": mysql.get_exposed_port(mysql.port),
+            "user": mysql.username,
+            "password": mysql.password,
+            "database": mysql.dbname,
+        }
+
+    @staticmethod
+    def to_connection_url(mysql: MySqlContainer):
+        info = TestMySql.to_connection_info(mysql)
+        return f"mysql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"
+
+    def test_query(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["columns"]) == len(self.manifest["models"][0]["columns"])
+        assert len(result["data"]) == 1
+        assert result["data"][0] == [
+            1,
+            370,
+            "O",
+            "172799.49",
+            820540800000,
+            "1_370",
+            1704153599000,
+            1704153599000,
+        ]
+        assert result["dtypes"] == {
+            "orderkey": "int32",
+            "custkey": "int32",
+            "orderstatus": "object",
+            "totalprice": "object",
+            "orderdate": "object",
+            "order_cust_key": "object",
+            "timestamp": "datetime64[ns]",
+            "timestamptz": "datetime64[ns]",
+        }
+
+    @pytest.mark.skip(
+        reason="ibis miss port in connection_url, wait fix PR in ibis repo"
+    )
+    def test_query_with_connection_url(self, mysql: MySqlContainer):
+        connection_url = self.to_connection_url(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={
+                "connectionInfo": {"connectionUrl": connection_url},
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["columns"]) == len(self.manifest["models"][0]["columns"])
+        assert len(result["data"]) == 1
+        assert result["data"][0][0] == 1
+        assert result["dtypes"] is not None
+
+    def test_query_with_column_dtypes(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+                "columnDtypes": {
+                    "totalprice": "float",
+                    "orderdate": "datetime64",
+                    "timestamp": "datetime64",
+                    "timestamptz": "datetime64",
+                },
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["columns"]) == len(self.manifest["models"][0]["columns"])
+        assert len(result["data"]) == 1
+        assert result["data"][0] == [
+            1,
+            370,
+            "O",
+            172799.49,
+            "1996-01-02 00:00:00.000000",
+            "1_370",
+            "2024-01-01 23:59:59.000000",
+            "2024-01-01 23:59:59.000000",
+        ]
+        assert result["dtypes"] == {
+            "orderkey": "int32",
+            "custkey": "int32",
+            "orderstatus": "object",
+            "totalprice": "float64",
+            "orderdate": "object",
+            "order_cust_key": "object",
+            "timestamp": "object",
+            "timestamptz": "object",
+        }
+
+    def test_query_without_manifest(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={
+                "connectionInfo": connection_info,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 422
+        result = response.json()
+        assert result["detail"][0] is not None
+        assert result["detail"][0]["type"] == "missing"
+        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+        assert result["detail"][0]["msg"] == "Field required"
+
+    def test_query_without_sql(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={"connectionInfo": connection_info, "manifestStr": self.manifest_str},
+        )
+        assert response.status_code == 422
+        result = response.json()
+        assert result["detail"][0] is not None
+        assert result["detail"][0]["type"] == "missing"
+        assert result["detail"][0]["loc"] == ["body", "sql"]
+        assert result["detail"][0]["msg"] == "Field required"
+
+    def test_query_without_connection_info(self):
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            json={
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 422
+        result = response.json()
+        assert result["detail"][0] is not None
+        assert result["detail"][0]["type"] == "missing"
+        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+        assert result["detail"][0]["msg"] == "Field required"
+
+    def test_query_with_dry_run(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            params={"dryRun": True},
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 204
+
+    def test_query_with_dry_run_and_invalid_sql(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/query",
+            params={"dryRun": True},
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "sql": "SELECT * FROM X",
+            },
+        )
+        assert response.status_code == 422
+        assert response.text is not None
+
+    def test_validate_with_unknown_rule(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/validate/unknown_rule",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+            },
+        )
+        assert response.status_code == 422
+        assert (
+            response.text
+            == "The rule `unknown_rule` is not in the rules, rules: ['column_is_valid']"
+        )
+
+    def test_validate_rule_column_is_valid(self, mysql: MySqlContainer):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+            },
+        )
+        assert response.status_code == 204
+
+    def test_validate_rule_column_is_valid_with_invalid_parameters(
+        self, mysql: MySqlContainer
+    ):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"modelName": "X", "columnName": "orderkey"},
+            },
+        )
+        assert response.status_code == 422
+
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"modelName": "Orders", "columnName": "X"},
+            },
+        )
+        assert response.status_code == 422
+
+    def test_validate_rule_column_is_valid_without_parameters(
+        self, mysql: MySqlContainer
+    ):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={"connectionInfo": connection_info, "manifestStr": self.manifest_str},
+        )
+        assert response.status_code == 422
+        result = response.json()
+        assert result["detail"][0] is not None
+        assert result["detail"][0]["type"] == "missing"
+        assert result["detail"][0]["loc"] == ["body", "parameters"]
+        assert result["detail"][0]["msg"] == "Field required"
+
+    def test_validate_rule_column_is_valid_without_one_parameter(
+        self, mysql: MySqlContainer
+    ):
+        connection_info = self.to_connection_info(mysql)
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"modelName": "Orders"},
+            },
+        )
+        assert response.status_code == 422
+        assert response.text == "Missing required parameter: `columnName`"
+
+        response = client.post(
+            url="/v2/ibis/mysql/validate/column_is_valid",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": self.manifest_str,
+                "parameters": {"columnName": "orderkey"},
+            },
+        )
+        assert response.status_code == 422
+        assert response.text == "Missing required parameter: `modelName`"


### PR DESCRIPTION
# Description
Make `POST /v2/ibis/{data_source}/query` support new data source `MySQL`

## Request body
- host: string, `required`
- port: integer, `required`
- user: string, `required`
- password: string, `required`
- database: string, `required`

or

- connectionUrl: string, `required`

```json
{
  "sql": "select * from \"Orders\" limit 1",
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInNjaGVtYSI6Im15X3...",
  "connectionInfo": {
    "host": "localhost",
    "port": 3306,
    "database": "dbname",
    "user": "username",
    "password": "password"
  }
}
```

or

```json
{
  "sql": "select * from \"Orders\" limit 1",
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInNjaGVtYSI6Im15X3...",
  "connectionInfo": {
    "connectionUrl": "mysql://username:password@localhost:3306/dbname"
  }
}
```

## Response body
- columns
- data
- dtypes: Type through the pandas

```json
{
    "columns": [
        "o_orderkey",
        "o_custkey",
        "o_orderstatus",
        "o_totalprice",
        "o_orderdate",
        "o_orderpriority",
        "o_clerk",
        "o_shippriority",
        "o_comment"
    ],
    "data": [
        [
            1,
            370,
            "O",
            172799.49,
            820540800000,
            "5-LOW",
            "Clerk#000000951",
            0,
            "nstructions sleep furiously among "
        ]
    ],
    "dtypes": {
        "o_orderkey": "int32",
        "o_custkey": "int32",
        "o_orderstatus": "object",
        "o_totalprice": "object",
        "o_orderdate": "object",
        "o_orderpriority": "object",
        "o_clerk": "object",
        "o_shippriority": "int32",
        "o_comment": "object"
    }
}
```

## Additional information
We found `con = ibis.connect(f"mysql://{user}:{password}@{host}:{port}/{database}")` will miss the `port`. We added kwargs to may it receive port until this issue is fixed.