### PR TITLE
Make trino test independent

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run tests
         env:
           WREN_ENGINE_ENDPOINT: http://localhost:8080
-        run: poetry run pytest -m "not bigquery and not snowflake"
+        run: poetry run pytest -m "not bigquery and not snowflake and not trino"
       - name: Test bigquery if need
         if: contains(github.event.pull_request.labels.*.name, 'bigquery')
         env:
@@ -90,3 +90,8 @@ jobs:
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
         run: poetry run pytest -m snowflake
+      - name: Test trino if need
+        if: contains(github.event.pull_request.labels.*.name, 'trino')
+        env:
+          WREN_ENGINE_ENDPOINT: http://localhost:8080
+        run: poetry run pytest -m trino


### PR DESCRIPTION
The Trino test container is unstable, causing occasional test failures. We have split the tests until the issue is resolved.