### PR TITLE
Add pyo3-build-config for macos building

### DIFF
--- a/wren-modeling-py/Cargo.lock
+++ b/wren-modeling-py/Cargo.lock
@@ -2783,6 +2783,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "pyo3",
+ "pyo3-build-config",
  "serde_json",
  "thiserror",
  "wren-core",

--- a/wren-modeling-py/Cargo.toml
+++ b/wren-modeling-py/Cargo.toml
@@ -14,3 +14,6 @@ wren-core = { path = "../wren-modeling-rs/core" }
 base64 = "0.22.1"
 serde_json = "1.0.117"
 thiserror = "1.0"
+
+[build-dependencies]
+pyo3-build-config =  "0.21.2"

--- a/wren-modeling-py/build.rs
+++ b/wren-modeling-py/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
Cargo build will be failed in the MacOS before.
This project needs to add `pyo3-build-config`.

Reference
https://pyo3.rs/v0.14.2/building_and_distribution.html#macos