### PR TITLE
Add ExprSource for all analysis items

### DIFF
--- a/ibis-server/tests/routers/v2/test_analysis.py
+++ b/ibis-server/tests/routers/v2/test_analysis.py
@@ -96,6 +96,13 @@ def test_analysis_sql_select_all_customer():
     assert "alias" not in result[0]["relation"]
     assert len(result[0]["selectItems"]) == 8
     assert result[0]["selectItems"][0]["nodeLocation"] == {"line": 1, "column": 8}
+    assert result[0]["selectItems"][0]["exprSources"] == [
+        {
+            "expression": "custkey",
+            "nodeLocation": {"line": 1, "column": 8},
+            "sourceDataset": "customer",
+        },
+    ]
     assert result[0]["selectItems"][1]["nodeLocation"] == {"line": 1, "column": 8}
     assert result[0]["relation"]["tableName"] == "customer"
     assert result[0]["relation"]["nodeLocation"] == {"line": 1, "column": 15}
@@ -120,6 +127,13 @@ def test_analysis_sql_group_by_customer():
     assert result[0]["groupByKeys"][0][0] == {
         "expression": "custkey",
         "nodeLocation": {"line": 1, "column": 49},
+        "exprSources": [
+            {
+                "expression": "custkey",
+                "nodeLocation": {"line": 1, "column": 8},
+                "sourceDataset": "customer",
+            },
+        ],
     }
 
 
@@ -169,6 +183,13 @@ def test_analysis_sql_where_clause():
     assert result[0]["relation"]["tableName"] == "customer"
     assert result[0]["filter"]["type"] == "OR"
     assert result[0]["filter"]["left"]["type"] == "EXPR"
+    assert result[0]["filter"]["left"]["exprSources"] == [
+        {
+            "expression": "custkey",
+            "nodeLocation": {"line": 1, "column": 30},
+            "sourceDataset": "customer",
+        },
+    ]
     assert result[0]["filter"]["right"]["type"] == "AND"
 
 
@@ -184,14 +205,35 @@ def test_analysis_sql_group_by_multiple_columns():
     assert result[0]["groupByKeys"][0][0] == {
         "expression": "custkey",
         "nodeLocation": {"line": 1, "column": 55},
+        "exprSources": [
+            {
+                "expression": "custkey",
+                "nodeLocation": {"line": 1, "column": 8},
+                "sourceDataset": "customer",
+            },
+        ],
     }
     assert result[0]["groupByKeys"][1][0] == {
         "expression": "name",
         "nodeLocation": {"line": 1, "column": 58},
+        "exprSources": [
+            {
+                "expression": "name",
+                "nodeLocation": {"line": 1, "column": 27},
+                "sourceDataset": "customer",
+            },
+        ],
     }
     assert result[0]["groupByKeys"][2][0] == {
         "expression": "nationkey",
         "nodeLocation": {"line": 1, "column": 61},
+        "exprSources": [
+            {
+                "expression": "nationkey",
+                "nodeLocation": {"line": 1, "column": 61},
+                "sourceDataset": "customer",
+            },
+        ],
     }
 
 
@@ -206,6 +248,13 @@ def test_analysis_sql_order_by():
     assert len(result[0]["sortings"]) == 2
     assert result[0]["sortings"][0]["expression"] == "custkey"
     assert result[0]["sortings"][0]["ordering"] == "ASCENDING"
+    assert result[0]["sortings"][0]["exprSources"] == [
+        {
+            "expression": "custkey",
+            "nodeLocation": {"line": 1, "column": 8},
+            "sourceDataset": "customer",
+        },
+    ]
     assert result[0]["sortings"][0]["nodeLocation"] == {"line": 1, "column": 45}
     assert result[0]["sortings"][1]["expression"] == "name"
     assert result[0]["sortings"][1]["ordering"] == "DESCENDING"

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExprSource.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExprSource.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.base.sqlrewrite.analyzer.decisionpoint;
+
+import io.trino.sql.tree.NodeLocation;
+
+import java.util.Objects;
+
+public record ExprSource(String expression, String sourceDataset, NodeLocation nodeLocation)
+{
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ExprSource that = (ExprSource) o;
+        return Objects.equals(expression, that.expression) &&
+                Objects.equals(sourceDataset, that.sourceDataset)
+                && Objects.equals(nodeLocation, that.nodeLocation);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression, sourceDataset, nodeLocation);
+    }
+}

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalysis.java
@@ -16,6 +16,8 @@ package io.wren.base.sqlrewrite.analyzer.decisionpoint;
 
 import io.trino.sql.tree.NodeLocation;
 
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 public abstract class FilterAnalysis
@@ -30,9 +32,9 @@ public abstract class FilterAnalysis
         return new LogicalAnalysis(Type.OR, left, right, nodeLocation);
     }
 
-    public static FilterAnalysis expression(String node, NodeLocation nodeLocation)
+    public static FilterAnalysis expression(String node, NodeLocation nodeLocation, List<ExprSource> exprSources)
     {
-        return new ExpressionAnalysis(node, nodeLocation);
+        return new ExpressionAnalysis(node, nodeLocation, exprSources);
     }
 
     public enum Type
@@ -89,16 +91,23 @@ public abstract class FilterAnalysis
             extends FilterAnalysis
     {
         private final String node;
+        private final List<ExprSource> exprSources;
 
-        public ExpressionAnalysis(String node, NodeLocation nodeLocation)
+        public ExpressionAnalysis(String node, NodeLocation nodeLocation, List<ExprSource> exprSources)
         {
             super(Type.EXPR, nodeLocation);
             this.node = requireNonNull(node, "node is null");
+            this.exprSources = exprSources == null ? List.of() : List.copyOf(exprSources);
         }
 
         public String getNode()
         {
             return node;
+        }
+
+        public List<ExprSource> getExprSources()
+        {
+            return exprSources;
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
@@ -40,6 +40,7 @@ public class FilterAnalyzer
             extends AstVisitor<FilterAnalysis, Node>
     {
         private final Scope scope;
+
         private Visitor(Scope scope)
         {
             this.scope = scope;

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/FilterAnalyzer.java
@@ -20,6 +20,9 @@ import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.Node;
+import io.wren.base.sqlrewrite.analyzer.Scope;
+
+import java.util.List;
 
 /**
  * Only extract the top level logical expression. If a logical expression is contained by other expression, it will be treated as a single expression.
@@ -28,21 +31,28 @@ public class FilterAnalyzer
 {
     private FilterAnalyzer() {}
 
-    public static FilterAnalysis analyze(Expression expression)
+    public static FilterAnalysis analyze(Expression expression, Scope scope)
     {
-        return new Visitor().process(expression, null);
+        return new Visitor(scope).process(expression, null);
     }
 
     static class Visitor
             extends AstVisitor<FilterAnalysis, Node>
     {
+        private final Scope scope;
+        private Visitor(Scope scope)
+        {
+            this.scope = scope;
+        }
+
         @Override
         protected FilterAnalysis visitExpression(Expression node, Node context)
         {
             if (node instanceof LogicalExpression) {
                 return process(node, context);
             }
-            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null));
+            List<ExprSource> exprSources = List.copyOf(RelationAnalyzer.ExpressionSourceAnalyzer.analyze(node, scope));
+            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null), exprSources);
         }
 
         @Override
@@ -56,7 +66,8 @@ public class FilterAnalyzer
                     return FilterAnalysis.or(process(node.getChildren().get(0), node), process(node.getChildren().get(1), node), node.getLocation().orElse(null));
                 }
             }
-            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null));
+            List<ExprSource> exprSources = List.copyOf(RelationAnalyzer.ExpressionSourceAnalyzer.analyze(node, scope));
+            return FilterAnalysis.expression(ExpressionFormatter.formatExpression(node, SqlFormatter.Dialect.DEFAULT), node.getLocation().orElse(null), exprSources);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/QueryAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/QueryAnalysis.java
@@ -89,13 +89,15 @@ public class QueryAnalysis
         private final String expression;
         private final Map<String, String> properties;
         private final NodeLocation nodeLocation;
+        private final List<ExprSource> exprSources;
 
-        public ColumnAnalysis(Optional<String> aliasName, String expression, Map<String, String> properties, NodeLocation nodeLocation)
+        public ColumnAnalysis(Optional<String> aliasName, String expression, Map<String, String> properties, NodeLocation nodeLocation, List<ExprSource> exprSources)
         {
             this.aliasName = aliasName;
             this.expression = expression;
             this.properties = properties;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources == null ? List.of() : List.copyOf(exprSources);
         }
 
         public Optional<String> getAliasName()
@@ -117,6 +119,11 @@ public class QueryAnalysis
         {
             return nodeLocation;
         }
+
+        public List<ExprSource> getExprSources()
+        {
+            return exprSources;
+        }
     }
 
     public static class SortItemAnalysis
@@ -124,12 +131,14 @@ public class QueryAnalysis
         private final String expression;
         private final SortItem.Ordering ordering;
         private final NodeLocation nodeLocation;
+        private final List<ExprSource> exprSources;
 
-        public SortItemAnalysis(String expression, SortItem.Ordering ordering, NodeLocation nodeLocation)
+        public SortItemAnalysis(String expression, SortItem.Ordering ordering, NodeLocation nodeLocation, List<ExprSource> exprSources)
         {
             this.expression = expression;
             this.ordering = ordering;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources == null ? List.of() : List.copyOf(exprSources);
         }
 
         public String getExpression()
@@ -146,17 +155,24 @@ public class QueryAnalysis
         {
             return nodeLocation;
         }
+
+        public List<ExprSource> getExprSources()
+        {
+            return exprSources;
+        }
     }
 
     public static class GroupByKey
     {
         private final String expression;
         private final NodeLocation nodeLocation;
+        private final List<ExprSource> exprSources;
 
-        public GroupByKey(String expression, NodeLocation nodeLocation)
+        public GroupByKey(String expression, NodeLocation nodeLocation, List<ExprSource> exprSources)
         {
             this.expression = expression;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources == null ? List.of() : List.copyOf(exprSources);
         }
 
         public String getExpression()
@@ -167,6 +183,11 @@ public class QueryAnalysis
         public NodeLocation getNodeLocation()
         {
             return nodeLocation;
+        }
+
+        public List<ExprSource> getExprSources()
+        {
+            return exprSources;
         }
 
         @Override
@@ -180,13 +201,14 @@ public class QueryAnalysis
             }
             GroupByKey that = (GroupByKey) o;
             return Objects.equals(expression, that.expression) &&
-                    Objects.equals(nodeLocation, that.nodeLocation);
+                    Objects.equals(nodeLocation, that.nodeLocation) &&
+                    Objects.equals(exprSources, that.exprSources);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(expression, nodeLocation);
+            return Objects.hash(expression, nodeLocation, exprSources);
         }
 
         @Override
@@ -195,6 +217,7 @@ public class QueryAnalysis
             return "GroupByKey{" +
                     "expression='" + expression + '\'' +
                     ", nodeLocation=" + nodeLocation +
+                    ", exprSources=" + exprSources +
                     '}';
         }
     }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
@@ -17,7 +17,6 @@ package io.wren.base.sqlrewrite.analyzer.decisionpoint;
 import io.trino.sql.tree.NodeLocation;
 
 import java.util.List;
-import java.util.Objects;
 
 import static io.wren.base.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -147,32 +146,6 @@ public abstract class RelationAnalysis
         public List<QueryAnalysis> getBody()
         {
             return body;
-        }
-    }
-
-    public record ExprSource(String expression, String sourceDataset, NodeLocation nodeLocation)
-    {
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            ExprSource that = (ExprSource) o;
-            return Objects.equals(expression, that.expression) &&
-                    Objects.equals(sourceDataset, that.sourceDataset)
-                    && Objects.equals(nodeLocation, that.nodeLocation);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(expression, sourceDataset, nodeLocation);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -127,7 +127,7 @@ public class RelationAnalyzer
             RelationAnalysis right = process(node.getRight(), context);
 
             Scope scope = analysis.getScope(node);
-            List<RelationAnalysis.ExprSource> exprSources = node.getCriteria().map(criteria -> analyzeCriteria(criteria, scope))
+            List<ExprSource> exprSources = node.getCriteria().map(criteria -> analyzeCriteria(criteria, scope))
                     .orElse(null);
             return new RelationAnalysis.JoinRelation(
                     RelationAnalysis.Type.valueOf(format("%s_JOIN", node.getType())),
@@ -157,9 +157,9 @@ public class RelationAnalyzer
             return builder.toString();
         }
 
-        private List<RelationAnalysis.ExprSource> analyzeCriteria(JoinCriteria criteria, Scope scope)
+        private List<ExprSource> analyzeCriteria(JoinCriteria criteria, Scope scope)
         {
-            Set<RelationAnalysis.ExprSource> exprSources = new HashSet<>();
+            Set<ExprSource> exprSources = new HashSet<>();
             switch (criteria) {
                 case JoinOn joinOn:
                     exprSources.addAll(ExpressionSourceAnalyzer.analyze(joinOn.getExpression(), scope));
@@ -228,7 +228,7 @@ public class RelationAnalyzer
     static class ExpressionSourceAnalyzer
             extends DefaultExpressionTraversalVisitor<Void>
     {
-        static Set<RelationAnalysis.ExprSource> analyze(Expression expression, Scope scope)
+        static Set<ExprSource> analyze(Expression expression, Scope scope)
         {
             ExpressionSourceAnalyzer analyzer = new ExpressionSourceAnalyzer(scope);
             analyzer.process(expression, null);
@@ -236,7 +236,7 @@ public class RelationAnalyzer
         }
 
         private final Scope scope;
-        private final Set<RelationAnalysis.ExprSource> exprSources = new HashSet<>();
+        private final Set<ExprSource> exprSources = new HashSet<>();
 
         public ExpressionSourceAnalyzer(Scope scope)
         {
@@ -248,7 +248,7 @@ public class RelationAnalyzer
         {
             scope.getRelationType().resolveFields(QualifiedName.of(node.getValue()))
                     .stream().filter(field -> field.getSourceDatasetName().isPresent())
-                    .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(node.getValue(), field.getSourceDatasetName().get(), node.getLocation().orElse(null))));
+                    .forEach(field -> exprSources.add(new ExprSource(node.getValue(), field.getSourceDatasetName().get(), node.getLocation().orElse(null))));
             return null;
         }
 
@@ -258,7 +258,7 @@ public class RelationAnalyzer
             Optional.ofNullable(getQualifiedName(node)).ifPresent(qualifiedName ->
                     scope.getRelationType().resolveFields(qualifiedName)
                             .stream().filter(field -> field.getSourceDatasetName().isPresent())
-                            .forEach(field -> exprSources.add(new RelationAnalysis.ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get(), node.getLocation().orElse(null)))));
+                            .forEach(field -> exprSources.add(new ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get(), node.getLocation().orElse(null)))));
             return null;
         }
     }

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -20,6 +20,7 @@ import io.trino.sql.tree.Statement;
 import io.wren.base.SessionContext;
 import io.wren.base.WrenMDL;
 import io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionPointAnalyzer;
+import io.wren.base.sqlrewrite.analyzer.decisionpoint.ExprSource;
 import io.wren.base.sqlrewrite.analyzer.decisionpoint.FilterAnalysis;
 import io.wren.base.sqlrewrite.analyzer.decisionpoint.QueryAnalysis;
 import io.wren.base.sqlrewrite.analyzer.decisionpoint.RelationAnalysis;
@@ -153,7 +154,7 @@ public class AnalysisResource
         return new SortItemAnalysisDto(sortItemAnalysis.getExpression(), sortItemAnalysis.getOrdering().name(), toNodeLocationDto(sortItemAnalysis.getNodeLocation()));
     }
 
-    private static QueryAnalysisDto.ExprSourceDto toExprSourceDto(RelationAnalysis.ExprSource exprSource)
+    private static QueryAnalysisDto.ExprSourceDto toExprSourceDto(ExprSource exprSource)
     {
         return new QueryAnalysisDto.ExprSourceDto(exprSource.expression(), exprSource.sourceDataset(), toNodeLocationDto(exprSource.nodeLocation()));
     }

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -87,7 +87,10 @@ public class AnalysisResource
 
     private static ColumnAnalysisDto toColumnAnalysisDto(QueryAnalysis.ColumnAnalysis columnAnalysis)
     {
-        return new ColumnAnalysisDto(columnAnalysis.getAliasName(), columnAnalysis.getExpression(), columnAnalysis.getProperties(), toNodeLocationDto(columnAnalysis.getNodeLocation()));
+        return new ColumnAnalysisDto(columnAnalysis.getAliasName(),
+                columnAnalysis.getExpression(), columnAnalysis.getProperties(),
+                toNodeLocationDto(columnAnalysis.getNodeLocation()),
+                columnAnalysis.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
     }
 
     private static FilterAnalysisDto toFilterAnalysisDto(FilterAnalysis filterAnalysis)
@@ -98,14 +101,16 @@ public class AnalysisResource
                     null,
                     null,
                     exprAnalysis.getNode(),
-                    toNodeLocationDto(exprAnalysis.getNodeLocation()));
+                    toNodeLocationDto(exprAnalysis.getNodeLocation()),
+                    exprAnalysis.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
             case FilterAnalysis.LogicalAnalysis logicalAnalysis ->
                     new FilterAnalysisDto(
                             logicalAnalysis.getType().name(),
                             toFilterAnalysisDto(logicalAnalysis.getLeft()),
                             toFilterAnalysisDto(logicalAnalysis.getRight()),
                             null,
-                            toNodeLocationDto(logicalAnalysis.getNodeLocation()));
+                            toNodeLocationDto(logicalAnalysis.getNodeLocation()),
+                            null);
             case null -> null;
             default -> throw new IllegalArgumentException("Unsupported filter analysis: " + filterAnalysis);
         };
@@ -151,7 +156,10 @@ public class AnalysisResource
 
     private static SortItemAnalysisDto toSortItemAnalysisDto(QueryAnalysis.SortItemAnalysis sortItemAnalysis)
     {
-        return new SortItemAnalysisDto(sortItemAnalysis.getExpression(), sortItemAnalysis.getOrdering().name(), toNodeLocationDto(sortItemAnalysis.getNodeLocation()));
+        return new SortItemAnalysisDto(sortItemAnalysis.getExpression(),
+                sortItemAnalysis.getOrdering().name(),
+                toNodeLocationDto(sortItemAnalysis.getNodeLocation()),
+                sortItemAnalysis.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
     }
 
     private static QueryAnalysisDto.ExprSourceDto toExprSourceDto(ExprSource exprSource)
@@ -161,7 +169,9 @@ public class AnalysisResource
 
     private static QueryAnalysisDto.GroupByKeyDto toGroupByKeyDto(QueryAnalysis.GroupByKey groupByKey)
     {
-        return new QueryAnalysisDto.GroupByKeyDto(groupByKey.getExpression(), toNodeLocationDto(groupByKey.getNodeLocation()));
+        return new QueryAnalysisDto.GroupByKeyDto(groupByKey.getExpression(),
+                toNodeLocationDto(groupByKey.getNodeLocation()),
+                groupByKey.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
     }
 
     private static NodeLocationDto toNodeLocationDto(NodeLocation nodeLocation)

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -93,14 +93,16 @@ public class QueryAnalysisDto
         private String expression;
         private Map<String, String> properties;
         private NodeLocationDto nodeLocation;
+        private List<ExprSourceDto> exprSources;
 
         @JsonCreator
-        public ColumnAnalysisDto(Optional<String> alias, String expression, Map<String, String> properties, NodeLocationDto nodeLocation)
+        public ColumnAnalysisDto(Optional<String> alias, String expression, Map<String, String> properties, NodeLocationDto nodeLocation, List<ExprSourceDto> exprSources)
         {
             this.alias = alias;
             this.expression = expression;
             this.properties = properties;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources;
         }
 
         @JsonProperty
@@ -125,6 +127,12 @@ public class QueryAnalysisDto
         public NodeLocationDto getNodeLocation()
         {
             return nodeLocation;
+        }
+
+        @JsonProperty
+        public List<ExprSourceDto> getExprSources()
+        {
+            return exprSources;
         }
     }
 
@@ -227,15 +235,17 @@ public class QueryAnalysisDto
         private FilterAnalysisDto right;
         private String node;
         private NodeLocationDto nodeLocation;
+        private List<ExprSourceDto> exprSources;
 
         @JsonCreator
-        public FilterAnalysisDto(String type, FilterAnalysisDto left, FilterAnalysisDto right, String node, NodeLocationDto nodeLocation)
+        public FilterAnalysisDto(String type, FilterAnalysisDto left, FilterAnalysisDto right, String node, NodeLocationDto nodeLocation, List<ExprSourceDto> exprSources)
         {
             this.type = type;
             this.left = left;
             this.right = right;
             this.node = node;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources;
         }
 
         @JsonProperty
@@ -267,6 +277,12 @@ public class QueryAnalysisDto
         {
             return nodeLocation;
         }
+
+        @JsonProperty
+        public List<ExprSourceDto> getExprSources()
+        {
+            return exprSources;
+        }
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -275,13 +291,15 @@ public class QueryAnalysisDto
         private String expression;
         private String ordering;
         private NodeLocationDto nodeLocation;
+        private List<ExprSourceDto> exprSources;
 
         @JsonCreator
-        public SortItemAnalysisDto(String expression, String ordering, NodeLocationDto nodeLocation)
+        public SortItemAnalysisDto(String expression, String ordering, NodeLocationDto nodeLocation, List<ExprSourceDto> exprSources)
         {
             this.expression = expression;
             this.ordering = ordering;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources;
         }
 
         @JsonProperty
@@ -300,6 +318,12 @@ public class QueryAnalysisDto
         public NodeLocationDto getNodeLocation()
         {
             return nodeLocation;
+        }
+
+        @JsonProperty
+        public List<ExprSourceDto> getExprSources()
+        {
+            return exprSources;
         }
     }
 
@@ -372,12 +396,14 @@ public class QueryAnalysisDto
     {
         private String expression;
         private NodeLocationDto nodeLocation;
+        private List<ExprSourceDto> exprSources;
 
         @JsonCreator
-        public GroupByKeyDto(String expression, NodeLocationDto nodeLocation)
+        public GroupByKeyDto(String expression, NodeLocationDto nodeLocation, List<ExprSourceDto> exprSources)
         {
             this.expression = expression;
             this.nodeLocation = nodeLocation;
+            this.exprSources = exprSources;
         }
 
         @JsonProperty
@@ -392,6 +418,12 @@ public class QueryAnalysisDto
             return nodeLocation;
         }
 
+        @JsonProperty
+        public List<ExprSourceDto> getExprSources()
+        {
+            return exprSources;
+        }
+
         @Override
         public boolean equals(Object o)
         {
@@ -403,13 +435,14 @@ public class QueryAnalysisDto
             }
             GroupByKeyDto that = (GroupByKeyDto) o;
             return Objects.equals(expression, that.expression) &&
-                    Objects.equals(nodeLocation, that.nodeLocation);
+                    Objects.equals(nodeLocation, that.nodeLocation)
+                    && Objects.equals(exprSources, that.exprSources);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(expression, nodeLocation);
+            return Objects.hash(expression, nodeLocation, exprSources);
         }
 
         @Override
@@ -418,6 +451,7 @@ public class QueryAnalysisDto
             return "GroupByKeyDto{" +
                     "expression='" + expression + '\'' +
                     ", nodeLocation=" + nodeLocation +
+                    ", exprSources=" + exprSources +
                     '}';
         }
     }

--- a/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
@@ -124,6 +124,8 @@ public class TestAnalysisResource
         assertThat(result.get(0).getSelectItems().size()).isEqualTo(8);
         // all of select item match the star symbol position
         assertThat(result.get(0).getSelectItems().get(0).getNodeLocation()).isEqualTo(nodeLocationDto(1, 8));
+        assertThat(result.get(0).getSelectItems().get(0).getExprSources())
+                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8))));
         assertThat(result.get(0).getSelectItems().get(1).getNodeLocation()).isEqualTo(nodeLocationDto(1, 8));
         assertThat(result.get(0).getRelation().getTableName()).isEqualTo("customer");
         assertThat(result.get(0).getRelation().getNodeLocation()).isEqualTo(nodeLocationDto(1, 15));
@@ -138,7 +140,10 @@ public class TestAnalysisResource
         assertThat(result.get(0).getRelation().getTableName()).isEqualTo("customer");
         assertThat(result.get(0).getRelation().getNodeLocation()).isEqualTo(nodeLocationDto(1, 31));
         assertThat(result.get(0).getGroupByKeys().size()).isEqualTo(1);
-        assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("custkey", nodeLocationDto(1, 49)));
+        assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
+                new QueryAnalysisDto.GroupByKeyDto("custkey",
+                nodeLocationDto(1, 49),
+                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8)))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "select * from customer c join orders o on c.custkey = o.custkey"));
         assertThat(result.size()).isEqualTo(1);
@@ -165,20 +170,29 @@ public class TestAnalysisResource
 
         assertThat(result.get(0).getFilter().getType()).isEqualTo(FilterAnalysis.Type.OR.name());
         assertThat(result.get(0).getFilter().getLeft().getType()).isEqualTo(FilterAnalysis.Type.EXPR.name());
+        assertThat(assertThat(result.get(0).getFilter().getLeft().getExprSources())
+                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 30)))));
         assertThat(result.get(0).getFilter().getRight().getType()).isEqualTo(FilterAnalysis.Type.AND.name());
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT custkey, count(*), name FROM customer GROUP BY 1, 3, nationkey"));
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().size()).isEqualTo(3);
-        assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("custkey", nodeLocationDto(1, 55)));
-        assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("name", nodeLocationDto(1, 58)));
-        assertThat(result.get(0).getGroupByKeys().get(2).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("nationkey", nodeLocationDto(1, 61)));
+        assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("custkey",
+                nodeLocationDto(1, 55),
+                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8)))));
+        assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("name",
+                nodeLocationDto(1, 58),
+                List.of(new QueryAnalysisDto.ExprSourceDto("name", "customer", nodeLocationDto(1, 27)))));
+        assertThat(result.get(0).getGroupByKeys().get(2).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("nationkey",
+                nodeLocationDto(1, 61),
+                List.of(new QueryAnalysisDto.ExprSourceDto("nationkey", "customer", nodeLocationDto(1, 61)))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT custkey, name FROM customer ORDER BY 1 ASC, 2 DESC"));
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getSortings().size()).isEqualTo(2);
         assertThat(result.get(0).getSortings().get(0).getExpression()).isEqualTo("custkey");
         assertThat(result.get(0).getSortings().get(0).getOrdering()).isEqualTo(SortItem.Ordering.ASCENDING.name());
+        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8))));
         assertThat(result.get(0).getSortings().get(0).getNodeLocation()).isEqualTo(nodeLocationDto(1, 45));
         assertThat(result.get(0).getSortings().get(1).getExpression()).isEqualTo("name");
         assertThat(result.get(0).getSortings().get(1).getOrdering()).isEqualTo(SortItem.Ordering.DESCENDING.name());


### PR DESCRIPTION
# Description
We implement ExprSource analysis for the join criteria in #564. In this PR, I add this analysis for all expression items (e.g. selectItems, filter, group by keys and sorting).

## Sample Result
```json
[
    {
        "selectItems": [
            {
                "alias": null,
                "expression": "custkey",
                "properties": {
                    "includeMathematicalOperation": "false",
                    "includeFunctionCall": "false"
                },
                "nodeLocation": {
                    "line": 1,
                    "column": 8
                },
                "exprSources": [
                    {
                        "expression": "custkey",
                        "sourceDataset": "customer",
                        "nodeLocation": {
                            "line": 1,
                            "column": 8
                        }
                    }
                ]
            },
           ...
        ],
        "relation": {
            "type": "TABLE",
            "tableName": "customer",
            "nodeLocation": {
                "line": 1,
                "column": 37
            }
        },
        "filter": {
            "type": "EXPR",
            "node": "(custkey = 1)",
            "nodeLocation": {
                "line": 1,
                "column": 60
            },
            "exprSources": [
                {
                    "expression": "custkey",
                    "sourceDataset": "customer",
                    "nodeLocation": {
                        "line": 1,
                        "column": 52
                    }
                }
            ]
        },
        "groupByKeys": [
            [
                {
                    "expression": "custkey",
                    "nodeLocation": {
                        "line": 1,
                        "column": 73
                    },
                    "exprSources": [
                        {
                            "expression": "custkey",
                            "sourceDataset": "customer",
                            "nodeLocation": {
                                "line": 1,
                                "column": 8
                            }
                        }
                    ]
                }
            ],
         ....
        ],
        "sortings": [
            {
                "expression": "custkey",
                "ordering": "ASCENDING",
                "nodeLocation": {
                    "line": 1,
                    "column": 98
                },
                "exprSources": [
                    {
                        "expression": "custkey",
                        "sourceDataset": "customer",
                        "nodeLocation": {
                            "line": 1,
                            "column": 8
                        }
                    }
                ]
            },
            ....
        ],
        "isSubqueryOrCte": false
    }
]
```