### PR TITLE
Fix the alias join for Non-Clickhouse connector

### DIFF
--- a/ibis-server/tests/routers/ibis/test_clickhouse.py
+++ b/ibis-server/tests/routers/ibis/test_clickhouse.py
@@ -349,6 +349,19 @@ class TestClickHouse:
             "totalprice": "object",
         }
 
+    def test_query_alias_join(self, clickhouse: ClickHouseContainer):
+        connection_info = self.to_connection_info(clickhouse)
+        # ClickHouse does not support alias join
+        with pytest.raises(Exception):
+            client.post(
+                url=f"{self.base_url}/query",
+                json={
+                    "connectionInfo": connection_info,
+                    "manifestStr": self.manifest_str,
+                    "sql": 'SELECT orderstatus FROM ("Orders" o JOIN "Customer" c ON o.custkey = c.custkey) j1 LIMIT 1',
+                },
+            )
+
     def test_query_without_manifest(self, clickhouse: ClickHouseContainer):
         connection_info = self.to_connection_info(clickhouse)
         response = client.post(

--- a/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -697,7 +697,7 @@ public final class SqlFormatter
 
         private void processRelationSuffix(Relation relation, Integer indent)
         {
-            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation)) {
+            if ((relation instanceof AliasedRelation) || (relation instanceof SampledRelation) || (relation instanceof PatternRecognitionRelation) || (relation instanceof Join)) {
                 builder.append("( ");
                 process(relation, indent + 1);
                 append(indent, ")");

--- a/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -46,4 +46,26 @@ public class TestSqlFormatter
                 INNER JOIN c ON (a.x = c.z)
                 """, formattedSql);
     }
+
+    @Test
+    public void testFormatAliasJoin()
+    {
+        String sql = "SELECT * FROM (a JOIN b ON a.x = b.y) t1";
+        String formattedSql = SqlFormatter.formatSql(SQL_PARSER.createStatement(sql, new ParsingOptions()));
+        assertEquals("""
+                SELECT *
+                FROM
+                  ( a
+                   INNER JOIN b ON (a.x = b.y)) t1
+                """, formattedSql);
+        sql = "SELECT * FROM ((a JOIN b ON a.x = b.y) t1 join c on t1.x = c.y)";
+        formattedSql = SqlFormatter.formatSql(SQL_PARSER.createStatement(sql, new ParsingOptions()));
+        assertEquals("""
+                SELECT *
+                FROM
+                  ( a
+                   INNER JOIN b ON (a.x = b.y)) t1
+                INNER JOIN c ON (t1.x = c.y)
+                """, formattedSql);
+    }
 }

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -345,13 +345,25 @@ public class QueryAnalysisDto
                 return false;
             }
             ExprSourceDto that = (ExprSourceDto) o;
-            return Objects.equals(expression, that.expression) && Objects.equals(sourceDataset, that.sourceDataset);
+            return Objects.equals(expression, that.expression) &&
+                    Objects.equals(sourceDataset, that.sourceDataset)
+                    && Objects.equals(nodeLocation, that.nodeLocation);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(expression, sourceDataset);
+            return Objects.hash(expression, sourceDataset, nodeLocation);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ExprSourceDto{" +
+                    "expression='" + expression + '\'' +
+                    ", sourceDataset='" + sourceDataset + '\'' +
+                    ", nodeLocation=" + nodeLocation +
+                    '}';
         }
     }
 

--- a/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
@@ -153,8 +153,8 @@ public class TestAnalysisResource
         assertThat(result.get(0).getRelation().getRight().getNodeLocation()).isEqualTo(nodeLocationDto(1, 31));
         assertThat(result.get(0).getRelation().getCriteria()).isEqualTo("ON (c.custkey = o.custkey)");
         assertThat(Set.copyOf(result.get(0).getRelation().getExprSources()))
-                .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer", nodeLocationDto(1, 8)),
-                        new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders", nodeLocationDto(1, 8))));
+                .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer", nodeLocationDto(1, 43)),
+                        new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders", nodeLocationDto(1, 55))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT * FROM customer WHERE custkey = 1 OR (name = 'test' AND address = 'test')"));
         assertThat(result.size()).isEqualTo(1);

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -184,4 +184,18 @@ public class TestWrenWithDuckDB
                         column("custkey_call_concat", "varchar")));
         assertThat(queryResultDto.getData().size()).isEqualTo(100);
     }
+
+    @Test
+    public void testQueryJoinAliased()
+    {
+        QueryResultDto queryResultDto = query(manifest, "select totalprice from (Orders o join Customer c on o.custkey = c.custkey) join_relation limit 100");
+        assertThat(queryResultDto.getColumns())
+                .isEqualTo(List.of(column("totalprice", "DECIMAL(15,2)")));
+        assertThat(queryResultDto.getData().size()).isEqualTo(100);
+
+        queryResultDto = query(manifest, "select totalprice from ((Orders o join Customer c on o.custkey = c.custkey) j join Lineitem l on j.orderkey = l.orderkey) limit 100");
+        assertThat(queryResultDto.getColumns())
+                .isEqualTo(List.of(column("totalprice", "DECIMAL(15,2)")));
+        assertThat(queryResultDto.getData().size()).isEqualTo(100);
+    }
 }


### PR DESCRIPTION
# Description
Expect `Clickhouse`, the most data source support the alias join relation. However, we remove the brackets in #649. It will cause some problem when someone use alias join in other connector.

The followed SQL should be valid in non-clickhouse:
```sql
SELECT orderstatus FROM ("Orders" o JOIN "Customer" c ON o.custkey = c.custkey) j1 LIMIT 1
```
It's also hard to implement for sqlglot https://github.com/tobymao/sqlglot/issues/3735#issuecomment-2208028722
We needs to avoid this syntax ASAP.

# Changed
- Fix the SQL analysis tests in 2cd455d