### PR TITLE
Introduce the calculation for TO_MANY relationship

### DIFF
--- a/wren-modeling-py/Cargo.lock
+++ b/wren-modeling-py/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219d05930b81663fd3b32e3bde8ce5bff3c4d23052a99f11a8fa50a3b47b2658"
+checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272150200c07a86a390be651abdd320a2d12e84535f0837566ca87ecd8f95e0"
+checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8010572cf8c745e242d1b632bd97bd6d4f40fefed5ed1290a8f433abaa686fea"
+checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0a2432f0cba5692bf4cb757469c66791394bac9ec7ce63c1afe74744c37b27"
+checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
 dependencies = [
  "bytes",
  "half",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc10cd7995e83505cc290df9384d6e5412b207b79ce6bdff89a10505ed2cba"
+checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cbcba196b862270bf2a5edb75927380a7f3a163622c61d40cbba416a6305f2"
+checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2742ac1f6650696ab08c88f6dd3f0eb68ce10f8c253958a18c943a68cd04aec5"
+checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42ea853130f7e78b9b9d178cb4cd01dee0f78e64d96c2949dc0a915d6d9e19d"
+checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaafb5714d4e59feae964714d724f880511500e3569cc2a94d02456b403a2a49"
+checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e6b61e3dc468f503181dccc2fc705bdcc5f2f146755fa5b56d0a6c5943f412"
+checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848ee52bb92eb459b811fb471175ea3afcf620157674c8794f539838920f9228"
+checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -320,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d9483aaabe910c4781153ae1b6ae0393f72d9ef757d38d09d450070cf2e528"
+checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
 
 [[package]]
 name = "arrow-select"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849524fa70e0e3c5ab58394c770cb8f514d0122d20de08475f7b472ed8075830"
+checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9373cb5a021aee58863498c37eb484998ef13377f69989c6c5ccfbd258236cdb"
+checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -381,7 +381,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -554,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
  "phf",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fb4eeeb7109393a0739ac5b8fd892f95ccef691421491c85544f7997366f68"
+checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
 dependencies = [
  "ahash",
  "arrow",
@@ -717,6 +717,7 @@ dependencies = [
  "datafusion-functions-array",
  "datafusion-optimizer",
  "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-sql",
  "flate2",
@@ -731,6 +732,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "parquet",
+ "paste",
  "pin-project-lite",
  "rand",
  "sqlparser",
@@ -745,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741aeac15c82f239f2fc17deccaab19873abbd62987be20023689b15fa72fa09"
+checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
 dependencies = [
  "ahash",
  "arrow",
@@ -756,6 +758,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
+ "hashbrown",
  "instant",
  "libc",
  "num_cpus",
@@ -766,18 +769,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8ddfb8d8cb51646a30da0122ecfffb81ca16919ae9a3495a9e7468bdcd52b8"
+checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-execution"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282122f90b20e8f98ebfa101e4bf20e718fd2684cf81bef4e8c6366571c64404"
+checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
 dependencies = [
  "arrow",
  "chrono",
@@ -796,13 +799,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5478588f733df0dfd87a62671c7478f590952c95fa2fa5c137e3ff2929491e22"
+checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
+ "arrow-buffer",
  "chrono",
  "datafusion-common",
  "paste",
@@ -814,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4afd261cea6ac9c3ca1192fd5e9f940596d8e9208c5b1333f4961405db53185"
+checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
 dependencies = [
  "arrow",
  "base64",
@@ -841,11 +845,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b36a6c4838ab94b5bf8f7a96ce6ce059d805c5d1dcaa6ace49e034eb65cd999"
+checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
 dependencies = [
+ "ahash",
  "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -857,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-array"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdd200a6233f48d3362e7ccb784f926f759100e44ae2137a5e2dcb986a59c4"
+checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -877,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f2820938810e8a2d71228fd6f59f33396aebc5f5f687fcbf14de5aab6a7e1a"
+checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
 dependencies = [
  "arrow",
  "async-trait",
@@ -896,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adf8eb12716f52ddf01e09eb6c94d3c9b291e062c05c91b839a448bddba2ff8"
+checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
 dependencies = [
  "ahash",
  "arrow",
@@ -927,20 +933,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5472c3230584c150197b3f2c23f2392b9dc54dbfb62ad41e7e36447cfce4be"
+checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
 dependencies = [
  "arrow",
  "datafusion-common",
  "datafusion-expr",
+ "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ae750c38389685a8b62e5b899bbbec488950755ad6d218f3662d35b800c4fe"
+checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
 dependencies = [
  "ahash",
  "arrow",
@@ -972,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befc67a3cdfbfa76853f43b10ac27337821bb98e519ab6baf431fcc0bcfcafdb"
+checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -982,6 +989,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "log",
+ "regex",
  "sqlparser",
  "strum",
 ]
@@ -995,17 +1003,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -1073,9 +1070,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -1156,7 +1153,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -1297,133 +1294,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1588,12 +1465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1758,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
+checksum = "fbebfd32c213ba1907fa7a9c9138015a8de2b43e30c5aa45b18f7deb46786ad6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1817,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "096795d4f47f65fd3ee1ec5a98b77ab26d602f2cc785b0e4be5443add17ecc32"
+checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1848,6 +1719,7 @@ dependencies = [
  "tokio",
  "twox-hash",
  "zstd",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -1961,9 +1833,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2016,7 +1888,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2029,7 +1901,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2082,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags 2.5.0",
 ]
@@ -2202,7 +2074,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2278,9 +2150,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "sqlparser"
-version = "0.45.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7bbffee862a796d67959a89859d6b1046bb5016d63e23835ad0da182777bbe0"
+checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -2294,14 +2166,8 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2328,14 +2194,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "syn"
@@ -2350,24 +2216,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -2405,7 +2260,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2429,14 +2284,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
+name = "tinyvec"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "tinyvec_macros",
 ]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2459,7 +2319,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2494,7 +2354,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -2523,10 +2383,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2548,26 +2423,14 @@ checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2627,7 +2490,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-shared",
 ]
 
@@ -2649,7 +2512,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2765,7 +2628,6 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 name = "wren-core"
 version = "0.1.0"
 dependencies = [
- "arrow-schema",
  "async-trait",
  "datafusion",
  "env_logger",
@@ -2789,48 +2651,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
-]
-
-[[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
 ]
 
 [[package]]
@@ -2850,75 +2676,32 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.66",
+ "syn 2.0.67",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
+version = "2.0.9+zstd.1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
 dependencies = [
  "cc",
  "pkg-config",

--- a/wren-modeling-py/src/errors.rs
+++ b/wren-modeling-py/src/errors.rs
@@ -1,7 +1,7 @@
-use std::string::FromUtf8Error;
 use base64::DecodeError;
 use pyo3::exceptions::PyException;
 use pyo3::PyErr;
+use std::string::FromUtf8Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/wren-modeling-py/tests/test_modeling_core.py
+++ b/wren-modeling-py/tests/test_modeling_core.py
@@ -27,5 +27,5 @@ def test_transform_sql():
     rewritten_sql = wren_core.transform_sql(manifest_str, sql)
     assert (
         rewritten_sql
-        == 'SELECT "customer"."custkey", "customer"."name" FROM (SELECT "customer"."custkey", "customer"."name" FROM (SELECT "main"."customer"."c_custkey" AS "custkey", "main"."customer"."c_name" AS "name" FROM "main"."customer") AS "customer") AS "customer"'
+        == 'SELECT customer.custkey, customer."name" FROM (SELECT customer.custkey, customer."name" FROM (SELECT main.customer.c_custkey AS custkey, main.customer.c_name AS "name" FROM main.customer) AS customer) AS customer'
     )

--- a/wren-modeling-rs/Cargo.toml
+++ b/wren-modeling-rs/Cargo.toml
@@ -13,9 +13,8 @@ rust-version = "1.78"
 version = "0.1.0"
 
 [workspace.dependencies]
-arrow-schema = { version = "51.0.0", default-features = false }
 async-trait = "0.1.80"
-datafusion = { version = "38.0.0" }
+datafusion = { version = "39.0.0" }
 env_logger = "0.11.3"
 log = { version = "0.4.14" }
 petgraph = "0.6.5"

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -13,7 +13,6 @@ name = "wren_core"
 path = "src/lib.rs"
 
 [dependencies]
-arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 datafusion = { workspace = true }
 env_logger = { workspace = true }

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -60,10 +60,8 @@ impl ModelPlanNode {
             model.name(),
         );
 
-        let required_columns = model
-            .get_physical_columns()
-            .into_iter()
-            .filter(|column| {
+        let required_columns =
+            model.get_physical_columns().into_iter().filter(|column| {
                 required_fields.iter().any(|expr| {
                     if let Expr::Column(column_expr) = expr {
                         column_expr.name.as_str() == column.name()
@@ -817,8 +815,7 @@ impl CalculationPlanNode {
         let Some(model) = calculation.dataset.try_as_model() else {
             return plan_err!("Only support model as source dataset");
         };
-        let Some(pk_column) =
-            model.primary_key().and_then(|pk| model.get_column(pk))
+        let Some(pk_column) = model.primary_key().and_then(|pk| model.get_column(pk))
         else {
             return plan_err!("Primary key not found");
         };

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -29,12 +29,15 @@ impl WrenContextProvider {
         for model in mdl.manifest.models.iter() {
             tables.insert(
                 format!("{}.{}.{}", mdl.catalog(), mdl.schema(), model.name()),
-                create_table_source(&model)?,
+                create_table_source(model)?,
             );
         }
         // register physical table
         for (name, table) in mdl.register_tables.iter() {
-            tables.insert(name.clone(), Arc::new(DefaultTableSource::new(table.clone())));
+            tables.insert(
+                name.clone(),
+                Arc::new(DefaultTableSource::new(table.clone())),
+            );
         }
         Ok(Self {
             tables,
@@ -45,7 +48,7 @@ impl WrenContextProvider {
     pub fn new_bare(mdl: &WrenMDL) -> Result<Self> {
         let mut tables = HashMap::new();
         for model in mdl.manifest.models.iter() {
-            tables.insert(model.name().to_string(), create_table_source(&model)?);
+            tables.insert(model.name().to_string(), create_table_source(model)?);
         }
         Ok(Self {
             tables,

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -25,11 +25,16 @@ pub struct WrenContextProvider {
 impl WrenContextProvider {
     pub fn new(mdl: &WrenMDL) -> Result<Self> {
         let mut tables = HashMap::new();
+        // register model table
         for model in mdl.manifest.models.iter() {
             tables.insert(
                 format!("{}.{}.{}", mdl.catalog(), mdl.schema(), model.name()),
                 create_table_source(&model)?,
             );
+        }
+        // register physical table
+        for (name, table) in mdl.register_tables.iter() {
+            tables.insert(name.clone(), Arc::new(DefaultTableSource::new(table.clone())));
         }
         Ok(Self {
             tables,

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::builder::LogicalTableSource;
 use datafusion::{
@@ -78,15 +78,15 @@ impl ContextProvider for WrenContextProvider {
         &self.options
     }
 
-    fn udfs_names(&self) -> Vec<String> {
+    fn udf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udafs_names(&self) -> Vec<String> {
+    fn udaf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udwfs_names(&self) -> Vec<String> {
+    fn udwf_names(&self) -> Vec<String> {
         Vec::new()
     }
 }
@@ -149,15 +149,15 @@ impl ContextProvider for RemoteContextProvider {
         &self.options
     }
 
-    fn udfs_names(&self) -> Vec<String> {
+    fn udf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udafs_names(&self) -> Vec<String> {
+    fn udaf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udwfs_names(&self) -> Vec<String> {
+    fn udwf_names(&self) -> Vec<String> {
         Vec::new()
     }
 }
@@ -229,15 +229,15 @@ impl ContextProvider for DynamicContextProvider {
         self.delegate.options()
     }
 
-    fn udfs_names(&self) -> Vec<String> {
+    fn udf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udafs_names(&self) -> Vec<String> {
+    fn udaf_names(&self) -> Vec<String> {
         Vec::new()
     }
 
-    fn udwfs_names(&self) -> Vec<String> {
+    fn udwf_names(&self) -> Vec<String> {
         Vec::new()
     }
 }

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -1,6 +1,6 @@
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use std::{collections::HashMap, sync::Arc};
 
-use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::{builder::LogicalTableSource, TableSource};
 use petgraph::dot::{Config, Dot};

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -1,7 +1,9 @@
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::common::not_impl_err;
 use std::{collections::HashMap, sync::Arc};
 
 use datafusion::datasource::DefaultTableSource;
+use datafusion::error::Result;
 use datafusion::logical_expr::{builder::LogicalTableSource, TableSource};
 use petgraph::dot::{Config, Dot};
 use petgraph::Graph;
@@ -12,32 +14,36 @@ use crate::mdl::{
     Dataset, WrenMDL,
 };
 
-pub fn map_data_type(data_type: &str) -> DataType {
-    match data_type {
+pub fn map_data_type(data_type: &str) -> Result<DataType> {
+    let result = match data_type {
         "integer" => DataType::Int32,
         "bigint" => DataType::Int64,
         "varchar" => DataType::Utf8,
         "double" => DataType::Float64,
         "timestamp" => DataType::Timestamp(TimeUnit::Nanosecond, None),
         "date" => DataType::Date32,
-        _ => unimplemented!("{}", &data_type),
-    }
+        _ => return not_impl_err!("Unsupported data type: {}", &data_type),
+    };
+    Ok(result)
 }
 
-pub fn create_table_source(model: &Model) -> Arc<dyn TableSource> {
-    let schema = create_schema(model.get_physical_columns());
-    Arc::new(LogicalTableSource::new(schema))
+pub fn create_table_source(model: &Model) -> Result<Arc<dyn TableSource>> {
+    let schema = create_schema(model.get_physical_columns())?;
+    Ok(Arc::new(LogicalTableSource::new(schema)))
 }
 
-pub fn create_schema(columns: Vec<Arc<Column>>) -> SchemaRef {
+pub fn create_schema(columns: Vec<Arc<Column>>) -> Result<SchemaRef> {
     let fields: Vec<Field> = columns
         .iter()
         .map(|column| {
-            let data_type = map_data_type(&column.r#type);
-            Field::new(&column.name, data_type, column.no_null)
+            let data_type = map_data_type(&column.r#type)?;
+            Ok(Field::new(&column.name, data_type, column.no_null))
         })
-        .collect();
-    SchemaRef::new(Schema::new_with_metadata(fields, HashMap::new()))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(SchemaRef::new(Schema::new_with_metadata(
+        fields,
+        HashMap::new(),
+    )))
 }
 
 pub fn create_remote_table_source(model: &Model, mdl: &WrenMDL) -> Arc<dyn TableSource> {

--- a/wren-modeling-rs/core/src/mdl/builder.rs
+++ b/wren-modeling-rs/core/src/mdl/builder.rs
@@ -78,7 +78,7 @@ impl ModelBuilder {
                 base_object: "".to_string(),
                 table_reference: "".to_string(),
                 columns: vec![],
-                primary_key: "".to_string(),
+                primary_key: None,
                 cached: false,
                 refresh_time: "".to_string(),
                 properties: vec![],
@@ -107,7 +107,7 @@ impl ModelBuilder {
     }
 
     pub fn primary_key(mut self, primary_key: &str) -> Self {
-        self.model.primary_key = primary_key.to_string();
+        self.model.primary_key = Some(primary_key.to_string());
         self
     }
 

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -301,7 +301,7 @@ mod test {
         let manifest = serde_json::from_str::<Manifest>(&mdl_json).unwrap();
         let wren_mdl = WrenMDL::new(manifest);
         let lineage = crate::mdl::lineage::Lineage::new(&wren_mdl)?;
-        assert_eq!(lineage.source_columns_map.len(), 9);
+        assert_eq!(lineage.source_columns_map.len(), 13);
         assert_eq!(
             lineage
                 .source_columns_map
@@ -363,7 +363,7 @@ mod test {
         let manifest = serde_json::from_str::<Manifest>(&mdl_json).unwrap();
         let wren_mdl = WrenMDL::new(manifest);
         let lineage = crate::mdl::lineage::Lineage::new(&wren_mdl)?;
-        assert_eq!(lineage.required_fields_map.len(), 4);
+        assert_eq!(lineage.required_fields_map.len(), 5);
         assert_eq!(
             lineage
                 .required_fields_map

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -30,7 +30,7 @@ pub struct Model {
     pub table_reference: String,
     pub columns: Vec<Arc<Column>>,
     #[serde(default)]
-    pub primary_key: String,
+    pub primary_key: Option<String>,
     #[serde(default)]
     pub cached: bool,
     #[serde(default)]
@@ -52,6 +52,17 @@ impl Model {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn get_column(&self, column_name: &str) -> Option<Arc<Column>> {
+        self.columns
+            .iter()
+            .find(|c| c.name == column_name)
+            .map(Arc::clone)
+    }
+
+    pub fn primary_key(&self) -> Option<&str> {
+        self.primary_key.as_deref()
     }
 }
 
@@ -97,6 +108,15 @@ pub enum JoinType {
     OneToMany,
     ManyToOne,
     ManyToMany,
+}
+
+impl JoinType {
+    pub fn is_to_one(&self) -> bool {
+        match self {
+            JoinType::OneToOne | JoinType::ManyToOne => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for JoinType {

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -112,10 +112,7 @@ pub enum JoinType {
 
 impl JoinType {
     pub fn is_to_one(&self) -> bool {
-        match self {
-            JoinType::OneToOne | JoinType::ManyToOne => true,
-            _ => false,
-        }
+        matches!(self, JoinType::OneToOne | JoinType::ManyToOne)
     }
 }
 

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -61,8 +61,8 @@ impl AnalyzedWrenMDL {
         Arc::clone(&self.wren_mdl)
     }
 
-    pub fn lineage(&self) -> Arc<lineage::Lineage> {
-        Arc::clone(&self.lineage)
+    pub fn lineage(&self) -> &lineage::Lineage {
+        &self.lineage
     }
 }
 
@@ -244,7 +244,7 @@ pub fn transform_sql(
 pub fn decision_point_analyze(_wren_mdl: Arc<WrenMDL>, _sql: &str) {}
 
 /// Cheap clone of the ColumnReference
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ColumnReference {
     pub dataset: Dataset,
     pub column: Arc<Column>,
@@ -253,10 +253,6 @@ pub struct ColumnReference {
 impl ColumnReference {
     fn new(dataset: Dataset, column: Arc<Column>) -> Self {
         ColumnReference { dataset, column }
-    }
-
-    pub fn get_column(&self) -> Arc<Column> {
-        Arc::clone(&self.column)
     }
 
     pub fn get_qualified_name(&self) -> String {
@@ -275,6 +271,13 @@ impl Dataset {
         match self {
             Dataset::Model(model) => model.name(),
             Dataset::Metric(metric) => metric.name(),
+        }
+    }
+
+    pub fn try_as_model(&self) -> Option<Arc<Model>> {
+        match self {
+            Dataset::Model(model) => Some(Arc::clone(model)),
+            _ => None,
         }
     }
 }

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -318,14 +318,16 @@ mod test {
                 "select orders.orderkey from test.test.orders left join test.test.customer on (orders.custkey = customer.custkey) where orders.totalprice > 10",
                 "select orderkey, sum(totalprice) from test.test.orders group by 1",
                 "select orderkey, count(*) from test.test.orders where orders.totalprice > 10 group by 1",
+                "select totalcost from test.test.profile",
         // TODO: support calculated without relationship
         //     "select orderkey_plus_custkey from orders",
         ];
 
         for sql in tests {
-            println!("{}", sql);
+            println!("Original: {}", sql);
             let actual = mdl::transform_sql(Arc::clone(&analyzed_mdl), sql)?;
-            plan_sql(&actual, Arc::clone(&analyzed_mdl))?;
+            let after_roundtrip = plan_sql(&actual, Arc::clone(&analyzed_mdl))?;
+            println!("After roundtrip: {}", after_roundtrip);
         }
 
         Ok(())

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeSet, VecDeque};
 use std::ops::ControlFlow;
 use std::sync::Arc;
 
-use datafusion::common::Column;
+use datafusion::common::{internal_err, plan_err, Column};
+use datafusion::error::Result;
 use datafusion::logical_expr::logical_plan::tree_node::unwrap_arc;
 use datafusion::logical_expr::{Expr, LogicalPlan};
 use datafusion::sql::planner::SqlToRel;
@@ -62,20 +63,22 @@ pub fn collect_identifiers(expr: &String) -> BTreeSet<Column> {
 pub fn create_wren_calculated_field_expr(
     column_rf: ColumnReference,
     analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-) -> Expr {
+) -> Result<Expr> {
     if !column_rf.column.is_calculated {
-        panic!("Column is not calculated: {}", column_rf.column.name)
+        return plan_err!("Column is not calculated: {}", column_rf.column.name);
     }
     let qualified_col = from_qualified_name(
         &analyzed_wren_mdl.wren_mdl,
         column_rf.dataset.name(),
         column_rf.column.name(),
     );
-    let required_fields = analyzed_wren_mdl
+    let Some(required_fields) = analyzed_wren_mdl
         .lineage
         .required_fields_map
         .get(&qualified_col)
-        .unwrap_or_else(|| panic!("Required fields not found for {}", qualified_col));
+    else {
+        return plan_err!("Required fields not found for {}", qualified_col);
+    };
 
     // collect all required models.
     let models = required_fields
@@ -106,23 +109,24 @@ pub fn create_wren_calculated_field_expr(
     });
     debug!("Statement: {:?}", statement.to_string());
     // Create the expression only has the table prefix. We don't need the catalog and schema prefix when planning.
-    let context_provider = WrenContextProvider::new_bare(&analyzed_wren_mdl.wren_mdl);
+    let context_provider = WrenContextProvider::new_bare(&analyzed_wren_mdl.wren_mdl)?;
     let sql_to_rel = SqlToRel::new(&context_provider);
     let plan = match sql_to_rel.sql_statement_to_plan(statement.clone()) {
         Ok(plan) => plan,
-        Err(e) => panic!("Error creating plan: {}", e),
+        Err(e) => return plan_err!("Error creating plan: {}", e),
     };
 
     let result = match plan {
         LogicalPlan::Projection(projection) => {
             if let LogicalPlan::Aggregate(aggregation) = unwrap_arc(projection.input) {
-                return aggregation.aggr_expr[0].clone();
+                aggregation.aggr_expr[0].clone()
+            } else {
+                projection.expr[0].clone()
             }
-            projection.expr[0].clone()
         }
-        _ => unreachable!("Unexpected plan type: {:?}", plan),
+        _ => return internal_err!("Unexpected plan type: {:?}", plan),
     };
-    result
+    Ok(result)
 }
 
 /// Create the Logical Expr for the remote column.
@@ -131,8 +135,8 @@ pub(crate) fn create_remote_expr_for_model(
     expr: &String,
     model: Arc<Model>,
     analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-) -> Expr {
-    let context_provider = RemoteContextProvider::new(&analyzed_wren_mdl.wren_mdl);
+) -> Result<Expr> {
+    let context_provider = RemoteContextProvider::new(&analyzed_wren_mdl.wren_mdl)?;
     create_expr_for_model(
         expr,
         model,
@@ -146,8 +150,8 @@ pub(crate) fn create_wren_expr_for_model(
     expr: &String,
     model: Arc<Model>,
     analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-) -> Expr {
-    let context_provider = WrenContextProvider::new(&analyzed_wren_mdl.wren_mdl);
+) -> Result<Expr> {
+    let context_provider = WrenContextProvider::new(&analyzed_wren_mdl.wren_mdl)?;
     let wrapped = format!(
         "select {} from {}.{}.{}",
         expr,
@@ -160,14 +164,11 @@ pub(crate) fn create_wren_expr_for_model(
     debug!("Statement: {:?}", statement.to_string());
 
     let sql_to_rel = SqlToRel::new(&context_provider);
-    let plan = match sql_to_rel.sql_statement_to_plan(statement.clone()) {
-        Ok(plan) => plan,
-        Err(e) => panic!("Error creating plan: {}", e),
-    };
+    let plan = sql_to_rel.sql_statement_to_plan(statement.clone())?;
 
     match plan {
-        LogicalPlan::Projection(projection) => projection.expr[0].clone(),
-        _ => unreachable!("Unexpected plan type: {:?}", plan),
+        LogicalPlan::Projection(projection) => Ok(projection.expr[0].clone()),
+        _ => internal_err!("Unexpected plan type: {:?}", plan),
     }
 }
 
@@ -176,20 +177,16 @@ pub(crate) fn create_expr_for_model(
     expr: &String,
     model: Arc<Model>,
     context_provider: DynamicContextProvider,
-) -> Expr {
+) -> Result<Expr> {
     let wrapped = format!("select {} from {}", expr, &model.table_reference);
     let parsed = Parser::parse_sql(&GenericDialect {}, &wrapped).unwrap();
     let statement = &parsed[0];
 
     let sql_to_rel = SqlToRel::new(&context_provider);
-    let plan = match sql_to_rel.sql_statement_to_plan(statement.clone()) {
-        Ok(plan) => plan,
-        Err(e) => panic!("Error creating plan: {}", e),
-    };
-
+    let plan = sql_to_rel.sql_statement_to_plan(statement.clone())?;
     match plan {
-        LogicalPlan::Projection(projection) => projection.expr[0].clone(),
-        _ => unreachable!("Unexpected plan type: {:?}", plan),
+        LogicalPlan::Projection(projection) => Ok(projection.expr[0].clone()),
+        _ => internal_err!("Unexpected plan type: {:?}", plan),
     }
 }
 
@@ -202,16 +199,17 @@ mod tests {
     use crate::logical_plan::utils::from_qualified_name;
     use crate::mdl::manifest::Manifest;
     use crate::mdl::AnalyzedWrenMDL;
+    use datafusion::error::Result;
 
     #[test]
-    fn test_create_wren_expr() {
+    fn test_create_wren_expr() -> Result<()> {
         let test_data: PathBuf =
             [env!("CARGO_MANIFEST_DIR"), "tests", "data", "mdl.json"]
                 .iter()
                 .collect();
         let mdl_json = fs::read_to_string(test_data.as_path()).unwrap();
         let mdl = serde_json::from_str::<Manifest>(&mdl_json).unwrap();
-        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl));
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl)?);
 
         let column_rf = analyzed_mdl
             .wren_mdl
@@ -225,19 +223,20 @@ mod tests {
         let expr = super::create_wren_calculated_field_expr(
             column_rf.clone(),
             analyzed_mdl.clone(),
-        );
+        )?;
         assert_eq!(expr.to_string(), "customer.name");
+        Ok(())
     }
 
     #[test]
-    fn test_create_wren_expr_non_relationship() {
+    fn test_create_wren_expr_non_relationship() -> Result<()> {
         let test_data: PathBuf =
             [env!("CARGO_MANIFEST_DIR"), "tests", "data", "mdl.json"]
                 .iter()
                 .collect();
         let mdl_json = fs::read_to_string(test_data.as_path()).unwrap();
         let mdl = serde_json::from_str::<Manifest>(&mdl_json).unwrap();
-        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl));
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl)?);
 
         let column_rf = analyzed_mdl
             .wren_mdl
@@ -251,7 +250,8 @@ mod tests {
         let expr = super::create_wren_calculated_field_expr(
             column_rf.clone(),
             analyzed_mdl.clone(),
-        );
+        )?;
         assert_eq!(expr.to_string(), "orders.orderkey + orders.custkey");
+        Ok(())
     }
 }

--- a/wren-modeling-rs/core/tests/data/mdl.json
+++ b/wren-modeling-rs/core/tests/data/mdl.json
@@ -21,6 +21,44 @@
           "type": "integer",
           "expression": "custkey + 1",
           "isCalculated": true
+        },
+        {
+          "name": "orders",
+          "type": "orders",
+          "relationship": "CustomerOrders"
+        }
+      ],
+      "primaryKey": "custkey"
+    },
+    {
+      "name": "profile",
+      "tableReference": "profile",
+      "columns": [
+        {
+          "name": "custkey",
+          "type": "integer",
+          "expression": "p_custkey"
+        },
+        {
+          "name": "phone",
+          "type": "varchar",
+          "expression": "p_phone"
+        },
+        {
+          "name": "sex",
+          "type": "varchar",
+          "expression": "p_sex"
+        },
+        {
+          "name": "customer",
+          "type": "customer",
+          "relationship": "CustomerProfile"
+        },
+        {
+          "name": "totalcost",
+          "type": "integer",
+          "isCalculated": true,
+          "expression": "sum(customer.orders.totalprice)"
         }
       ],
       "primaryKey": "custkey"
@@ -77,6 +115,12 @@
       "models": ["customer", "orders"],
       "joinType": "one_to_many",
       "condition": "customer.custkey = orders.custkey"
+    },
+    {
+      "name" : "CustomerProfile",
+      "models": ["customer", "profile"],
+      "joinType": "one_to_one",
+      "condition": "customer.custkey = profile.custkey"
     }
   ]
 }

--- a/wren-modeling-rs/sqllogictest/bin/sqllogictests.rs
+++ b/wren-modeling-rs/sqllogictest/bin/sqllogictests.rs
@@ -18,6 +18,7 @@
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 #[cfg(target_family = "windows")]
 use std::thread;
 
@@ -140,10 +141,11 @@ async fn run_test_file(test_file: TestFile) -> Result<()> {
         info!("Skipping: {}", path.display());
         return Ok(());
     };
+    let test_ctx = Arc::new(test_ctx);
     setup_scratch_dir(&relative_path)?;
     let mut runner = sqllogictest::Runner::new(|| async {
         Ok(DataFusion::new(
-            test_ctx.session_ctx().clone(),
+            Arc::clone(&test_ctx),
             relative_path.clone(),
         ))
     });
@@ -166,10 +168,11 @@ async fn run_complete_file(test_file: TestFile) -> Result<()> {
         info!("Skipping: {}", path.display());
         return Ok(());
     };
+    let test_ctx = Arc::new(test_ctx);
     setup_scratch_dir(&relative_path)?;
     let mut runner = sqllogictest::Runner::new(|| async {
         Ok(DataFusion::new(
-            test_ctx.session_ctx().clone(),
+            Arc::clone(&test_ctx),
             relative_path.clone(),
         ))
     });

--- a/wren-modeling-rs/sqllogictest/src/engine/runner.rs
+++ b/wren-modeling-rs/sqllogictest/src/engine/runner.rs
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{path::PathBuf, time::Duration};
 use std::sync::Arc;
+use std::{path::PathBuf, time::Duration};
 
+use crate::TestContext;
 use async_trait::async_trait;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use log::info;
 use sqllogictest::DBOutput;
 use wren_core::mdl::transform_sql;
-use crate::TestContext;
 
 use super::{
     error::Result,
@@ -55,8 +55,8 @@ impl sqllogictest::AsyncDB for DataFusion {
             self.relative_path.display(),
             sql
         );
-        let sql = transform_sql(Arc::clone(&self.ctx.analyzed_wren_mdl()), sql)?;
-        run_query(&self.ctx.session_ctx(), sql).await
+        let sql = transform_sql(Arc::clone(self.ctx.analyzed_wren_mdl()), sql)?;
+        run_query(self.ctx.session_ctx(), sql).await
     }
 
     /// Engine name of current database.

--- a/wren-modeling-rs/sqllogictest/src/lib.rs
+++ b/wren-modeling-rs/sqllogictest/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod engine;
 
-mod test_context;
+pub mod test_context;
 pub use test_context::TestContext;

--- a/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
@@ -21,3 +21,8 @@ query B
 select cnt1 = cnt2 from (select count(*) as cnt1 from (select customer_state from  wrenai.default.order_items)), (select count(*) as cnt2 from datafusion.public.order_items) limit 1;
 ----
 true
+
+query B
+select actual = expected from (select totalprice as actual from wrenai.default.orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'), (select sum(price) as expected from datafusion.public.order_items where order_id = '76754c0e642c8f99a8c3fcb8a14ac700') limit 1;
+----
+true

--- a/wren-modeling-rs/wren-example/Cargo.toml
+++ b/wren-modeling-rs/wren-example/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 publish = false
 
 [dev-dependencies]
-arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 datafusion = { workspace = true }
 env_logger = { workspace = true }

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
             order_items_provider,
         ),
     ]);
-    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register));
+    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
 
     let new_state = ctx
         .state()
@@ -194,7 +194,7 @@ pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL
     ctx.register_catalog(&wren_mdl.manifest.catalog, Arc::new(catalog));
 
     for model in wren_mdl.manifest.models.iter() {
-        let table = WrenDataSource::new(Arc::clone(model));
+        let table = WrenDataSource::new(Arc::clone(model))?;
         ctx.register_table(
             format!(
                 "{}.{}.{}",
@@ -211,9 +211,9 @@ struct WrenDataSource {
 }
 
 impl WrenDataSource {
-    pub fn new(model: Arc<Model>) -> Self {
-        let schema = create_schema(model.get_physical_columns());
-        Self { schema }
+    pub fn new(model: Arc<Model>) -> Result<Self> {
+        let schema = create_schema(model.get_physical_columns())?;
+        Ok(Self { schema })
     }
 }
 

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -185,7 +185,10 @@ fn init_manifest() -> Manifest {
         .build()
 }
 
-pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) -> Result<()> {
+pub async fn register_table_with_mdl(
+    ctx: &SessionContext,
+    wren_mdl: Arc<WrenMDL>,
+) -> Result<()> {
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
 

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -2,8 +2,8 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow_schema::SchemaRef;
 use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::catalog::schema::MemorySchemaProvider;
 use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
 use datafusion::datasource::{TableProvider, TableType};

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -86,7 +86,8 @@ async fn main() -> Result<()> {
             order_items_provider,
         ),
     ]);
-    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
+    let analyzed_mdl =
+        Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
 
     let new_state = ctx
         .state()
@@ -99,7 +100,7 @@ async fn main() -> Result<()> {
         ))))
         // There is some conflict with optimize_projections. Disable optimization rule temporarily,
         .with_optimizer_rules(vec![]);
-    register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await;
+    register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await?;
     let new_ctx = SessionContext::new_with_state(new_state);
     let sql = "select * from wrenai.default.order_items";
     // create a plan to run a SQL query
@@ -184,7 +185,7 @@ fn init_manifest() -> Manifest {
         .build()
 }
 
-pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) {
+pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) -> Result<()> {
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
 
@@ -204,6 +205,7 @@ pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL
         )
         .unwrap();
     }
+    Ok(())
 }
 
 struct WrenDataSource {

--- a/wren-modeling-rs/wren-example/examples/plan-sql.rs
+++ b/wren-modeling-rs/wren-example/examples/plan-sql.rs
@@ -8,7 +8,7 @@ use wren_core::mdl::{transform_sql, AnalyzedWrenMDL};
 #[tokio::main]
 async fn main() -> datafusion::common::Result<()> {
     let manifest = init_manifest();
-    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest));
+    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
 
     let sql = "select * from wrenai.default.order_items_model";
     println!("Original SQL: \n{}", sql);

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -83,14 +83,15 @@ async fn main() -> Result<()> {
             order_items_provider,
         ),
     ]);
-    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
+    let analyzed_mdl =
+        Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
 
     let transformed = transform_sql(
         Arc::clone(&analyzed_mdl),
         "select totalprice from wrenai.default.orders",
     )
     .unwrap();
-    register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await;
+    register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await?;
     let df = ctx.sql(&transformed).await?;
     df.show().await?;
     Ok(())
@@ -184,7 +185,10 @@ fn init_manifest() -> Manifest {
         .build()
 }
 
-pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) -> Result<()>{
+pub async fn register_table_with_mdl(
+    ctx: &SessionContext,
+    wren_mdl: Arc<WrenMDL>,
+) -> Result<()> {
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
 

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<()> {
             order_items_provider,
         ),
     ]);
-    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register));
+    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
 
     let transformed = transform_sql(
         Arc::clone(&analyzed_mdl),
@@ -184,7 +184,7 @@ fn init_manifest() -> Manifest {
         .build()
 }
 
-pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) {
+pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) -> Result<()>{
     let catalog = MemoryCatalogProvider::new();
     let schema = MemorySchemaProvider::new();
 
@@ -194,16 +194,16 @@ pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL
     ctx.register_catalog(&wren_mdl.manifest.catalog, Arc::new(catalog));
 
     for model in wren_mdl.manifest.models.iter() {
-        let table = WrenDataSource::new(Arc::clone(model));
+        let table = WrenDataSource::new(Arc::clone(model))?;
         ctx.register_table(
             format!(
                 "{}.{}.{}",
                 &wren_mdl.manifest.catalog, &wren_mdl.manifest.schema, &model.name
             ),
             Arc::new(table),
-        )
-        .unwrap();
+        )?;
     }
+    Ok(())
 }
 
 struct WrenDataSource {
@@ -211,9 +211,9 @@ struct WrenDataSource {
 }
 
 impl WrenDataSource {
-    pub fn new(model: Arc<Model>) -> Self {
-        let schema = create_schema(model.get_physical_columns());
-        Self { schema }
+    pub fn new(model: Arc<Model>) -> Result<Self> {
+        let schema = create_schema(model.get_physical_columns())?;
+        Ok(Self { schema })
     }
 }
 

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -1,0 +1,244 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::schema::MemorySchemaProvider;
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider};
+use datafusion::datasource::{TableProvider, TableType};
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion::logical_expr::Expr;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::prelude::{CsvReadOptions, SessionContext};
+
+use wren_core::logical_plan::utils::create_schema;
+use wren_core::mdl::builder::{
+    ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder,
+};
+use wren_core::mdl::manifest::{JoinType, Manifest, Model};
+use wren_core::mdl::{transform_sql, AnalyzedWrenMDL, WrenMDL};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let manifest = init_manifest();
+
+    // register the table
+    let ctx = SessionContext::new();
+    ctx.register_csv(
+        "orders",
+        "sqllogictest/tests/resources/ecommerce/orders.csv",
+        CsvReadOptions::new(),
+    )
+    .await?;
+    let provider = ctx
+        .catalog("datafusion")
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("orders")
+        .await?
+        .unwrap();
+
+    ctx.register_csv(
+        "customers",
+        "sqllogictest/tests/resources/ecommerce/customers.csv",
+        CsvReadOptions::new(),
+    )
+    .await?;
+    let customers_provider = ctx
+        .catalog("datafusion")
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("customers")
+        .await?
+        .unwrap();
+
+    ctx.register_csv(
+        "order_items",
+        "sqllogictest/tests/resources/ecommerce/order_items.csv",
+        CsvReadOptions::new(),
+    )
+    .await?;
+    let order_items_provider = ctx
+        .catalog("datafusion")
+        .unwrap()
+        .schema("public")
+        .unwrap()
+        .table("order_items")
+        .await?
+        .unwrap();
+
+    let register = HashMap::from([
+        ("datafusion.public.orders".to_string(), provider),
+        (
+            "datafusion.public.customers".to_string(),
+            customers_provider,
+        ),
+        (
+            "datafusion.public.order_items".to_string(),
+            order_items_provider,
+        ),
+    ]);
+    let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register));
+
+    let transformed = transform_sql(
+        Arc::clone(&analyzed_mdl),
+        "select totalprice from wrenai.default.orders",
+    )
+    .unwrap();
+    register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await;
+    let df = ctx.sql(&transformed).await?;
+    df.show().await?;
+    Ok(())
+}
+
+fn init_manifest() -> Manifest {
+    ManifestBuilder::new()
+        .model(
+            ModelBuilder::new("customers")
+                .table_reference("datafusion.public.customers")
+                .column(ColumnBuilder::new("city", "varchar").build())
+                .column(ColumnBuilder::new("id", "varchar").build())
+                .column(ColumnBuilder::new("state", "varchar").build())
+                .primary_key("id")
+                .build(),
+        )
+        .model(
+            ModelBuilder::new("order_items")
+                .table_reference("datafusion.public.order_items")
+                .column(ColumnBuilder::new("freight_value", "double").build())
+                .column(ColumnBuilder::new("id", "bigint").build())
+                .column(ColumnBuilder::new("item_number", "bigint").build())
+                .column(ColumnBuilder::new("order_id", "varchar").build())
+                .column(ColumnBuilder::new("price", "double").build())
+                .column(ColumnBuilder::new("product_id", "varchar").build())
+                .column(ColumnBuilder::new("shipping_limit_date", "varchar").build())
+                .column(
+                    ColumnBuilder::new("orders", "orders")
+                        .relationship("orders_order_items")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new("customer_state", "varchar")
+                        .calculated(true)
+                        .expression("orders.customers.state")
+                        .build(),
+                )
+                .primary_key("id")
+                .build(),
+        )
+        .model(
+            ModelBuilder::new("orders")
+                .table_reference("datafusion.public.orders")
+                .column(ColumnBuilder::new("approved_timestamp", "varchar").build())
+                .column(ColumnBuilder::new("customer_id", "varchar").build())
+                .column(ColumnBuilder::new("delivered_carrier_date", "varchar").build())
+                .column(ColumnBuilder::new("estimated_delivery_date", "varchar").build())
+                .column(ColumnBuilder::new("order_id", "varchar").build())
+                .column(ColumnBuilder::new("purchase_timestamp", "varchar").build())
+                .column(
+                    ColumnBuilder::new("order_items", "order_items")
+                        .relationship("orders_order_items")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new("totalprice", "double")
+                        .expression("sum(order_items.price)")
+                        .calculated(true)
+                        .build(),
+                )
+                .primary_key("order_id")
+                .column(
+                    ColumnBuilder::new("customers", "customers")
+                        .relationship("orders_customer")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new("customer_state", "varchar")
+                        .calculated(true)
+                        .expression("customers.state")
+                        .build(),
+                )
+                .build(),
+        )
+        .relationship(
+            RelationshipBuilder::new("orders_customer")
+                .model("orders")
+                .model("customers")
+                .join_type(JoinType::ManyToOne)
+                .condition("orders.customer_id = customers.id")
+                .build(),
+        )
+        .relationship(
+            RelationshipBuilder::new("orders_order_items")
+                .model("orders")
+                .model("order_items")
+                .join_type(JoinType::ManyToOne)
+                .condition("orders.order_id = order_items.order_id")
+                .build(),
+        )
+        .build()
+}
+
+pub async fn register_table_with_mdl(ctx: &SessionContext, wren_mdl: Arc<WrenMDL>) {
+    let catalog = MemoryCatalogProvider::new();
+    let schema = MemorySchemaProvider::new();
+
+    catalog
+        .register_schema(&wren_mdl.manifest.schema, Arc::new(schema))
+        .unwrap();
+    ctx.register_catalog(&wren_mdl.manifest.catalog, Arc::new(catalog));
+
+    for model in wren_mdl.manifest.models.iter() {
+        let table = WrenDataSource::new(Arc::clone(model));
+        ctx.register_table(
+            format!(
+                "{}.{}.{}",
+                &wren_mdl.manifest.catalog, &wren_mdl.manifest.schema, &model.name
+            ),
+            Arc::new(table),
+        )
+        .unwrap();
+    }
+}
+
+struct WrenDataSource {
+    schema: SchemaRef,
+}
+
+impl WrenDataSource {
+    pub fn new(model: Arc<Model>) -> Self {
+        let schema = create_schema(model.get_physical_columns());
+        Self { schema }
+    }
+}
+
+#[async_trait]
+impl TableProvider for WrenDataSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::View
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        _projection: Option<&Vec<usize>>,
+        // filters and limit can be used here to inject some push-down operations if needed
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        unreachable!("WrenDataSource should be replaced before physical planning")
+    }
+}


### PR DESCRIPTION
# Description
- Upgrade Datafusion to v39.0.0
- Introduce the TO_MANAY calculation
- Enhance the error handling: stop to panic and throw DataFusionError instead.
- Fix and enhance the testing

# Known issue
- The generated logical plan can't apply to DataFusion directly. Currently, I use a workaround to run the SQL by DataFusion.
   - Generated the SQL by `WrenMDL#transform_sql`
   - Execute the generated SQL by DataFusion.