### PR TITLE
Make ibis CI for each PR

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -2,8 +2,6 @@ name: ibis CI
 
 on:
   pull_request:
-    paths:
-      - 'ibis-server/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}


### PR DESCRIPTION
We're still consistently encountering an issue where JAVA or Rust code modifications affect the ibis-server, but this isn't being detected in the Pull Request CI.