### PR TITLE
Add data source Trino

### DIFF
--- a/ibis-server/.pre-commit-config.yaml
+++ b/ibis-server/.pre-commit-config.yaml
@@ -8,3 +8,12 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+  - repo: local
+    hooks:
+      - id: taplo
+        name: taplo
+        language: system
+        entry: taplo
+        args: [ "fmt" ]
+        types:
+          - toml

--- a/ibis-server/README.md
+++ b/ibis-server/README.md
@@ -78,6 +78,7 @@ just run
 - Install [poetry](https://github.com/python-poetry/poetry) with version 1.7.1: `curl -sSL https://install.python-poetry.org | python3 - --version 1.7.1`
 - Install [casey/just](https://github.com/casey/just)
 - Install [pre-commit](https://pre-commit.com) hooks: `just pre-commit-install`
+- Install [taplo](https://github.com/tamasfe/taplo) for TOML linting
 
 ### Modeling Core
 The modeling core is written in Rust and provides the Python adaptor. \

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -41,6 +41,10 @@ class QuerySnowflakeDTO(QueryDTO):
     connection_info: SnowflakeConnectionInfo = connection_info_field
 
 
+class QueryTrinoDTO(QueryDTO):
+    connection_info: ConnectionUrl | TrinoConnectionInfo = connection_info_field
+
+
 class BigQueryConnectionInfo(BaseModel):
     project_id: str
     dataset_id: str
@@ -97,6 +101,17 @@ class SnowflakeConnectionInfo(BaseModel):
     )  # Use `sf_schema` to avoid `schema` shadowing in BaseModel
 
 
+class TrinoConnectionInfo(BaseModel):
+    host: str
+    port: int = Field(default=8080)
+    catalog: str
+    trino_schema: str = Field(
+        alias="schema"
+    )  # Use `trino_schema` to avoid `schema` shadowing in BaseModel
+    user: str | None = None
+    password: str | None = None
+
+
 ConnectionInfo = (
     BigQueryConnectionInfo
     | ConnectionUrl
@@ -104,6 +119,7 @@ ConnectionInfo = (
     | MySqlConnectionInfo
     | PostgresConnectionInfo
     | SnowflakeConnectionInfo
+    | TrinoConnectionInfo
 )
 
 

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -24,7 +24,9 @@ from app.model import (
     QueryMySqlDTO,
     QueryPostgresDTO,
     QuerySnowflakeDTO,
+    QueryTrinoDTO,
     SnowflakeConnectionInfo,
+    TrinoConnectionInfo,
 )
 
 
@@ -35,6 +37,7 @@ class DataSource(StrEnum):
     mysql = auto()
     postgres = auto()
     snowflake = auto()
+    trino = auto()
 
     def get_connection(self, info: ConnectionInfo) -> BaseBackend:
         try:
@@ -56,6 +59,7 @@ class DataSourceExtension(Enum):
     mysql = QueryMySqlDTO
     postgres = QueryPostgresDTO
     snowflake = QuerySnowflakeDTO
+    trino = QueryTrinoDTO
 
     def __init__(self, dto: QueryDTO):
         self.dto = dto
@@ -135,4 +139,20 @@ class DataSourceExtension(Enum):
             account=info.account,
             database=info.database,
             schema=info.sf_schema,
+        )
+
+    @staticmethod
+    def get_trino_connection(
+        info: ConnectionUrl | TrinoConnectionInfo,
+    ) -> BaseBackend:
+        if hasattr(info, "connection_url"):
+            return ibis.connect(info.connection_url)
+
+        return ibis.trino.connect(
+            host=info.host,
+            port=info.port,
+            database=info.catalog,
+            schema=info.trino_schema,
+            user=info.user,
+            password=info.password,
         )

--- a/ibis-server/justfile
+++ b/ibis-server/justfile
@@ -53,3 +53,4 @@ format:
 fmt:
     poetry run ruff format .
     poetry run ruff check --fix .
+    taplo fmt

--- a/ibis-server/poetry.lock
+++ b/ibis-server/poetry.lock
@@ -1202,13 +1202,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "ibis-framework"
-version = "9.0.0"
+version = "9.1.0"
 description = "The portable Python dataframe library"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 files = [
-    {file = "ibis_framework-9.0.0-py3-none-any.whl", hash = "sha256:9ed9cb4f68fb528d2f5be2879937aa186ce54305eaf40112aa97b2ce4159bdae"},
-    {file = "ibis_framework-9.0.0.tar.gz", hash = "sha256:464c4f14febbc54625be80915df3b307bc0adc89b498ec2481b6c13358db321e"},
+    {file = "ibis_framework-9.1.0-py3-none-any.whl", hash = "sha256:f1f7438ed1746250fd81ede484e40539655d0372b452fd5929bfc2ed295f7c83"},
+    {file = "ibis_framework-9.1.0.tar.gz", hash = "sha256:b9612be4da0182a7b5526592d1e5155c92b3971073d03cad8bd7ee14bf015bb1"},
 ]
 
 [package.dependencies]
@@ -1231,20 +1231,21 @@ python-dateutil = ">=2.8.2,<3"
 pytz = ">=2022.7"
 rich = ">=12.4.4,<14"
 snowflake-connector-python = {version = ">=3.0.2,<3.3.0b1 || >3.3.0b1,<4", optional = true, markers = "extra == \"snowflake\""}
-sqlglot = ">=23.4,<23.13"
+sqlglot = ">=23.4,<25.2"
 toolz = ">=0.11,<1"
+trino = {version = ">=0.321,<1", optional = true, markers = "extra == \"trino\""}
 typing-extensions = ">=4.3.0,<5"
 
 [package.extras]
 bigquery = ["db-dtypes (>=0.3,<2)", "google-cloud-bigquery (>=3,<4)", "google-cloud-bigquery-storage (>=2,<3)", "pydata-google-auth (>=1.4.0,<2)"]
 clickhouse = ["clickhouse-connect[arrow,numpy,pandas] (>=0.5.23,<1)"]
 dask = ["dask[array,dataframe] (>=2022.9.1,<2024.3.0)", "packaging (>=21.3,<25)", "regex (>=2021.7.6)"]
-datafusion = ["datafusion (>=0.6,<37)"]
+datafusion = ["datafusion (>=0.6,<39)"]
 decompiler = ["black (>=22.1.0,<25)"]
 deltalake = ["deltalake (>=0.9.0,<1)"]
-druid = ["pydruid[sqlalchemy] (>=0.6.5,<1)"]
-duckdb = ["duckdb (>=0.8.1,<1)"]
-examples = ["fsspec (<2024.3.0)", "pins[gcs] (>=0.8.3,<1)"]
+druid = ["pydruid (>=0.6.7,<1)"]
+duckdb = ["duckdb (>=0.8.1,<2)"]
+examples = ["fsspec (<2024.6.1)", "pins[gcs] (>=0.8.3,<1)"]
 exasol = ["pyexasol[pandas] (>=0.25.2,<1)"]
 geospatial = ["geopandas (>=0.6,<1)", "shapely (>=2,<3)"]
 impala = ["impyla (>=0.17,<1)"]
@@ -2712,18 +2713,18 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "sqlglot"
-version = "23.12.2"
+version = "25.1.0"
 description = "An easily customizable SQL parser and transpiler"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sqlglot-23.12.2-py3-none-any.whl", hash = "sha256:5d63006a802482ab49a4f2e848cecb17edc4ba920395c1f226c8e7ad48fac874"},
-    {file = "sqlglot-23.12.2.tar.gz", hash = "sha256:3d887c3841d615fc97f02df73b441514ebe20576afffdf145019212a4c37e4a8"},
+    {file = "sqlglot-25.1.0-py3-none-any.whl", hash = "sha256:a9b23f0ea455ca3a7bc8daf4b404f9a19d4ab201b0220907e121f935c8a01013"},
+    {file = "sqlglot-25.1.0.tar.gz", hash = "sha256:1df2c5c0ef56961c4269a626414d3c349340f2aa329dffdb9d3f90f2eef50dbf"},
 ]
 
 [package.extras]
-dev = ["duckdb (>=0.6)", "maturin (>=1.4,<2.0)", "mypy", "pandas", "pandas-stubs", "pdoc", "pre-commit", "pyspark", "python-dateutil", "ruff (==0.3.2)", "types-python-dateutil", "typing-extensions"]
-rs = ["sqlglotrs (==0.2.0)"]
+dev = ["duckdb (>=0.6)", "maturin (>=1.4,<2.0)", "mypy", "pandas", "pandas-stubs", "pdoc", "pre-commit", "python-dateutil", "ruff (==0.4.3)", "types-python-dateutil", "typing-extensions"]
+rs = ["sqlglotrs (==0.2.6)"]
 
 [[package]]
 name = "starlette"
@@ -2810,6 +2811,30 @@ files = [
     {file = "toolz-0.12.1-py3-none-any.whl", hash = "sha256:d22731364c07d72eea0a0ad45bafb2c2937ab6fd38a3507bf55eae8744aa7d85"},
     {file = "toolz-0.12.1.tar.gz", hash = "sha256:ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d"},
 ]
+
+[[package]]
+name = "trino"
+version = "0.328.0"
+description = "Client for the Trino distributed SQL Engine"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "trino-0.328.0-py3-none-any.whl", hash = "sha256:5d4498356f894978478ae5574a503fe011254ac01bc19f786a3d3733eca8096f"},
+    {file = "trino-0.328.0.tar.gz", hash = "sha256:bd6454ef1c16cc630b4bccb73e975502b007ff9b96ddeb56711f6099ca41e3a2"},
+]
+
+[package.dependencies]
+python-dateutil = "*"
+pytz = "*"
+requests = ">=2.31.0"
+tzlocal = "*"
+
+[package.extras]
+all = ["requests-kerberos", "sqlalchemy (>=1.3)"]
+external-authentication-token-cache = ["keyring"]
+kerberos = ["requests-kerberos"]
+sqlalchemy = ["sqlalchemy (>=1.3)"]
+tests = ["black", "httpretty (<1.1)", "isort", "pre-commit", "pytest", "pytest-runner", "requests-kerberos", "sqlalchemy (>=1.3)"]
 
 [[package]]
 name = "typer"
@@ -3371,4 +3396,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "bff93649a2869f08fdacf75e99986e05db9aa23483713838ac473f1ed4f2425f"
+content-hash = "ca3ada97404730ca1b4fc981f7a47a471eb5a78527c99cf375618fb9ba047172"

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -10,8 +10,16 @@ packages = [{ include = "app" }]
 python = ">=3.11,<3.12"
 fastapi = "0.111.0"
 pydantic = "2.6.4"
-uvicorn = {extras = ["standard"], version = "0.29.0"}
-ibis-framework = {extras = ["bigquery", "clickhouse", "mssql", "mysql", "postgres", "snowflake"], version = "9.0.0"}
+uvicorn = { version = "0.29.0", extras = ["standard"] }
+ibis-framework = { version = "9.1.0", extras = [
+  "bigquery",
+  "clickhouse",
+  "mssql",
+  "mysql",
+  "postgres",
+  "snowflake",
+  "trino",
+] }
 google-auth = "2.29.0"
 httpx = "0.27.0"
 python-dotenv = "1.0.1"
@@ -23,23 +31,28 @@ sqlglot = ">=23.4,<25.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.2.0"
-testcontainers = {extras = ["clickhouse", "mssql", "mysql", "postgres"], version = "4.5.0"}
+testcontainers = { version = "4.5.0", extras = [
+  "clickhouse",
+  "mssql",
+  "mysql",
+  "postgres",
+] }
 sqlalchemy = "2.0.30"
 pre-commit = "3.7.1"
 ruff = "0.4.8"
 maturin = "1.6.0"
+trino = ">=0.321,<1"
 
 [tool.pytest.ini_options]
-addopts = [
-    "--strict-markers",
-]
+addopts = ["--strict-markers"]
 markers = [
-    "bigquery: mark a test as a bigquery test",
-    "clickhouse: mark a test as a clickhouse test",
-    "mssql: mark a test as a mssql test",
-    "mysql: mark a test as a mysql test",
-    "postgres: mark a test as a postgres test",
-    "snowflake: mark a test as a snowflake test",
+  "bigquery: mark a test as a bigquery test",
+  "clickhouse: mark a test as a clickhouse test",
+  "mssql: mark a test as a mssql test",
+  "mysql: mark a test as a mysql test",
+  "postgres: mark a test as a postgres test",
+  "snowflake: mark a test as a snowflake test",
+  "trino: mark a test as a trino test",
 ]
 
 [tool.ruff]
@@ -48,88 +61,88 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = [
-    "C4",  # comprehensions
-    "D",   # pydocstyle
-    "E",   # pycodestyle
-    "EXE", # flake8-executable
-    "F",   # pyflakes
-    "FA",  # flake8-future-annotations
-    "G",   # flake8-logging-format
-    "FLY", # flynt (format string conversion)
-    "I",   # isort
-    "ICN", # flake8-import-conventions
-    "INP", # flake8-no-pep420 (implicit namespace packages)
-    "ISC", # flake8-implicit-str-concat
-    "PGH", # pygrep-hooks
-    "PIE", # flake8-pie
-    "PL",  # pylint
-    "RET", # flake8-return
-    "RUF", # ruff-specific rules
-    "SIM", # flake8-simplify
-    "T10", # flake8-debugger
-    "T20", # flake8-print
-    "TID", # flake8-tidy-imports
-    "UP",  # pyupgrade
-    "YTT", # flake8-2020
+  "C4",  # comprehensions
+  "D",   # pydocstyle
+  "E",   # pycodestyle
+  "EXE", # flake8-executable
+  "F",   # pyflakes
+  "FA",  # flake8-future-annotations
+  "G",   # flake8-logging-format
+  "FLY", # flynt (format string conversion)
+  "I",   # isort
+  "ICN", # flake8-import-conventions
+  "INP", # flake8-no-pep420 (implicit namespace packages)
+  "ISC", # flake8-implicit-str-concat
+  "PGH", # pygrep-hooks
+  "PIE", # flake8-pie
+  "PL",  # pylint
+  "RET", # flake8-return
+  "RUF", # ruff-specific rules
+  "SIM", # flake8-simplify
+  "T10", # flake8-debugger
+  "T20", # flake8-print
+  "TID", # flake8-tidy-imports
+  "UP",  # pyupgrade
+  "YTT", # flake8-2020
 ]
 ignore = [
-    "B008",    # do not perform function calls in argument defaults
-    "B028",    # required stacklevel argument to warn
-    "B904",    # raise from e or raise from None in exception handlers
-    "B905",    # zip-without-explicit-strict
-    "C408",    # dict(...) as literal
-    "C901",    # too complex
-    "D100",    # public module
-    "D101",    # public class
-    "D102",    # public method
-    "D103",    # public function
-    "D104",    # public package
-    "D105",    # magic methods
-    "D106",    # nested class
-    "D107",    # init
-    "D202",    # blank lines after function docstring
-    "D203",    # blank line before class docstring
-    "D213",    # Multi-line docstring summary should start at the second line
-    "D401",    # Imperative mood
-    "D402",    # First line should not be the function's signature
-    "D413",    # Blank line required after last section
-    "E501",    # line-too-long, this is automatically enforced by ruff format
-    "E731",    # lambda-assignment
-    "ISC001",  # single line implicit string concat, handled by ruff format
-    "PGH003",  # blanket-type-ignore
-    "PLC0105", # covariant type parameters should have a _co suffix
-    "PLR0124", # name compared with self, e.g., a == a
-    "PLR0911", # too many return statements
-    "PLR0912", # too many branches
-    "PLR0913", # too many arguments
-    "PLR0915", # too many statements
-    "PLR2004", # forces everything to be a constant
-    "PLW2901", # overwriting loop variable
-    "RET504",  # unnecessary-assign, these are useful for debugging
-    "RET505",  # superfluous-else-return, stylistic choice
-    "RET506",  # superfluous-else-raise, stylistic choice
-    "RET507",  # superfluous-else-continue, stylistic choice
-    "RET508",  # superfluous-else-break, stylistic choice
-    "RUF005",  # splat instead of concat
-    "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
-    "S101",    # ignore "Use of `assert` detected"
-    "SIM102",  # nested ifs
-    "SIM108",  # convert everything to ternary operator
-    "SIM114",  # combine `if` branches using logical `or` operator
-    "SIM116",  # dictionary instead of `if` statements
-    "SIM117",  # nested with statements
-    "SIM118",  # remove .keys() calls from dictionaries
-    "SIM300",  # yoda conditions
-    "UP007",   # Optional[str] -> str | None
-    "UP038",   # non-pep604-isinstance, results in slower code
-    "W191",  # indentation contains tabs
+  "B008",    # do not perform function calls in argument defaults
+  "B028",    # required stacklevel argument to warn
+  "B904",    # raise from e or raise from None in exception handlers
+  "B905",    # zip-without-explicit-strict
+  "C408",    # dict(...) as literal
+  "C901",    # too complex
+  "D100",    # public module
+  "D101",    # public class
+  "D102",    # public method
+  "D103",    # public function
+  "D104",    # public package
+  "D105",    # magic methods
+  "D106",    # nested class
+  "D107",    # init
+  "D202",    # blank lines after function docstring
+  "D203",    # blank line before class docstring
+  "D213",    # Multi-line docstring summary should start at the second line
+  "D401",    # Imperative mood
+  "D402",    # First line should not be the function's signature
+  "D413",    # Blank line required after last section
+  "E501",    # line-too-long, this is automatically enforced by ruff format
+  "E731",    # lambda-assignment
+  "ISC001",  # single line implicit string concat, handled by ruff format
+  "PGH003",  # blanket-type-ignore
+  "PLC0105", # covariant type parameters should have a _co suffix
+  "PLR0124", # name compared with self, e.g., a == a
+  "PLR0911", # too many return statements
+  "PLR0912", # too many branches
+  "PLR0913", # too many arguments
+  "PLR0915", # too many statements
+  "PLR2004", # forces everything to be a constant
+  "PLW2901", # overwriting loop variable
+  "RET504",  # unnecessary-assign, these are useful for debugging
+  "RET505",  # superfluous-else-return, stylistic choice
+  "RET506",  # superfluous-else-raise, stylistic choice
+  "RET507",  # superfluous-else-continue, stylistic choice
+  "RET508",  # superfluous-else-break, stylistic choice
+  "RUF005",  # splat instead of concat
+  "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+  "S101",    # ignore "Use of `assert` detected"
+  "SIM102",  # nested ifs
+  "SIM108",  # convert everything to ternary operator
+  "SIM114",  # combine `if` branches using logical `or` operator
+  "SIM116",  # dictionary instead of `if` statements
+  "SIM117",  # nested with statements
+  "SIM118",  # remove .keys() calls from dictionaries
+  "SIM300",  # yoda conditions
+  "UP007",   # Optional[str] -> str | None
+  "UP038",   # non-pep604-isinstance, results in slower code
+  "W191",    # indentation contains tabs
 ]
 # none of these codes will be automatically fixed by ruff
 unfixable = [
-    "T201",   # print statements
-    "F401",   # unused imports
-    "RUF100", # unused noqa comments
-    "F841",   # unused variables
+  "T201",   # print statements
+  "F401",   # unused imports
+  "RUF100", # unused noqa comments
+  "F841",   # unused variables
 ]
 
 [build-system]

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -3,9 +3,9 @@ import base64
 import orjson
 import pytest
 from fastapi.testclient import TestClient
-from self_testcontainers.trino import TrinoContainer
 
 from app.main import app
+from tests.self_testcontainers.trino import TrinoContainer
 
 pytestmark = pytest.mark.trino
 

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -1,0 +1,373 @@
+import base64
+
+import orjson
+import pytest
+from fastapi.testclient import TestClient
+from self_testcontainers.trino import TrinoContainer
+
+from app.main import app
+
+pytestmark = pytest.mark.trino
+
+client = TestClient(app)
+
+base_url = "/v2/connector/trino"
+
+manifest = {
+    "catalog": "my_catalog",
+    "schema": "my_schema",
+    "models": [
+        {
+            "name": "Orders",
+            "refSql": "select * from tpch.tiny.orders",
+            "columns": [
+                {"name": "orderkey", "expression": "orderkey", "type": "integer"},
+                {"name": "custkey", "expression": "custkey", "type": "integer"},
+                {
+                    "name": "orderstatus",
+                    "expression": "orderstatus",
+                    "type": "varchar",
+                },
+                {
+                    "name": "totalprice",
+                    "expression": "totalprice",
+                    "type": "float",
+                },
+                {"name": "orderdate", "expression": "orderdate", "type": "date"},
+                {
+                    "name": "order_cust_key",
+                    "expression": "concat(cast(orderkey as varchar), '_', cast(custkey as varchar))",
+                    "type": "varchar",
+                },
+                {
+                    "name": "timestamp",
+                    "expression": "TIMESTAMP '2024-01-01 23:59:59'",
+                    "type": "timestamp",
+                },
+                {
+                    "name": "timestamptz",
+                    "expression": "with_timezone(TIMESTAMP '2024-01-01 23:59:59', 'UTC')",
+                    "type": "timestamp",
+                },
+            ],
+            "primaryKey": "orderkey",
+        },
+    ],
+}
+
+manifest_str = base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
+
+
+@pytest.fixture(scope="module")
+def trino(request) -> TrinoContainer:
+    db = TrinoContainer().start()
+    request.addfinalizer(db.stop)
+    return db
+
+
+def test_query(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        172799.49,
+        820540800000,
+        "1_370",
+        1704153599000,
+        1704153599000,
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "float64",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "datetime64[ns]",
+        "timestamptz": "datetime64[ns, UTC]",
+    }
+
+
+def test_query_with_connection_url(trino: TrinoContainer):
+    connection_url = to_connection_url(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
+
+
+def test_query_with_column_dtypes(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+            "columnDtypes": {
+                "totalprice": "float",
+                "orderdate": "datetime64",
+                "timestamp": "datetime64",
+                "timestamptz": "datetime64",
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        172799.49,
+        "1996-01-02 00:00:00.000000",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "float64",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+    }
+
+
+def test_query_with_limit(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders"',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+
+    response = client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 10',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+
+
+def test_query_without_manifest(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+def test_query_without_sql(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+def test_query_without_connection_info():
+    response = client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+def test_query_with_dry_run(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_query_with_dry_run_and_invalid_sql(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
+
+
+def test_validate_with_unknown_rule(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert (
+        response.text
+        == "The rule `unknown_rule` is not in the rules, rules: ['column_is_valid']"
+    )
+
+
+def test_validate_rule_column_is_valid(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
+
+
+def test_validate_rule_column_is_valid_with_invalid_parameters(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_validate_rule_column_is_valid_without_parameters(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+def test_validate_rule_column_is_valid_without_one_parameter(trino: TrinoContainer):
+    connection_info = to_connection_info(trino)
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+def to_connection_info(trino: TrinoContainer):
+    return {
+        "host": trino.get_container_host_ip(),
+        "port": trino.get_exposed_port(trino.port),
+        "catalog": "tpch",
+        "schema": "sf1",
+        "user": "test",
+    }
+
+
+def to_connection_url(trino: TrinoContainer):
+    info = to_connection_info(trino)
+    return f"trino://{info['user']}@{info['host']}:{info['port']}/{info['catalog']}/{info['schema']}"

--- a/ibis-server/tests/self_testcontainers/trino/__init__.py
+++ b/ibis-server/tests/self_testcontainers/trino/__init__.py
@@ -3,6 +3,7 @@ import re
 from testcontainers.core.config import testcontainers_config as c
 from testcontainers.core.generic import DbContainer
 from testcontainers.core.waiting_utils import wait_container_is_ready, wait_for_logs
+from trino.dbapi import connect
 
 
 # Reference: https://github.com/testcontainers/testcontainers-python/pull/152
@@ -25,6 +26,15 @@ class TrinoContainer(DbContainer):
             c.max_tries,
             c.sleep_time,
         )
+        conn = connect(
+            host=self.get_container_host_ip(),
+            port=self.get_exposed_port(self.port),
+            user="test",
+        )
+        cur = conn.cursor()
+        cur.execute("SELECT 1")
+        cur.fetchall()
+        conn.close()
 
     def get_connection_url(self):
         return f"trino://{self.get_container_host_ip()}:{self.port}"


### PR DESCRIPTION
# Description
Make `POST /v2/connector/{data_source}/query` support new data source `trino`

## Request body
- host: string, `required`
- port: integer, `required`
- catalog: string, `required`
- schema: string, `required`
- user: string, `required`
- password: string
```json
{
  "sql": "select * from \"Orders\" limit 1",
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInNjaGVtYSI6Im15X3...",
  "connectionInfo": {
    "host": "localhost",
    "port": 8080,
    "catalog": "catalog",
    "schema": "schema",
    "user": "username",
    "password": "password"
  }
}
```
or
- connectionUrl: string, `required`
```json
{
  "sql": "select * from \"Orders\" limit 1",
  "manifestStr": "eyJjYXRhbG9nIjoibXlfY2F0YWxvZyIsInNjaGVtYSI6Im15X3...",
  "connectionInfo": {
    "connectionUrl": "trino://username:password@localhost:8080/catalog/schema"
  }
}
```

## Response body
- columns
- data
- dtypes: Type through the pandas

```json
{
    "columns": [
        "o_orderkey",
        "o_custkey",
        "o_orderstatus",
        "o_totalprice",
        "o_orderdate",
        "o_orderpriority",
        "o_clerk",
        "o_shippriority",
        "o_comment"
    ],
    "data": [
        [
            1,
            370,
            "O",
            172799.49,
            820540800000,
            "5-LOW",
            "Clerk#000000951",
            0,
            "nstructions sleep furiously among "
        ]
    ],
    "dtypes": {
        "o_orderkey": "int32",
        "o_custkey": "int32",
        "o_orderstatus": "object",
        "o_totalprice": "object",
        "o_orderdate": "object",
        "o_orderpriority": "object",
        "o_clerk": "object",
        "o_shippriority": "int32",
        "o_comment": "object"
    }
}
```

# Additional information
Add [taplo](https://github.com/tamasfe/taplo) to format toml.
Testcontainers does not support Trino, so I created TrinoContainer for ourselves. I will add a PR to [testcontainers-python](https://github.com/testcontainers/testcontainers-python).
