### PR TITLE
Add node location info for SQL analysis result

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalysis.java
@@ -14,23 +14,25 @@
 
 package io.wren.base.sqlrewrite.analyzer.decisionpoint;
 
+import io.trino.sql.tree.NodeLocation;
+
 import static java.util.Objects.requireNonNull;
 
 public abstract class FilterAnalysis
 {
-    public static FilterAnalysis and(FilterAnalysis left, FilterAnalysis right)
+    public static FilterAnalysis and(FilterAnalysis left, FilterAnalysis right, NodeLocation nodeLocation)
     {
-        return new LogicalAnalysis(Type.AND, left, right);
+        return new LogicalAnalysis(Type.AND, left, right, nodeLocation);
     }
 
-    public static FilterAnalysis or(FilterAnalysis left, FilterAnalysis right)
+    public static FilterAnalysis or(FilterAnalysis left, FilterAnalysis right, NodeLocation nodeLocation)
     {
-        return new LogicalAnalysis(Type.OR, left, right);
+        return new LogicalAnalysis(Type.OR, left, right, nodeLocation);
     }
 
-    public static FilterAnalysis expression(String node)
+    public static FilterAnalysis expression(String node, NodeLocation nodeLocation)
     {
-        return new ExpressionAnalysis(node);
+        return new ExpressionAnalysis(node, nodeLocation);
     }
 
     public enum Type
@@ -41,15 +43,22 @@ public abstract class FilterAnalysis
     }
 
     private final Type type;
+    private final NodeLocation nodeLocation;
 
-    public FilterAnalysis(Type type)
+    public FilterAnalysis(Type type, NodeLocation nodeLocation)
     {
         this.type = requireNonNull(type, "type is null");
+        this.nodeLocation = nodeLocation;
     }
 
     public Type getType()
     {
         return type;
+    }
+
+    public NodeLocation getNodeLocation()
+    {
+        return nodeLocation;
     }
 
     public static class LogicalAnalysis
@@ -58,9 +67,9 @@ public abstract class FilterAnalysis
         private final FilterAnalysis left;
         private final FilterAnalysis right;
 
-        public LogicalAnalysis(Type type, FilterAnalysis left, FilterAnalysis right)
+        public LogicalAnalysis(Type type, FilterAnalysis left, FilterAnalysis right, NodeLocation nodeLocation)
         {
-            super(type);
+            super(type, nodeLocation);
             this.left = requireNonNull(left, "left is null");
             this.right = requireNonNull(right, "right is null");
         }
@@ -81,9 +90,9 @@ public abstract class FilterAnalysis
     {
         private final String node;
 
-        public ExpressionAnalysis(String node)
+        public ExpressionAnalysis(String node, NodeLocation nodeLocation)
         {
-            super(Type.EXPR);
+            super(Type.EXPR, nodeLocation);
             this.node = requireNonNull(node, "node is null");
         }
 

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
@@ -42,7 +42,7 @@ public class FilterAnalyzer
             if (node instanceof LogicalExpression) {
                 return process(node, context);
             }
-            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT));
+            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null));
         }
 
         @Override
@@ -50,13 +50,13 @@ public class FilterAnalyzer
         {
             if (parent == null || parent instanceof LogicalExpression) {
                 if (node.getOperator().equals(LogicalExpression.Operator.AND)) {
-                    return FilterAnalysis.and(process(node.getChildren().get(0), node), process(node.getChildren().get(1), node));
+                    return FilterAnalysis.and(process(node.getChildren().get(0), node), process(node.getChildren().get(1), node), node.getLocation().orElse(null));
                 }
                 if (node.getOperator().equals(LogicalExpression.Operator.OR)) {
-                    return FilterAnalysis.or(process(node.getChildren().get(0), node), process(node.getChildren().get(1), node));
+                    return FilterAnalysis.or(process(node.getChildren().get(0), node), process(node.getChildren().get(1), node), node.getLocation().orElse(null));
                 }
             }
-            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT));
+            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null));
         }
     }
 }

--- a/wren-main/src/main/java/io/wren/main/web/dto/NodeLocationDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/NodeLocationDto.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.main.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class NodeLocationDto
+{
+    public static NodeLocationDto nodeLocationDto(int line, int column)
+    {
+        return new NodeLocationDto(line, column);
+    }
+
+    private final int line;
+    private final int column;
+
+    @JsonCreator
+    public NodeLocationDto(
+            @JsonProperty int line,
+            @JsonProperty int column)
+    {
+        this.line = line;
+        this.column = column;
+    }
+
+    @JsonProperty
+    public int getLine()
+    {
+        return line;
+    }
+
+    @JsonProperty
+    public int getColumn()
+    {
+        return column;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeLocationDto that = (NodeLocationDto) o;
+        return line == that.line && column == that.column;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(line, column);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "NodeLocationDto{" +
+                "line=" + line +
+                ", column=" + column +
+                '}';
+    }
+}

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -29,7 +29,7 @@ public class QueryAnalysisDto
     private List<ColumnAnalysisDto> selectItems;
     private RelationAnalysisDto relation;
     private FilterAnalysisDto filter;
-    private List<List<String>> groupByKeys;
+    private List<List<GroupByKeyDto>> groupByKeys;
     private List<SortItemAnalysisDto> sortings;
     private boolean isSubqueryOrCte;
 
@@ -38,7 +38,7 @@ public class QueryAnalysisDto
             List<ColumnAnalysisDto> selectItems,
             RelationAnalysisDto relation,
             FilterAnalysisDto filter,
-            List<List<String>> groupByKeys,
+            List<List<GroupByKeyDto>> groupByKeys,
             List<SortItemAnalysisDto> sortings,
             boolean isSubqueryOrCte)
     {
@@ -69,7 +69,7 @@ public class QueryAnalysisDto
     }
 
     @JsonProperty
-    public List<List<String>> getGroupByKeys()
+    public List<List<GroupByKeyDto>> getGroupByKeys()
     {
         return groupByKeys;
     }
@@ -92,13 +92,15 @@ public class QueryAnalysisDto
         private Optional<String> alias;
         private String expression;
         private Map<String, String> properties;
+        private NodeLocationDto nodeLocation;
 
         @JsonCreator
-        public ColumnAnalysisDto(Optional<String> alias, String expression, Map<String, String> properties)
+        public ColumnAnalysisDto(Optional<String> alias, String expression, Map<String, String> properties, NodeLocationDto nodeLocation)
         {
             this.alias = alias;
             this.expression = expression;
             this.properties = properties;
+            this.nodeLocation = nodeLocation;
         }
 
         @JsonProperty
@@ -118,6 +120,12 @@ public class QueryAnalysisDto
         {
             return properties;
         }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -131,6 +139,7 @@ public class QueryAnalysisDto
         private String tableName;
         private List<QueryAnalysisDto> body;
         private List<ExprSourceDto> exprSources;
+        private NodeLocationDto nodeLocation;
 
         @JsonCreator
         public RelationAnalysisDto(
@@ -141,7 +150,8 @@ public class QueryAnalysisDto
                 String criteria,
                 String tableName,
                 List<QueryAnalysisDto> body,
-                List<ExprSourceDto> exprSources)
+                List<ExprSourceDto> exprSources,
+                NodeLocationDto nodeLocation)
         {
             this.type = type;
             this.alias = alias;
@@ -151,6 +161,7 @@ public class QueryAnalysisDto
             this.tableName = tableName;
             this.body = body;
             this.exprSources = exprSources;
+            this.nodeLocation = nodeLocation;
         }
 
         @JsonProperty
@@ -200,6 +211,12 @@ public class QueryAnalysisDto
         {
             return exprSources;
         }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -209,14 +226,16 @@ public class QueryAnalysisDto
         private FilterAnalysisDto left;
         private FilterAnalysisDto right;
         private String node;
+        private NodeLocationDto nodeLocation;
 
         @JsonCreator
-        public FilterAnalysisDto(String type, FilterAnalysisDto left, FilterAnalysisDto right, String node)
+        public FilterAnalysisDto(String type, FilterAnalysisDto left, FilterAnalysisDto right, String node, NodeLocationDto nodeLocation)
         {
             this.type = type;
             this.left = left;
             this.right = right;
             this.node = node;
+            this.nodeLocation = nodeLocation;
         }
 
         @JsonProperty
@@ -242,6 +261,12 @@ public class QueryAnalysisDto
         {
             return node;
         }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -249,12 +274,14 @@ public class QueryAnalysisDto
     {
         private String expression;
         private String ordering;
+        private NodeLocationDto nodeLocation;
 
         @JsonCreator
-        public SortItemAnalysisDto(String expression, String ordering)
+        public SortItemAnalysisDto(String expression, String ordering, NodeLocationDto nodeLocation)
         {
             this.expression = expression;
             this.ordering = ordering;
+            this.nodeLocation = nodeLocation;
         }
 
         @JsonProperty
@@ -268,18 +295,26 @@ public class QueryAnalysisDto
         {
             return ordering;
         }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
     }
 
     public static class ExprSourceDto
     {
         private String expression;
         private String sourceDataset;
+        private NodeLocationDto nodeLocation;
 
         @JsonCreator
-        public ExprSourceDto(String expression, String sourceDataset)
+        public ExprSourceDto(String expression, String sourceDataset, NodeLocationDto nodeLocation)
         {
             this.expression = expression;
             this.sourceDataset = sourceDataset;
+            this.nodeLocation = nodeLocation;
         }
 
         @JsonProperty
@@ -292,6 +327,12 @@ public class QueryAnalysisDto
         public String getSourceDataset()
         {
             return sourceDataset;
+        }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
         }
 
         @Override
@@ -311,6 +352,61 @@ public class QueryAnalysisDto
         public int hashCode()
         {
             return Objects.hash(expression, sourceDataset);
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class GroupByKeyDto
+    {
+        private String expression;
+        private NodeLocationDto nodeLocation;
+
+        @JsonCreator
+        public GroupByKeyDto(String expression, NodeLocationDto nodeLocation)
+        {
+            this.expression = expression;
+            this.nodeLocation = nodeLocation;
+        }
+
+        @JsonProperty
+        public String getExpression()
+        {
+            return expression;
+        }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            GroupByKeyDto that = (GroupByKeyDto) o;
+            return Objects.equals(expression, that.expression) &&
+                    Objects.equals(nodeLocation, that.nodeLocation);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression, nodeLocation);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "GroupByKeyDto{" +
+                    "expression='" + expression + '\'' +
+                    ", nodeLocation=" + nodeLocation +
+                    '}';
         }
     }
 }


### PR DESCRIPTION
# Description
Add `nodeLocation` property for the SqlAnalysis result:
- `selectItems`
- `relation`
- `filter`
- `sortItem`
- `GroupByKey`
- `ExprSource`

## Example
### Input
```sql
SELECT custkey, name FROM customer ORDER BY 1 ASC, 2 DESC
```
### Result
```json
[
    {
       "selectItems":[
          {
             "alias":null,
             "expression":"custkey",
             "properties":{
                "includeMathematicalOperation":"false",
                "includeFunctionCall":"false"
             },
             "nodeLocation":{
                "line":1,
                "column":8
             }
          },
          {
             "alias":null,
             "expression":"name",
             "properties":{
                "includeMathematicalOperation":"false",
                "includeFunctionCall":"false"
             },
             "nodeLocation":{
                "line":1,
                "column":17
             }
          }
       ],
       "relation":{
          "type":"TABLE",
          "tableName":"customer",
          "nodeLocation":{
             "line":1,
             "column":27
          }
       },
       "groupByKeys":[
          
       ],
       "sortings":[
          {
             "expression":"custkey",
             "ordering":"ASCENDING",
             "nodeLocation":{
                "line":1,
                "column":45
             }
          },
          {
             "expression":"name",
             "ordering":"DESCENDING",
             "nodeLocation":{
                "line":1,
                "column":52
             }
          }
       ],
       "isSubqueryOrCte":false
    }
 ]
```