### PR TITLE
Add dry-plan

### DIFF
--- a/ibis-server/app/logger.py
+++ b/ibis-server/app/logger.py
@@ -19,15 +19,3 @@ def log_dto(f):
         return f(*args, **kwargs)
 
     return wrapper
-
-
-def log_rewritten(f):
-    logger = get_logger("app.mdl.rewriter")
-
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        rs = f(*args, **kwargs)
-        logger.debug(f"Rewritten SQL: {rs}")
-        return rs
-
-    return wrapper

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -1,21 +1,47 @@
 import httpx
 import orjson
+import sqlglot
+from model.data_source import DataSource
 
 from app.config import get_config
-from app.logger import log_rewritten
+from app.logger import get_logger
 
 wren_engine_endpoint = get_config().wren_engine_endpoint
 
+logger = get_logger("app.mdl.rewriter")
 
-@log_rewritten
-def rewrite(manifest_str: str, sql: str) -> str:
-    try:
-        r = httpx.request(
-            method="GET",
-            url=f"{wren_engine_endpoint}/v2/mdl/dry-plan",
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-            content=orjson.dumps({"manifestStr": manifest_str, "sql": sql}),
-        )
-        return r.text if r.status_code == httpx.codes.OK else r.raise_for_status()
-    except httpx.ConnectError as e:
-        raise ConnectionError(f"Can not connect to Wren Engine: {e}")
+
+class Rewriter:
+    def __init__(self, manifest_str: str, data_source: DataSource = None):
+        self.manifest_str = manifest_str
+        self.data_source = data_source
+
+    def rewrite(self, sql: str) -> str:
+        try:
+            r = httpx.request(
+                method="GET",
+                url=f"{wren_engine_endpoint}/v2/mdl/dry-plan",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                content=orjson.dumps({"manifestStr": self.manifest_str, "sql": sql}),
+            )
+            rewritten_sql = (
+                r.text if r.status_code == httpx.codes.OK else r.raise_for_status()
+            )
+            logger.debug(f"Rewritten SQL: {rewritten_sql}")
+            return (
+                rewritten_sql
+                if self.data_source is None
+                else self.transpile(rewritten_sql)
+            )
+        except httpx.ConnectError as e:
+            raise ConnectionError(f"Can not connect to Wren Engine: {e}")
+
+    def transpile(self, rewritten_sql: str) -> str:
+        transpiled_sql = sqlglot.transpile(
+            rewritten_sql, read="trino", write=self.data_source.name
+        )[0]
+        logger.debug(f"Translated SQL: {transpiled_sql}")
+        return transpiled_sql

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -43,8 +43,5 @@ class Rewriter:
         transpiled_sql = sqlglot.transpile(
             rewritten_sql, read="trino", write=self.data_source.name
         )[0]
-        transpiled_sql = sqlglot.parse_one(
-            transpiled_sql, dialect=self.data_source.name
-        ).sql(self.data_source.name)
         logger.debug(f"Translated SQL: {transpiled_sql}")
         return transpiled_sql

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -1,10 +1,10 @@
 import httpx
 import orjson
 import sqlglot
-from model.data_source import DataSource
 
 from app.config import get_config
 from app.logger import get_logger
+from app.model.data_source import DataSource
 
 wren_engine_endpoint = get_config().wren_engine_endpoint
 

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -43,5 +43,8 @@ class Rewriter:
         transpiled_sql = sqlglot.transpile(
             rewritten_sql, read="trino", write=self.data_source.name
         )[0]
+        transpiled_sql = sqlglot.parse_one(
+            transpiled_sql, dialect=self.data_source.name
+        ).sql(self.data_source.name)
         logger.debug(f"Translated SQL: {transpiled_sql}")
         return transpiled_sql

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -118,3 +118,8 @@ class ValidateDTO(BaseModel):
 class AnalyzeSQLDTO(BaseModel):
     manifest_str: str = manifest_str_field
     sql: str
+
+
+class DryPlanDTO(BaseModel):
+    manifest_str: str = manifest_str_field
+    sql: str

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -17,7 +17,7 @@ class Connector:
         self.manifest_str = manifest_str
 
     def query(self, sql: str, limit: int) -> pd.DataFrame:
-        rewritten_sql = Rewriter(self.manifest_str).rewrite(sql)
+        rewritten_sql = Rewriter(self.manifest_str, self.data_source).rewrite(sql)
         return (
             self.connection.sql(
                 rewritten_sql,
@@ -28,7 +28,7 @@ class Connector:
 
     def dry_run(self, sql: str) -> None:
         try:
-            rewritten_sql = Rewriter(self.manifest_str).rewrite(sql)
+            rewritten_sql = Rewriter(self.manifest_str, self.data_source).rewrite(sql)
             self.connection.sql(rewritten_sql)
         except Exception as e:
             raise QueryDryRunError(f"Exception: {type(e)}, message: {str(e)}")

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from app.mdl.rewriter import rewrite
+from app.mdl.rewriter import Rewriter
 from app.model import ConnectionInfo
 from app.model.data_source import DataSource
 
@@ -17,15 +17,19 @@ class Connector:
         self.manifest_str = manifest_str
 
     def query(self, sql: str, limit: int) -> pd.DataFrame:
-        rewritten_sql = rewrite(self.manifest_str, sql)
+        rewritten_sql = Rewriter(self.manifest_str).rewrite(sql)
         return (
-            self.connection.sql(rewritten_sql, dialect="trino").limit(limit).to_pandas()
+            self.connection.sql(
+                rewritten_sql,
+            )
+            .limit(limit)
+            .to_pandas()
         )
 
     def dry_run(self, sql: str) -> None:
         try:
-            rewritten_sql = rewrite(self.manifest_str, sql)
-            self.connection.sql(rewritten_sql, dialect="trino")
+            rewritten_sql = Rewriter(self.manifest_str).rewrite(sql)
+            self.connection.sql(rewritten_sql)
         except Exception as e:
             raise QueryDryRunError(f"Exception: {type(e)}, message: {str(e)}")
 

--- a/ibis-server/app/model/metadata/dto.py
+++ b/ibis-server/app/model/metadata/dto.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
@@ -70,7 +70,7 @@ class Column(BaseModel):
     type: str
     notNull: bool
     description: Optional[str] = None
-    properties: Optional[Dict[str, Any]] = None
+    properties: Optional[dict[str, Any]] = None
 
 
 class TableProperties(BaseModel):
@@ -81,7 +81,7 @@ class TableProperties(BaseModel):
 
 class Table(BaseModel):
     name: str  # unique table name (might contain schema name or catalog name as well)
-    columns: List[Column]
+    columns: list[Column]
     description: Optional[str] = None
     properties: TableProperties = None
     primaryKey: Optional[str] = None

--- a/ibis-server/app/routers/v2/ibis.py
+++ b/ibis-server/app/routers/v2/ibis.py
@@ -2,10 +2,10 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
-from mdl.rewriter import Rewriter
 
 from app.dependencies import verify_query_dto
 from app.logger import log_dto
+from app.mdl.rewriter import Rewriter
 from app.model import (
     DryPlanDTO,
     QueryDTO,

--- a/ibis-server/app/routers/v2/ibis.py
+++ b/ibis-server/app/routers/v2/ibis.py
@@ -2,10 +2,12 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
+from mdl.rewriter import Rewriter
 
 from app.dependencies import verify_query_dto
 from app.logger import log_dto
 from app.model import (
+    DryPlanDTO,
     QueryDTO,
     ValidateDTO,
 )
@@ -56,3 +58,15 @@ def get_table_list(data_source: DataSource, dto: MetadataDTO) -> list[Table]:
 def get_constraints(data_source: DataSource, dto: MetadataDTO) -> list[Constraint]:
     metadata = MetadataFactory(data_source, dto.connection_info)
     return metadata.get_constraints()
+
+
+@router.post("/dry-plan")
+@log_dto
+def dry_plan(dto: DryPlanDTO) -> str:
+    return Rewriter(dto.manifest_str).rewrite(dto.sql)
+
+
+@router.post("/{data_source}/dry-plan")
+@log_dto
+def dry_plan_for_data_source(data_source: DataSource, dto: DryPlanDTO) -> str:
+    return Rewriter(dto.manifest_str, data_source).rewrite(dto.sql)

--- a/ibis-server/poetry.lock
+++ b/ibis-server/poetry.lock
@@ -77,13 +77,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2024.6.2"
+version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
-    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
+    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
+    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
 ]
 
 [[package]]
@@ -3371,4 +3371,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "3b1f4a878b4b54136d5dc767159c762c0a6bdf1c8faad1238ab503946847afe7"
+content-hash = "bff93649a2869f08fdacf75e99986e05db9aa23483713838ac473f1ed4f2425f"

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -19,6 +19,7 @@ orjson = "3.10.3"
 pandas = "2.2.2"
 pymysql = "^1.1.1"
 clickhouse-connect = "0.7.15"
+sqlglot = ">=23.4,<25.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.2.0"

--- a/ibis-server/tests/routers/ibis/test_postgres.py
+++ b/ibis-server/tests/routers/ibis/test_postgres.py
@@ -409,3 +409,17 @@ class TestPostgres:
             json={"connectionInfo": connection_info},
         )
         assert response.status_code == 200
+
+    def test_dry_plan(self):
+        response = client.post(
+            url="/v2/ibis/postgres/dry-plan",
+            json={
+                "manifestStr": self.manifest_str,
+                "sql": 'SELECT orderkey, order_cust_key FROM "Orders" LIMIT 1',
+            },
+        )
+        assert response.status_code == 200
+        assert (
+            response.text
+            == '''"WITH \\"Orders\\" AS (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\" FROM (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\" FROM (SELECT o_orderkey AS \\"orderkey\\", o_custkey AS \\"custkey\\", o_orderstatus AS \\"orderstatus\\", o_totalprice AS \\"totalprice\\", o_orderdate AS \\"orderdate\\", CONCAT(o_orderkey, '_', o_custkey) AS \\"order_cust_key\\", CAST('2024-01-01T23:59:59' AS TIMESTAMP) AS \\"timestamp\\", CAST('2024-01-01T23:59:59' AS TIMESTAMPTZ) AS \\"timestamptz\\" FROM (SELECT * FROM public.orders) AS \\"Orders\\") AS \\"Orders\\") AS \\"Orders\\") SELECT orderkey, order_cust_key FROM \\"Orders\\" LIMIT 1"'''
+        )

--- a/ibis-server/tests/routers/test_ibis.py
+++ b/ibis-server/tests/routers/test_ibis.py
@@ -1,0 +1,40 @@
+import base64
+
+import orjson
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+manifest = {
+    "catalog": "my_catalog",
+    "schema": "my_schema",
+    "models": [
+        {
+            "name": "Orders",
+            "refSql": "select * from public.orders",
+            "columns": [
+                {"name": "orderkey", "expression": "o_orderkey", "type": "integer"}
+            ],
+            "primaryKey": "orderkey",
+        },
+    ],
+}
+
+manifest_str = base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
+
+
+def test_dry_plan():
+    response = client.post(
+        url="/v2/ibis/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT orderkey FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '''"WITH\\n  \\"Orders\\" AS (\\n   SELECT \\"Orders\\".\\"orderkey\\" \\"orderkey\\"\\n   FROM\\n     (\\n      SELECT \\"Orders\\".\\"orderkey\\" \\"orderkey\\"\\n      FROM\\n        (\\n         SELECT o_orderkey \\"orderkey\\"\\n         FROM\\n           (\\n            SELECT *\\n            FROM\\n              public.orders\\n         )  \\"Orders\\"\\n      )  \\"Orders\\"\\n   )  \\"Orders\\"\\n) \\nSELECT orderkey\\nFROM\\n  \\"Orders\\"\\nLIMIT 1\\n"'''
+    )


### PR DESCRIPTION
Add two APIs for the dry plan

One API only rewrites SQL with manifest
```
POST /v2/ibis/dry-plan
{
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInN......",
  "sql": "SELECT orderkey, order_cust_key FROM \"Orders\" LIMIT 1"
}
```
```
WITH
    "Orders" AS (
        SELECT
            "Orders"."orderkey" AS "orderkey",
            "Orders"."custkey" AS "custkey",
            "Orders"."order_cust_key" AS "order_cust_key"
        FROM
            (
                SELECT
                    "Orders"."orderkey" AS "orderkey",
                    "Orders"."custkey" AS "custkey",
                    "Orders"."order_cust_key" AS "order_cust_key"
                FROM
                    (
                        SELECT
                            o_orderkey AS "orderkey",
                            o_custkey AS "custkey",
                            CONCAT (o_orderkey, '_', o_custkey) AS "order_cust_key"
                        FROM
                            (
                                SELECT
                                    o_orderkey,
                                    o_custkey
                                FROM
                                    public.orders
                            ) AS "Orders"
                    ) AS "Orders"
            ) AS "Orders"
    )
SELECT
    orderkey,
    order_cust_key
FROM
    "Orders"
LIMIT
    1
```

Another API will rewrite SQL with manifest and transpile by data source dialect.
```
POST /v2/ibis/{data_source}/dry-plan
{
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInN......",
  "sql": "SELECT orderkey, order_cust_key FROM \"Orders\" LIMIT 1"
}
```
```
WITH
    "Orders" AS (
        SELECT
            "Orders"."orderkey" AS "orderkey",
            "Orders"."custkey" AS "custkey",
            "Orders"."order_cust_key" AS "order_cust_key"
        FROM
            (
                SELECT
                    "Orders"."orderkey" AS "orderkey",
                    "Orders"."custkey" AS "custkey",
                    "Orders"."order_cust_key" AS "order_cust_key"
                FROM
                    (
                        SELECT
                            o_orderkey AS "orderkey",
                            o_custkey AS "custkey",
                            CONCAT (o_orderkey, '_', o_custkey) AS "order_cust_key"
                        FROM
                            (
                                SELECT
                                    o_orderkey,
                                    o_custkey
                                FROM
                                    public.orders
                            ) AS "Orders"
                    ) AS "Orders"
            ) AS "Orders"
    )
SELECT
    orderkey,
    order_cust_key
FROM
    "Orders"
LIMIT
    1
```