### PR TITLE
Remove rust in Dockerfile

### DIFF
--- a/ibis-server/Dockerfile
+++ b/ibis-server/Dockerfile
@@ -21,11 +21,8 @@ WORKDIR /app
 
 COPY pyproject.toml ./
 COPY poetry.lock ./
-COPY rust/Cargo.toml ./
-COPY rust/Cargo.lock ./
 
 RUN poetry install --without dev
-RUN poetry run maturin develop
 
 FROM python:3.11-slim-buster as runtime
 


### PR DESCRIPTION
We don't use the rust in the normal flow. We can remove the failed builder for rust in the Dockerfile now.