### PR TITLE
Fix the complex calculated field and rename the default schema

### DIFF
--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -438,12 +438,12 @@ mod test {
         // [RemoveWrenPrefixRule] only remove the prefix of identifiers, so that the table name in
         // the expected result will have the schema prefix.
         let tests = vec![
-            ("select wrenai.default.a.c1, wrenai.default.a.c2 from wrenai.default.a",
-             r#"SELECT a.c1, a.c2 FROM wrenai."default".a"#),
-            ("select wrenai.default.a.c1, wrenai.default.a.c2 from wrenai.default.a where wrenai.default.a.c1 = 1",
-                 r#"SELECT a.c1, a.c2 FROM wrenai."default".a WHERE (a.c1 = 1)"#),
-            ("select wrenai.default.a.c1 + 1 from wrenai.default.a",
-            r#"SELECT (a.c1 + 1) FROM wrenai."default".a"#)
+            ("select wrenai.public.a.c1, wrenai.public.a.c2 from wrenai.public.a",
+             r#"SELECT a.c1, a.c2 FROM wrenai.public.a"#),
+            ("select wrenai.public.a.c1, wrenai.public.a.c2 from wrenai.public.a where wrenai.public.a.c1 = 1",
+                 r#"SELECT a.c1, a.c2 FROM wrenai.public.a WHERE (a.c1 = 1)"#),
+            ("select wrenai.public.a.c1 + 1 from wrenai.public.a",
+            r#"SELECT (a.c1 + 1) FROM wrenai.public.a"#)
         ];
 
         let context_provider = WrenContextProvider::new(&analyzed_wren_mdl.wren_mdl)?;

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -195,8 +195,10 @@ fn create_schema(columns: Vec<Arc<Column>>) -> Result<SchemaRef> {
                     unimplemented!("Unsupported data type: {}", column.r#type)
                 };
                 vec![Field::new(&column.name, data_type, column.no_null)]
-            } else {
+            } else if let Ok(idents) =
                 utils::collect_identifiers(column.expression.as_ref().unwrap())
+            {
+                idents
                     .iter()
                     .map(|c| {
                         // we don't know the data type or nullable of the remote table,
@@ -204,6 +206,11 @@ fn create_schema(columns: Vec<Arc<Column>>) -> Result<SchemaRef> {
                         Field::new(&c.name, DataType::Int8, true)
                     })
                     .collect()
+            } else {
+                panic!(
+                    "Failed to collect identifiers from expression: {}",
+                    column.expression.as_ref().unwrap()
+                );
             }
         })
         .collect();

--- a/wren-modeling-rs/core/src/mdl/builder.rs
+++ b/wren-modeling-rs/core/src/mdl/builder.rs
@@ -21,7 +21,7 @@ impl ManifestBuilder {
         Self {
             manifest: Manifest {
                 catalog: "wrenai".to_string(),
-                schema: "default".to_string(),
+                schema: "public".to_string(),
                 models: vec![],
                 relationships: vec![],
                 metrics: vec![],
@@ -150,6 +150,14 @@ impl ColumnBuilder {
                 properties: vec![],
             },
         }
+    }
+
+    pub fn new_calculated(name: &str, r#type: &str) -> Self {
+        Self::new(name, r#type).calculated(true)
+    }
+
+    pub fn new_relationship(name: &str, r#type: &str, relationship: &str) -> Self {
+        Self::new(name, r#type).relationship(relationship)
     }
 
     pub fn relationship(mut self, relationship: &str) -> Self {
@@ -481,7 +489,7 @@ mod test {
 
         let expected = crate::mdl::builder::ManifestBuilder::new()
             .catalog("wrenai")
-            .schema("default")
+            .schema("public")
             .model(model)
             .relationship(relationship)
             .metric(metric)

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -258,13 +258,13 @@ mod tests {
     #[test]
     fn test_collect_identifiers() -> Result<()> {
         let expr = "orders.orderkey + orders.custkey";
-        let result = super::collect_identifiers(&expr.to_string())?;
+        let result = super::collect_identifiers(&expr)?;
         assert_eq!(result.len(), 2);
         assert!(result.contains(&super::Column::new_unqualified("orders.orderkey")));
         assert!(result.contains(&super::Column::new_unqualified("orders.custkey")));
 
         let expr = "customers.state || order_id";
-        let result = super::collect_identifiers(&expr.to_string())?;
+        let result = super::collect_identifiers(&expr)?;
         assert_eq!(result.len(), 2);
         assert!(result.contains(&super::Column::new_unqualified("customers.state")));
         assert!(result.contains(&super::Column::new_unqualified("order_id")));

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -258,13 +258,13 @@ mod tests {
     #[test]
     fn test_collect_identifiers() -> Result<()> {
         let expr = "orders.orderkey + orders.custkey";
-        let result = super::collect_identifiers(&expr)?;
+        let result = super::collect_identifiers(expr)?;
         assert_eq!(result.len(), 2);
         assert!(result.contains(&super::Column::new_unqualified("orders.orderkey")));
         assert!(result.contains(&super::Column::new_unqualified("orders.custkey")));
 
         let expr = "customers.state || order_id";
-        let result = super::collect_identifiers(&expr)?;
+        let result = super::collect_identifiers(expr)?;
         assert_eq!(result.len(), 2);
         assert!(result.contains(&super::Column::new_unqualified("customers.state")));
         assert!(result.contains(&super::Column::new_unqualified("order_id")));

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -138,6 +138,11 @@ async fn register_ecommerce_mdl(
                 .column(ColumnBuilder::new("city", "varchar").build())
                 .column(ColumnBuilder::new("id", "varchar").build())
                 .column(ColumnBuilder::new("state", "varchar").build())
+                .column(
+                    ColumnBuilder::new_calculated("city_state", "varchar")
+                        .expression("city || ' ' || state")
+                        .build(),
+                )
                 .primary_key("id")
                 .build(),
         )
@@ -152,13 +157,15 @@ async fn register_ecommerce_mdl(
                 .column(ColumnBuilder::new("product_id", "varchar").build())
                 .column(ColumnBuilder::new("shipping_limit_date", "varchar").build())
                 .column(
-                    ColumnBuilder::new("orders", "orders")
-                        .relationship("orders_order_items")
-                        .build(),
+                    ColumnBuilder::new_relationship(
+                        "orders",
+                        "orders",
+                        "orders_order_items",
+                    )
+                    .build(),
                 )
                 .column(
-                    ColumnBuilder::new("customer_state", "varchar")
-                        .calculated(true)
+                    ColumnBuilder::new_calculated("customer_state", "varchar")
                         .expression("orders.customers.state")
                         .build(),
                 )
@@ -175,25 +182,34 @@ async fn register_ecommerce_mdl(
                 .column(ColumnBuilder::new("order_id", "varchar").build())
                 .column(ColumnBuilder::new("purchase_timestamp", "varchar").build())
                 .column(
-                    ColumnBuilder::new("customers", "customers")
-                        .relationship("orders_customer")
-                        .build(),
+                    ColumnBuilder::new_relationship(
+                        "customers",
+                        "customers",
+                        "orders_customer",
+                    )
+                    .build(),
                 )
                 .column(
-                    ColumnBuilder::new("customer_state", "varchar")
-                        .calculated(true)
+                    ColumnBuilder::new_calculated("customer_state", "varchar")
                         .expression("customers.state")
                         .build(),
                 )
                 .column(
-                    ColumnBuilder::new("order_items", "order_items")
-                        .relationship("orders_order_items")
+                    ColumnBuilder::new_calculated("customer_state_order_id", "varchar")
+                        .expression("customers.state || ' ' || order_id")
                         .build(),
                 )
                 .column(
-                    ColumnBuilder::new("totalprice", "double")
+                    ColumnBuilder::new_relationship(
+                        "order_items",
+                        "order_items",
+                        "orders_order_items",
+                    )
+                    .build(),
+                )
+                .column(
+                    ColumnBuilder::new_calculated("totalprice", "double")
                         .expression("sum(order_items.price)")
-                        .calculated(true)
                         .build(),
                 )
                 .primary_key("order_id")

--- a/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
@@ -1,28 +1,28 @@
 statement ok
-SELECT * from wrenai.default.orders
+SELECT * from wrenai.public.orders
 
 statement ok
-select cast(freight_value as int) + cast(price as int) from wrenai.default.order_items
+select cast(freight_value as int) + cast(price as int) from wrenai.public.order_items
 
 statement ok
-select product_id from wrenai.default.order_items where cast(freight_value as double) > 10
+select product_id from wrenai.public.order_items where cast(freight_value as double) > 10
 
 statement ok
-select * from wrenai.default.order_items;
+select * from wrenai.public.order_items;
 
 statement ok
-select * from wrenai.default.customers;
+select * from wrenai.public.customers;
 
 statement ok
-select count(*) from wrenai.default.order_items;
+select count(*) from wrenai.public.order_items;
 
 # check the count of order_items won't be increased by the relationship calculation
 query B
-select cnt1 = cnt2 from (select count(*) as cnt1 from (select customer_state from  wrenai.default.order_items)), (select count(*) as cnt2 from datafusion.public.order_items) limit 1;
+select cnt1 = cnt2 from (select count(*) as cnt1 from (select customer_state from  wrenai.public.order_items)), (select count(*) as cnt2 from datafusion.public.order_items) limit 1;
 ----
 true
 
 query B
-select actual = expected from (select totalprice as actual from wrenai.default.orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'), (select sum(price) as expected from datafusion.public.order_items where order_id = '76754c0e642c8f99a8c3fcb8a14ac700') limit 1;
+select actual = expected from (select totalprice as actual from wrenai.public.orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'), (select sum(price) as expected from datafusion.public.order_items where order_id = '76754c0e642c8f99a8c3fcb8a14ac700') limit 1;
 ----
 true

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -102,7 +102,7 @@ async fn main() -> Result<()> {
         .with_optimizer_rules(vec![]);
     register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await?;
     let new_ctx = SessionContext::new_with_state(new_state);
-    let sql = "select * from wrenai.default.order_items";
+    let sql = "select * from wrenai.public.order_items";
     // create a plan to run a SQL query
     let df = new_ctx.sql(sql).await?;
     df.show().await?;

--- a/wren-modeling-rs/wren-example/examples/plan-sql.rs
+++ b/wren-modeling-rs/wren-example/examples/plan-sql.rs
@@ -10,7 +10,7 @@ async fn main() -> datafusion::common::Result<()> {
     let manifest = init_manifest();
     let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
 
-    let sql = "select * from wrenai.default.order_items_model";
+    let sql = "select * from wrenai.public.order_items_model";
     println!("Original SQL: \n{}", sql);
     let sql = transform_sql(analyzed_mdl, sql).unwrap();
     println!("Wren engine generated SQL: \n{}", sql);

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
 
     let transformed = transform_sql(
         Arc::clone(&analyzed_mdl),
-        "select totalprice from wrenai.default.orders",
+        "select totalprice from wrenai.public.orders",
     )
     .unwrap();
     register_table_with_mdl(&ctx, Arc::clone(&analyzed_mdl.wren_mdl)).await?;


### PR DESCRIPTION
# Changed
- Rename the default schema from `default` to `public` because the `default` is a SQL reserved word.
- Fix the calculation expression for the relationship expression and normal expression (e.g. `a.b.c1 + a1`)
- Enhance the testing for relationship