### PR TITLE
Allow to invoke a calculation belong to another models

### DIFF
--- a/wren-modeling-rs/Cargo.toml
+++ b/wren-modeling-rs/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 async-trait = "0.1.80"
-datafusion = { version = "39.0.0" }
+datafusion = { version = "39.0.0", features = ["backtrace"] }
 env_logger = "0.11.3"
 log = { version = "0.4.14" }
 petgraph = "0.6.5"

--- a/wren-modeling-rs/core/src/logical_plan/analyze/mod.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/mod.rs
@@ -1,2 +1,5 @@
 pub mod plan;
+mod relation_chain;
 pub mod rule;
+
+pub use relation_chain::RelationChain;

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -158,7 +158,6 @@ impl ModelPlanNodeBuilder {
                     column.name(),
                 );
 
-                dbg!(model.name(), &qualified_column);
                 let Some(column_graph) = self
                     .analyzed_wren_mdl
                     .lineage()
@@ -285,12 +284,6 @@ impl ModelPlanNodeBuilder {
             .unwrap_or_default();
 
         let mut calculate_iter = self.required_calculation.iter();
-        dbg!(
-            model.name(),
-            &model_ref,
-            required_fields.clone(),
-            self.model_required_fields.clone()
-        );
         let source_chain =
             if !source_required_fields.is_empty() || required_fields.is_empty() {
                 if required_fields.is_empty() {
@@ -343,8 +336,6 @@ impl ModelPlanNodeBuilder {
             );
         }
 
-        dbg!(&relation_chain);
-        dbg!(&self.required_exprs_buffer);
         Ok(ModelPlanNode {
             plan_name: model.name().to_string(),
             required_exprs: self

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -6,19 +6,8 @@ use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
 
-use datafusion::common::{
-    internal_err, not_impl_err, plan_err, Column, DFSchema, DFSchemaRef, TableReference,
-};
-use datafusion::error::Result;
-use datafusion::logical_expr::utils::find_aggregate_exprs;
-use datafusion::logical_expr::{
-    col, Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
-};
-use petgraph::graph::NodeIndex;
-use petgraph::Graph;
-
-use crate::logical_plan::analyze::plan::RelationChain::Start;
-use crate::logical_plan::analyze::rule::ModelGenerationRule;
+use crate::logical_plan::analyze::RelationChain;
+use crate::logical_plan::analyze::RelationChain::Start;
 use crate::logical_plan::utils::{from_qualified_name, map_data_type};
 use crate::mdl;
 use crate::mdl::lineage::DatasetLink;
@@ -28,6 +17,39 @@ use crate::mdl::utils::{
     create_wren_expr_for_model, is_dag,
 };
 use crate::mdl::{AnalyzedWrenMDL, ColumnReference, Dataset};
+use datafusion::common::{
+    internal_err, plan_err, Column, DFSchema, DFSchemaRef, TableReference,
+};
+use datafusion::error::Result;
+use datafusion::logical_expr::utils::find_aggregate_exprs;
+use datafusion::logical_expr::{
+    col, Expr, Extension, LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore,
+};
+use petgraph::Graph;
+
+pub(crate) enum WrenPlan {
+    Source(Arc<ModelSourceNode>),
+    Model(Arc<ModelPlanNode>),
+    Calculation(Arc<CalculationPlanNode>),
+}
+
+impl WrenPlan {
+    fn name(&self) -> &str {
+        match self {
+            WrenPlan::Source(node) => &node.model_name,
+            WrenPlan::Model(node) => &node.model_name,
+            WrenPlan::Calculation(node) => node.calculation.column.name(),
+        }
+    }
+
+    fn as_ref(&self) -> Arc<dyn UserDefinedLogicalNode> {
+        match self {
+            WrenPlan::Source(source) => Arc::clone(source) as _,
+            WrenPlan::Model(plan) => Arc::clone(plan) as _,
+            WrenPlan::Calculation(calculation) => Arc::clone(calculation) as _,
+        }
+    }
+}
 
 /// [ModelPlanNode] is a logical plan node that represents a model. It contains the model name,
 /// required fields, and the relation chain that connects the model with other models.
@@ -48,15 +70,44 @@ impl ModelPlanNode {
         original_table_scan: Option<LogicalPlan>,
         analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
     ) -> Result<Self> {
-        let mut required_exprs_buffer = BTreeSet::new();
-        let mut directed_graph: Graph<Dataset, DatasetLink> = Graph::new();
-        let mut model_required_fields: HashMap<TableReference, BTreeSet<OrdExpr>> =
-            HashMap::new();
-        let mut required_calculation: Vec<CalculationPlanNode> = vec![];
-        let mut fields = VecDeque::new();
+        ModelPlanNodeBuilder::new(analyzed_wren_mdl).build(
+            model,
+            required_fields,
+            original_table_scan,
+        )
+    }
+}
+
+struct ModelPlanNodeBuilder {
+    required_exprs_buffer: BTreeSet<OrdExpr>,
+    directed_graph: Graph<Dataset, DatasetLink>,
+    model_required_fields: HashMap<TableReference, BTreeSet<OrdExpr>>,
+    required_calculation: Vec<WrenPlan>,
+    fields: VecDeque<(Option<TableReference>, Arc<Field>)>,
+    analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
+}
+
+impl ModelPlanNodeBuilder {
+    fn new(analyzed_wren_mdl: Arc<AnalyzedWrenMDL>) -> Self {
+        Self {
+            required_exprs_buffer: BTreeSet::new(),
+            directed_graph: Graph::new(),
+            model_required_fields: HashMap::new(),
+            required_calculation: vec![],
+            fields: VecDeque::new(),
+            analyzed_wren_mdl,
+        }
+    }
+
+    fn build(
+        mut self,
+        model: Arc<Model>,
+        required_fields: Vec<Expr>,
+        original_table_scan: Option<LogicalPlan>,
+    ) -> Result<ModelPlanNode> {
         let model_ref = TableReference::full(
-            analyzed_wren_mdl.wren_mdl().catalog(),
-            analyzed_wren_mdl.wren_mdl().schema(),
+            self.analyzed_wren_mdl.wren_mdl().catalog(),
+            self.analyzed_wren_mdl.wren_mdl().schema(),
             model.name(),
         );
 
@@ -74,19 +125,20 @@ impl ModelPlanNode {
         for column in required_columns {
             if column.is_calculated {
                 let expr = if column.expression.is_some() {
-                    let column_rf = analyzed_wren_mdl.wren_mdl().get_column_reference(
-                        &from_qualified_name(
-                            &analyzed_wren_mdl.wren_mdl(),
+                    let column_rf = self
+                        .analyzed_wren_mdl
+                        .wren_mdl()
+                        .get_column_reference(&from_qualified_name(
+                            &self.analyzed_wren_mdl.wren_mdl(),
                             model.name(),
                             column.name(),
-                        ),
-                    );
+                        ));
                     let Some(column_rf) = column_rf else {
                         return plan_err!("Column reference not found for {:?}", column);
                     };
                     let expr = create_wren_calculated_field_expr(
                         column_rf,
-                        Arc::clone(&analyzed_wren_mdl),
+                        Arc::clone(&self.analyzed_wren_mdl),
                     )?;
                     let expr_plan = expr.alias(column.name());
                     expr_plan
@@ -95,12 +147,13 @@ impl ModelPlanNode {
                 };
 
                 let qualified_column = from_qualified_name(
-                    &analyzed_wren_mdl.wren_mdl(),
+                    &self.analyzed_wren_mdl.wren_mdl(),
                     model.name(),
                     column.name(),
                 );
 
-                let Some(column_graph) = analyzed_wren_mdl
+                let Some(column_graph) = self
+                    .analyzed_wren_mdl
                     .lineage()
                     .required_dataset_topo
                     .get(&qualified_column)
@@ -112,73 +165,30 @@ impl ModelPlanNode {
                 };
 
                 if !find_aggregate_exprs(&[expr.clone()]).is_empty() {
-                    // The calculation column is provided by the CalculationPlanNode.
-                    required_exprs_buffer.insert(OrdExpr::new(col(format!(
-                        "{}.{}",
-                        column.name(),
-                        column.name()
-                    ))));
-
-                    let column_rf = analyzed_wren_mdl
-                        .wren_mdl()
-                        .get_column_reference(&qualified_column);
-                    let mut partial_model_required_fields = HashMap::new();
-                    let _ = collect_model_required_fields(
-                        qualified_column,
-                        Arc::clone(&analyzed_wren_mdl),
-                        &mut partial_model_required_fields,
-                    );
-
-                    let mut iter = column_graph.node_indices();
-
-                    let start = iter.next().unwrap();
-                    let source_required_fields = partial_model_required_fields
-                        .get(&model_ref)
-                        .map(|c| c.iter().cloned().map(|c| c.expr).collect())
-                        .unwrap_or_default();
-                    let source = column_graph.node_weight(start).unwrap();
-
-                    let source_chain = RelationChain::source(
-                        source,
-                        source_required_fields,
-                        Arc::clone(&analyzed_wren_mdl),
-                    )?;
-
-                    let partial_chain = RelationChain::with_chain(
-                        source_chain,
-                        start,
-                        iter,
-                        column_graph.clone(),
-                        &partial_model_required_fields,
-                        Arc::clone(&analyzed_wren_mdl),
-                    )?;
-
-                    let Some(column_rf) = column_rf else {
-                        return plan_err!("Column reference not found for {:?}", column);
-                    };
-                    let calculation = CalculationPlanNode::new(
-                        column_rf,
+                    let calculation = self.create_partial_calculation(
+                        model_ref.clone(),
+                        Arc::clone(&column),
+                        &qualified_column,
                         expr,
-                        partial_chain,
-                        Arc::clone(&analyzed_wren_mdl),
                     )?;
-                    required_calculation.push(calculation);
+                    self.required_calculation.push(calculation);
                 } else {
-                    required_exprs_buffer.insert(OrdExpr::new(expr.clone()));
-                    merge_graph(&mut directed_graph, column_graph)?;
+                    self.required_exprs_buffer
+                        .insert(OrdExpr::new(expr.clone()));
+                    merge_graph(&mut self.directed_graph, column_graph)?;
                     let _ = collect_model_required_fields(
-                        qualified_column,
-                        Arc::clone(&analyzed_wren_mdl),
-                        &mut model_required_fields,
+                        &qualified_column,
+                        Arc::clone(&self.analyzed_wren_mdl),
+                        &mut self.model_required_fields,
                     );
                 }
             } else {
                 let expr_plan = get_remote_column_exp(
                     &column,
                     Arc::clone(&model),
-                    Arc::clone(&analyzed_wren_mdl),
+                    Arc::clone(&self.analyzed_wren_mdl),
                 )?;
-                model_required_fields
+                self.model_required_fields
                     .entry(model_ref.clone())
                     .or_default()
                     .insert(OrdExpr::new(expr_plan.clone()));
@@ -187,9 +197,10 @@ impl ModelPlanNode {
                     model_ref.table(),
                     column.name()
                 )));
-                required_exprs_buffer.insert(OrdExpr::new(expr_plan.clone()));
+                self.required_exprs_buffer
+                    .insert(OrdExpr::new(expr_plan.clone()));
             }
-            fields.push_front((
+            self.fields.push_front((
                 Some(TableReference::bare(model.name())),
                 Arc::new(Field::new(
                     column.name(),
@@ -199,29 +210,34 @@ impl ModelPlanNode {
             ));
         }
 
-        directed_graph.add_node(Dataset::Model(Arc::clone(&model)));
-        if !is_dag(&directed_graph) {
+        self.directed_graph
+            .add_node(Dataset::Model(Arc::clone(&model)));
+        if !is_dag(&self.directed_graph) {
             return plan_err!("cyclic dependency detected: {}", model.name());
         }
 
         let schema_ref = DFSchemaRef::new(
-            DFSchema::new_with_metadata(fields.into_iter().collect(), HashMap::new())
-                .expect("create schema failed"),
+            DFSchema::new_with_metadata(
+                self.fields.into_iter().collect(),
+                HashMap::new(),
+            )
+            .expect("create schema failed"),
         );
 
-        let mut iter = directed_graph.node_indices();
+        let mut iter = self.directed_graph.node_indices();
         let Some(start) = iter.next() else {
             return internal_err!("Model not found");
         };
-        let Some(source) = directed_graph.node_weight(start) else {
+        let Some(source) = self.directed_graph.node_weight(start) else {
             return internal_err!("Dataset not found");
         };
-        let mut source_required_fields: Vec<Expr> = model_required_fields
+        let mut source_required_fields: Vec<Expr> = self
+            .model_required_fields
             .get(&model_ref)
             .map(|c| c.iter().cloned().map(|c| c.expr).collect())
             .unwrap_or_default();
 
-        let mut calculate_iter = required_calculation.iter();
+        let mut calculate_iter = self.required_calculation.iter();
 
         let source_chain =
             if !source_required_fields.is_empty() || required_fields.is_empty() {
@@ -231,14 +247,14 @@ impl ModelPlanNode {
                 RelationChain::source(
                     source,
                     source_required_fields,
-                    Arc::clone(&analyzed_wren_mdl),
+                    Arc::clone(&self.analyzed_wren_mdl),
                 )?
             } else {
                 let Some(first_calculation) = calculate_iter.next() else {
                     return plan_err!("Calculation not found and no any required field");
                 };
                 Start(LogicalPlan::Extension(Extension {
-                    node: Arc::new(first_calculation.clone()),
+                    node: first_calculation.as_ref(),
                 }))
             };
 
@@ -246,14 +262,13 @@ impl ModelPlanNode {
             source_chain,
             start,
             iter,
-            directed_graph,
-            &model_required_fields,
-            Arc::clone(&analyzed_wren_mdl),
+            self.directed_graph,
+            &self.model_required_fields,
+            Arc::clone(&self.analyzed_wren_mdl),
         )?;
 
         for calculation_plan in calculate_iter {
-            let target_ref =
-                TableReference::bare(calculation_plan.calculation.column.name());
+            let target_ref = TableReference::bare(calculation_plan.name());
             let Some(join_key) = model.primary_key() else {
                 return plan_err!(
                     "Model {} should have primary key for calculation",
@@ -262,7 +277,7 @@ impl ModelPlanNode {
             };
             relation_chain = RelationChain::Chain(
                 LogicalPlan::Extension(Extension {
-                    node: Arc::new(calculation_plan.clone()),
+                    node: calculation_plan.as_ref(),
                 }),
                 JoinType::OneToOne,
                 format!(
@@ -275,9 +290,10 @@ impl ModelPlanNode {
                 Box::new(relation_chain),
             );
         }
-        Ok(Self {
+        Ok(ModelPlanNode {
             model_name: model.name.clone(),
-            required_exprs: required_exprs_buffer
+            required_exprs: self
+                .required_exprs_buffer
                 .into_iter()
                 .map(|oe| oe.expr)
                 .collect(),
@@ -286,10 +302,78 @@ impl ModelPlanNode {
             original_table_scan,
         })
     }
+
+    fn create_partial_calculation(
+        &mut self,
+        model_ref: TableReference,
+        column: Arc<mdl::manifest::Column>,
+        qualified_column: &Column,
+        col_expr: Expr,
+    ) -> Result<WrenPlan> {
+        let Some(column_graph) = self
+            .analyzed_wren_mdl
+            .lineage()
+            .required_dataset_topo
+            .get(qualified_column)
+        else {
+            return plan_err!("Required dataset not found for {}", qualified_column);
+        };
+
+        // The calculation column is provided by the CalculationPlanNode.
+        let _ = &self.required_exprs_buffer.insert(OrdExpr::new(col(format!(
+            "{}.{}",
+            column.name(),
+            column.name()
+        ))));
+
+        let mut partial_model_required_fields = HashMap::new();
+        let _ = collect_model_required_fields(
+            qualified_column,
+            Arc::clone(&self.analyzed_wren_mdl),
+            &mut partial_model_required_fields,
+        );
+
+        let mut iter = column_graph.node_indices();
+
+        let start = iter.next().unwrap();
+        let source_required_fields = partial_model_required_fields
+            .get(&model_ref)
+            .map(|c| c.iter().cloned().map(|c| c.expr).collect())
+            .unwrap_or_default();
+        let source = column_graph.node_weight(start).unwrap();
+
+        let source_chain = RelationChain::source(
+            source,
+            source_required_fields,
+            Arc::clone(&self.analyzed_wren_mdl),
+        )?;
+
+        let partial_chain = RelationChain::with_chain(
+            source_chain,
+            start,
+            iter,
+            column_graph.clone(),
+            &partial_model_required_fields,
+            Arc::clone(&self.analyzed_wren_mdl),
+        )?;
+        let Some(column_rf) = self
+            .analyzed_wren_mdl
+            .wren_mdl()
+            .get_column_reference(qualified_column)
+        else {
+            return plan_err!("Column reference not found for {:?}", column);
+        };
+        Ok(WrenPlan::Calculation(Arc::new(CalculationPlanNode::new(
+            column_rf,
+            col_expr,
+            partial_chain,
+            Arc::clone(&self.analyzed_wren_mdl),
+        )?)))
+    }
 }
 
 fn collect_model_required_fields(
-    qualified_column: Column,
+    qualified_column: &Column,
     analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
     model_required_fields: &mut HashMap<TableReference, BTreeSet<OrdExpr>>,
 ) -> Result<()> {
@@ -359,11 +443,11 @@ fn get_remote_column_exp(
 
 #[derive(Eq, PartialEq, Debug, Hash, Clone)]
 pub struct OrdExpr {
-    expr: Expr,
+    pub(crate) expr: Expr,
 }
 
 impl OrdExpr {
-    fn new(expr: Expr) -> Self {
+    pub(crate) fn new(expr: Expr) -> Self {
         Self { expr }
     }
 }
@@ -405,210 +489,6 @@ fn merge_graph(
         graph.add_edge(*source, *target, new_graph[edge].clone());
     }
     Ok(())
-}
-
-/// RelationChain is a chain of models that are connected by the relationship.
-/// The chain is used to generate the join plan for the model.
-/// The physical layout will be looked like:
-/// (((Model3, Model2), Model1), Nil)
-#[derive(Eq, PartialEq, Debug, Hash, Clone)]
-pub enum RelationChain {
-    Chain(LogicalPlan, JoinType, String, Box<RelationChain>),
-    Start(LogicalPlan),
-}
-
-impl RelationChain {
-    pub(crate) fn source(
-        dataset: &Dataset,
-        required_fields: Vec<Expr>,
-        analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-    ) -> Result<Self> {
-        match dataset {
-            Dataset::Model(source_model) => {
-                Ok(Start(LogicalPlan::Extension(Extension {
-                    node: Arc::new(ModelSourceNode::new(
-                        Arc::clone(source_model),
-                        required_fields,
-                        analyzed_wren_mdl,
-                        None,
-                    )?),
-                })))
-            }
-            _ => {
-                not_impl_err!("Only support model as source dataset")
-            }
-        }
-    }
-
-    pub fn with_chain(
-        source: Self,
-        mut start: NodeIndex,
-        iter: impl Iterator<Item = NodeIndex>,
-        directed_graph: Graph<Dataset, DatasetLink>,
-        model_required_fields: &HashMap<TableReference, BTreeSet<OrdExpr>>,
-        analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-    ) -> Result<Self> {
-        let mut relation_chain = source;
-
-        for next in iter {
-            let target = directed_graph.node_weight(next).unwrap();
-            let Some(link_index) = directed_graph.find_edge(start, next) else {
-                break;
-            };
-            let link = directed_graph.edge_weight(link_index).unwrap();
-            let target_ref = TableReference::full(
-                analyzed_wren_mdl.wren_mdl().catalog(),
-                analyzed_wren_mdl.wren_mdl().schema(),
-                target.name(),
-            );
-            let Some(fields) = model_required_fields.get(&target_ref) else {
-                return plan_err!("Required fields not found for {}", target_ref);
-            };
-            match target {
-                Dataset::Model(target_model) => {
-                    relation_chain = RelationChain::Chain(
-                        LogicalPlan::Extension(Extension {
-                            node: Arc::new(ModelSourceNode::new(
-                                Arc::clone(target_model),
-                                fields.iter().cloned().map(|c| c.expr).collect(),
-                                Arc::clone(&analyzed_wren_mdl),
-                                None,
-                            )?),
-                        }),
-                        link.join_type,
-                        link.condition.clone(),
-                        Box::new(relation_chain),
-                    );
-                }
-                _ => return plan_err!("Only support model as source dataset"),
-            }
-            start = next;
-        }
-        Ok(relation_chain)
-    }
-
-    pub(crate) fn plan(
-        &mut self,
-        rule: ModelGenerationRule,
-    ) -> Result<Option<LogicalPlan>> {
-        match self {
-            RelationChain::Chain(plan, _, condition, ref mut next) => {
-                let left = rule
-                    .generate_model_internal(plan.clone())
-                    .expect("Failed to generate model plan")
-                    .data;
-                let join_keys: Vec<Expr> = mdl::utils::collect_identifiers(condition)?
-                    .iter()
-                    .cloned()
-                    .map(|c| col(c.flat_name()))
-                    .collect();
-                let join_condition = join_keys[0].clone().eq(join_keys[1].clone());
-                let Some(right) = next.plan(rule)? else {
-                    return plan_err!("Nil relation chain");
-                };
-                let mut required_exprs = BTreeSet::new();
-                // collect the output calculated fields
-                match plan {
-                    LogicalPlan::Extension(plan) => {
-                        if let Some(model_plan) =
-                            plan.node.as_any().downcast_ref::<ModelPlanNode>()
-                        {
-                            UserDefinedLogicalNodeCore::schema(model_plan)
-                                .fields()
-                                .iter()
-                                .map(|field| {
-                                    col(format!(
-                                        "{}.{}",
-                                        model_plan.model_name,
-                                        field.name()
-                                    ))
-                                })
-                                .for_each(|c| {
-                                    required_exprs.insert(OrdExpr::new(c));
-                                });
-                        } else if let Some(model_source_plan) =
-                            plan.node.as_any().downcast_ref::<ModelSourceNode>()
-                        {
-                            UserDefinedLogicalNodeCore::schema(model_source_plan)
-                                .fields()
-                                .iter()
-                                .map(|field| {
-                                    col(format!(
-                                        "{}.{}",
-                                        model_source_plan.model_name,
-                                        field.name()
-                                    ))
-                                })
-                                .for_each(|c| {
-                                    required_exprs.insert(OrdExpr::new(c));
-                                });
-                        } else if let Some(calculation_plan) =
-                            plan.node.as_any().downcast_ref::<CalculationPlanNode>()
-                        {
-                            UserDefinedLogicalNodeCore::schema(calculation_plan)
-                                .fields()
-                                .iter()
-                                .map(|field| {
-                                    col(format!(
-                                        "{}.{}",
-                                        calculation_plan.calculation.column.name(),
-                                        field.name()
-                                    ))
-                                })
-                                .for_each(|c| {
-                                    required_exprs.insert(OrdExpr::new(c));
-                                });
-                        } else {
-                            return plan_err!("Invalid extension plan node");
-                        }
-                    }
-                    _ => return internal_err!("Invalid plan node"),
-                };
-                // collect the column of the left table
-                for index in 0..left.schema().fields().len() {
-                    let (Some(table_rf), f) = left.schema().qualified_field(index) else {
-                        return plan_err!("Field not found");
-                    };
-                    let qualified_name = format!("{}.{}", table_rf, f.name());
-                    required_exprs.insert(OrdExpr::new(col(qualified_name)));
-                }
-
-                // collect the column of the right table
-                for index in 0..right.schema().fields().len() {
-                    let (Some(table_rf), f) = right.schema().qualified_field(index)
-                    else {
-                        return plan_err!("Field not found");
-                    };
-                    let qualified_name = format!("{}.{}", table_rf, f.name());
-                    required_exprs.insert(OrdExpr::new(col(qualified_name)));
-                }
-
-                let required_field: Vec<Expr> = required_exprs
-                    .iter()
-                    .map(|expr| expr.expr.clone())
-                    .collect();
-
-                Ok(Some(
-                    LogicalPlanBuilder::from(left)
-                        .join_on(
-                            right,
-                            datafusion::logical_expr::JoinType::Right,
-                            vec![join_condition],
-                        )
-                        .unwrap()
-                        .project(required_field)
-                        .unwrap()
-                        .build()
-                        .unwrap(),
-                ))
-            }
-            Start(plan) => Ok(Some(
-                rule.generate_model_internal(plan.clone())
-                    .expect("Failed to generate model plan")
-                    .data,
-            )),
-        }
-    }
 }
 
 impl UserDefinedLogicalNodeCore for ModelPlanNode {
@@ -779,11 +659,7 @@ impl UserDefinedLogicalNodeCore for ModelSourceNode {
         write!(f, "ModelSource: name={}", self.model_name)
     }
 
-    fn with_exprs_and_inputs(
-        &self,
-        _: Vec<Expr>,
-        _: Vec<LogicalPlan>,
-    ) -> datafusion::common::Result<Self> {
+    fn with_exprs_and_inputs(&self, _: Vec<Expr>, _: Vec<LogicalPlan>) -> Result<Self> {
         Ok(ModelSourceNode {
             model_name: self.model_name.clone(),
             required_exprs: self.required_exprs.clone(),

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -877,6 +877,9 @@ impl UserDefinedLogicalNodeCore for CalculationPlanNode {
     }
 }
 
+/// [PartialModelPlanNode] is a logical plan node that represents a partial model.
+/// When a calculation contains the calculation belong to another models, we should construct
+/// a [PartialModelPlanNode] for the calculation.
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub(crate) struct PartialModelPlanNode {
     pub model_node: ModelPlanNode,

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -8,7 +8,6 @@ use crate::mdl;
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::JoinType;
 use crate::mdl::{AnalyzedWrenMDL, Dataset};
-use datafusion::arrow::ipc::Field;
 use datafusion::catalog::TableReference;
 use datafusion::common::{internal_err, not_impl_err, plan_err, DFSchema, DFSchemaRef};
 use datafusion::logical_expr::{
@@ -81,7 +80,6 @@ impl RelationChain {
                     let node = if fields.iter().any(|e| {
                         e.column.is_some() && e.column.clone().unwrap().is_calculated
                     }) {
-                        dbg!(&fields);
                         let schema = create_schema(
                             fields
                                 .iter()
@@ -132,7 +130,6 @@ impl RelationChain {
         match self {
             RelationChain::Chain(plan, _, condition, ref mut next) => {
                 let left = rule.generate_model_internal(plan.clone())?.data;
-                dbg!(&plan, &left);
                 let join_keys: Vec<Expr> = mdl::utils::collect_identifiers(condition)?
                     .iter()
                     .cloned()
@@ -240,7 +237,6 @@ impl RelationChain {
                     .map(|expr| expr.expr.clone())
                     .collect();
 
-                dbg!(&required_field);
                 Ok(Some(
                     LogicalPlanBuilder::from(left)
                         .join_on(

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -1,0 +1,224 @@
+use crate::logical_plan::analyze::plan::{
+    CalculationPlanNode, ModelPlanNode, ModelSourceNode, OrdExpr,
+};
+use crate::logical_plan::analyze::relation_chain::RelationChain::Start;
+use crate::logical_plan::analyze::rule::ModelGenerationRule;
+use crate::mdl;
+use crate::mdl::lineage::DatasetLink;
+use crate::mdl::manifest::JoinType;
+use crate::mdl::{AnalyzedWrenMDL, Dataset};
+use datafusion::catalog::TableReference;
+use datafusion::common::{internal_err, not_impl_err, plan_err};
+use datafusion::logical_expr::{
+    col, Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
+};
+use petgraph::graph::NodeIndex;
+use petgraph::Graph;
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+/// RelationChain is a chain of models that are connected by the relationship.
+/// The chain is used to generate the join plan for the model.
+/// The physical layout will be looked like:
+/// (((Model3, Model2), Model1), Nil)
+#[derive(Eq, PartialEq, Debug, Hash, Clone)]
+pub enum RelationChain {
+    Chain(LogicalPlan, JoinType, String, Box<RelationChain>),
+    Start(LogicalPlan),
+}
+
+impl RelationChain {
+    pub(crate) fn source(
+        dataset: &Dataset,
+        required_fields: Vec<Expr>,
+        analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
+    ) -> datafusion::common::Result<Self> {
+        match dataset {
+            Dataset::Model(source_model) => {
+                dbg!(&required_fields);
+                Ok(Start(LogicalPlan::Extension(Extension {
+                    node: Arc::new(ModelSourceNode::new(
+                        Arc::clone(source_model),
+                        required_fields,
+                        analyzed_wren_mdl,
+                        None,
+                    )?),
+                })))
+            }
+            _ => {
+                not_impl_err!("Only support model as source dataset")
+            }
+        }
+    }
+
+    pub fn with_chain(
+        source: Self,
+        mut start: NodeIndex,
+        iter: impl Iterator<Item = NodeIndex>,
+        directed_graph: Graph<Dataset, DatasetLink>,
+        model_required_fields: &HashMap<TableReference, BTreeSet<OrdExpr>>,
+        analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
+    ) -> datafusion::common::Result<Self> {
+        let mut relation_chain = source;
+
+        for next in iter {
+            let target = directed_graph.node_weight(next).unwrap();
+            let Some(link_index) = directed_graph.find_edge(start, next) else {
+                break;
+            };
+            let link = directed_graph.edge_weight(link_index).unwrap();
+            let target_ref = TableReference::full(
+                analyzed_wren_mdl.wren_mdl().catalog(),
+                analyzed_wren_mdl.wren_mdl().schema(),
+                target.name(),
+            );
+            dbg!(&target_ref);
+            let Some(fields) = model_required_fields.get(&target_ref) else {
+                return plan_err!("Required fields not found for {}", target_ref);
+            };
+            match target {
+                Dataset::Model(target_model) => {
+                    relation_chain = RelationChain::Chain(
+                        LogicalPlan::Extension(Extension {
+                            node: Arc::new(ModelSourceNode::new(
+                                Arc::clone(target_model),
+                                fields.iter().cloned().map(|c| c.expr).collect(),
+                                Arc::clone(&analyzed_wren_mdl),
+                                None,
+                            )?),
+                        }),
+                        link.join_type,
+                        link.condition.clone(),
+                        Box::new(relation_chain),
+                    );
+                }
+                _ => return plan_err!("Only support model as source dataset"),
+            }
+            start = next;
+        }
+        Ok(relation_chain)
+    }
+
+    pub(crate) fn plan(
+        &mut self,
+        rule: ModelGenerationRule,
+    ) -> datafusion::common::Result<Option<LogicalPlan>> {
+        match self {
+            RelationChain::Chain(plan, _, condition, ref mut next) => {
+                let left = rule
+                    .generate_model_internal(plan.clone())
+                    .expect("Failed to generate model plan")
+                    .data;
+                let join_keys: Vec<Expr> = mdl::utils::collect_identifiers(condition)?
+                    .iter()
+                    .cloned()
+                    .map(|c| col(c.flat_name()))
+                    .collect();
+                let join_condition = join_keys[0].clone().eq(join_keys[1].clone());
+                let Some(right) = next.plan(rule)? else {
+                    return plan_err!("Nil relation chain");
+                };
+                let mut required_exprs = BTreeSet::new();
+                // collect the output calculated fields
+                match plan {
+                    LogicalPlan::Extension(plan) => {
+                        if let Some(model_plan) =
+                            plan.node.as_any().downcast_ref::<ModelPlanNode>()
+                        {
+                            UserDefinedLogicalNodeCore::schema(model_plan)
+                                .fields()
+                                .iter()
+                                .map(|field| {
+                                    col(format!(
+                                        "{}.{}",
+                                        model_plan.model_name,
+                                        field.name()
+                                    ))
+                                })
+                                .for_each(|c| {
+                                    required_exprs.insert(OrdExpr::new(c));
+                                });
+                        } else if let Some(model_source_plan) =
+                            plan.node.as_any().downcast_ref::<ModelSourceNode>()
+                        {
+                            UserDefinedLogicalNodeCore::schema(model_source_plan)
+                                .fields()
+                                .iter()
+                                .map(|field| {
+                                    col(format!(
+                                        "{}.{}",
+                                        model_source_plan.model_name,
+                                        field.name()
+                                    ))
+                                })
+                                .for_each(|c| {
+                                    required_exprs.insert(OrdExpr::new(c));
+                                });
+                        } else if let Some(calculation_plan) =
+                            plan.node.as_any().downcast_ref::<CalculationPlanNode>()
+                        {
+                            UserDefinedLogicalNodeCore::schema(calculation_plan)
+                                .fields()
+                                .iter()
+                                .map(|field| {
+                                    col(format!(
+                                        "{}.{}",
+                                        calculation_plan.calculation.column.name(),
+                                        field.name()
+                                    ))
+                                })
+                                .for_each(|c| {
+                                    required_exprs.insert(OrdExpr::new(c));
+                                });
+                        } else {
+                            return plan_err!("Invalid extension plan node");
+                        }
+                    }
+                    _ => return internal_err!("Invalid plan node"),
+                };
+                // collect the column of the left table
+                for index in 0..left.schema().fields().len() {
+                    let (Some(table_rf), f) = left.schema().qualified_field(index) else {
+                        return plan_err!("Field not found");
+                    };
+                    let qualified_name = format!("{}.{}", table_rf, f.name());
+                    required_exprs.insert(OrdExpr::new(col(qualified_name)));
+                }
+
+                // collect the column of the right table
+                for index in 0..right.schema().fields().len() {
+                    let (Some(table_rf), f) = right.schema().qualified_field(index)
+                    else {
+                        return plan_err!("Field not found");
+                    };
+                    let qualified_name = format!("{}.{}", table_rf, f.name());
+                    required_exprs.insert(OrdExpr::new(col(qualified_name)));
+                }
+
+                let required_field: Vec<Expr> = required_exprs
+                    .iter()
+                    .map(|expr| expr.expr.clone())
+                    .collect();
+
+                Ok(Some(
+                    LogicalPlanBuilder::from(left)
+                        .join_on(
+                            right,
+                            datafusion::logical_expr::JoinType::Right,
+                            vec![join_condition],
+                        )
+                        .unwrap()
+                        .project(required_field)
+                        .unwrap()
+                        .build()
+                        .unwrap(),
+                ))
+            }
+            Start(plan) => Ok(Some(
+                rule.generate_model_internal(plan.clone())
+                    .expect("Failed to generate model plan")
+                    .data,
+            )),
+        }
+    }
+}

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -35,7 +35,6 @@ impl RelationChain {
     ) -> datafusion::common::Result<Self> {
         match dataset {
             Dataset::Model(source_model) => {
-                dbg!(&required_fields);
                 Ok(Start(LogicalPlan::Extension(Extension {
                     node: Arc::new(ModelSourceNode::new(
                         Arc::clone(source_model),
@@ -72,7 +71,6 @@ impl RelationChain {
                 analyzed_wren_mdl.wren_mdl().schema(),
                 target.name(),
             );
-            dbg!(&target_ref);
             let Some(fields) = model_required_fields.get(&target_ref) else {
                 return plan_err!("Required fields not found for {}", target_ref);
             };
@@ -131,7 +129,7 @@ impl RelationChain {
                                 .map(|field| {
                                     col(format!(
                                         "{}.{}",
-                                        model_plan.model_name,
+                                        model_plan.plan_name,
                                         field.name()
                                     ))
                                 })

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -81,11 +81,7 @@ impl RelationChain {
                         e.column.is_some() && e.column.clone().unwrap().is_calculated
                     }) {
                         let schema = create_schema(
-                            fields
-                                .iter()
-                                .filter(|e| e.column.is_some())
-                                .map(|e| e.column.clone().unwrap())
-                                .collect(),
+                            fields.iter().filter_map(|e| e.column.clone()).collect(),
                         )?;
                         let plan = ModelPlanNode::new(
                             Arc::clone(target_model),
@@ -248,11 +244,7 @@ impl RelationChain {
                         .build()?,
                 ))
             }
-            Start(plan) => Ok(Some(
-                rule.generate_model_internal(plan.clone())
-                    .expect("Failed to generate model plan")
-                    .data,
-            )),
+            Start(plan) => Ok(Some(rule.generate_model_internal(plan.clone())?.data)),
         }
     }
 }

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -228,8 +228,6 @@ impl ModelGenerationRule {
                     let source_plan = model_plan.relation_chain.clone().plan(
                         ModelGenerationRule::new(Arc::clone(&self.analyzed_wren_mdl)),
                     )?;
-                    dbg!(&model_plan.required_exprs);
-                    dbg!(&source_plan);
                     let result = match source_plan {
                         Some(plan) => LogicalPlanBuilder::from(plan)
                             .project(model_plan.required_exprs.clone())?
@@ -243,7 +241,6 @@ impl ModelGenerationRule {
                     let alias = LogicalPlanBuilder::from(result)
                         .alias(&model_plan.plan_name)?
                         .build()?;
-                    dbg!(&alias);
                     Ok(Transformed::yes(alias))
                 } else if let Some(model_plan) =
                     extension.node.as_any().downcast_ref::<ModelSourceNode>()
@@ -331,12 +328,10 @@ impl ModelGenerationRule {
                     .as_any()
                     .downcast_ref::<PartialModelPlanNode>(
                 ) {
-                    dbg!(&partial_model.model_node.relation_chain);
                     let plan = LogicalPlan::Extension(Extension {
                         node: Arc::new(partial_model.model_node.clone()),
                     });
                     let source_plan = self.generate_model_internal(plan)?.data;
-                    dbg!(&source_plan);
                     let projection: Vec<_> = partial_model
                         .schema()
                         .fields()

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -11,7 +11,6 @@ use datafusion::logical_expr::{
 };
 use datafusion::logical_expr::{Expr, Join, LogicalPlan, LogicalPlanBuilder, TableScan};
 use datafusion::optimizer::analyzer::AnalyzerRule;
-use datafusion::prelude::Expr::Column;
 use datafusion::sql::TableReference;
 
 use crate::logical_plan::analyze::plan::{

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -237,9 +237,8 @@ impl Lineage {
         }
 
         // resolve pending fields
-        while !pending_fields.is_empty() {
-            let (value, source_column) = pending_fields.pop().unwrap();
-            consume_pending_field(mdl, &mut required_fields_map, value, &source_column)?;
+        while let Some((value, source_column)) = pending_fields.pop() {
+            consume_pending_field(mdl, &mut required_fields_map, value, source_column)?;
         }
 
         Ok(RequiredInfo {

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -175,6 +175,19 @@ async fn register_ecommerce_mdl(
                         .calculated(true)
                         .build(),
                 )
+                // TODO: allow multiple calculation in an expression
+                // .column(
+                //     ColumnBuilder::new("customer_location", "varchar")
+                //         .calculated(true)
+                //         .expression("orders.customer_state || '-' || orders.customer_city")
+                //         .build(),
+                // )
+                // .column(
+                //     ColumnBuilder::new("customer_location", "varchar")
+                //         .calculated(true)
+                //         .expression("orders.customers.state || '-' || orders.customers.city")
+                //         .build(),
+                // )
                 .primary_key("id")
                 .build(),
         )
@@ -216,6 +229,11 @@ async fn register_ecommerce_mdl(
                 .column(
                     ColumnBuilder::new_calculated("totalprice", "double")
                         .expression("sum(order_items.price)")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new_calculated("customer_city", "varchar")
+                        .expression("customers.city")
                         .build(),
                 )
                 .primary_key("order_id")

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -159,6 +159,22 @@ async fn register_ecommerce_mdl(
                         .expression("orders.customers.state")
                         .build(),
                 )
+                .column(
+                    ColumnBuilder::new_calculated("customer_state_cf", "varchar")
+                        .expression("orders.customers_state")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new_calculated("customer_state_cf_concat", "varchar")
+                        .expression("orders.customers_state || '-test'")
+                        .build(),
+                )
+                .column(
+                    ColumnBuilder::new("totalprice", "double")
+                        .expression("sum(orders.totalprice)")
+                        .calculated(true)
+                        .build(),
+                )
                 .primary_key("id")
                 .build(),
         )

--- a/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
@@ -76,12 +76,37 @@ async fn main() -> Result<()> {
     let analyzed_mdl =
         Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
 
+    // Access totalprice from customer (customer -> orders -> order_items)
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
-        "select totalprice from wrenai.public.orders",
+        "select totalprice from wrenai.public.customers",
     )
     .await
+    {
+        Ok(sql) => sql,
+        Err(e) => {
+            eprintln!("Error transforming SQL: {}", e);
+            return Ok(());
+        }
+    };
+    println!("Transformed SQL: {}", transformed);
+    let df = match ctx.sql(&transformed).await {
+        Ok(df) => df,
+        Err(e) => {
+            eprintln!("Error executing SQL: {}", e);
+            return Ok(());
+        }
+    };
+    df.show().await?;
+
+    // access customer_state from order_items (order_items -> orders -> customers)
+    let transformed = match transform_sql_with_ctx(
+        &ctx,
+        Arc::clone(&analyzed_mdl),
+        "select customer_state_cf from wrenai.public.order_items",
+    )
+        .await
     {
         Ok(sql) => sql,
         Err(e) => {
@@ -114,19 +139,21 @@ fn init_manifest() -> Manifest {
                         .relationship("orders_customer")
                         .build(),
                 )
+                .column(
+                    ColumnBuilder::new("totalprice", "double")
+                        .expression("sum(orders.totalprice)")
+                        .calculated(true)
+                        .build(),
+                )
                 .primary_key("id")
                 .build(),
         )
         .model(
             ModelBuilder::new("order_items")
                 .table_reference("datafusion.public.order_items")
-                .column(ColumnBuilder::new("freight_value", "double").build())
                 .column(ColumnBuilder::new("id", "bigint").build())
-                .column(ColumnBuilder::new("item_number", "bigint").build())
                 .column(ColumnBuilder::new("order_id", "varchar").build())
                 .column(ColumnBuilder::new("price", "double").build())
-                .column(ColumnBuilder::new("product_id", "varchar").build())
-                .column(ColumnBuilder::new("shipping_limit_date", "varchar").build())
                 .column(
                     ColumnBuilder::new("orders", "orders")
                         .relationship("orders_order_items")
@@ -138,18 +165,20 @@ fn init_manifest() -> Manifest {
                         .expression("orders.customers.state")
                         .build(),
                 )
+                .column(
+                    ColumnBuilder::new("customer_state_cf", "varchar")
+                        .calculated(true)
+                        .expression("orders.customer_state")
+                        .build(),
+                )
                 .primary_key("id")
                 .build(),
         )
         .model(
             ModelBuilder::new("orders")
                 .table_reference("datafusion.public.orders")
-                .column(ColumnBuilder::new("approved_timestamp", "varchar").build())
                 .column(ColumnBuilder::new("customer_id", "varchar").build())
-                .column(ColumnBuilder::new("delivered_carrier_date", "varchar").build())
-                .column(ColumnBuilder::new("estimated_delivery_date", "varchar").build())
                 .column(ColumnBuilder::new("order_id", "varchar").build())
-                .column(ColumnBuilder::new("purchase_timestamp", "varchar").build())
                 .column(
                     ColumnBuilder::new("order_items", "order_items")
                         .relationship("orders_order_items")

--- a/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
         Arc::clone(&analyzed_mdl),
         "select customer_state_cf from wrenai.public.order_items",
     )
-        .await
+    .await
     {
         Ok(sql) => sql,
         Err(e) => {

--- a/wren-modeling-rs/wren-example/examples/plan-sql.rs
+++ b/wren-modeling-rs/wren-example/examples/plan-sql.rs
@@ -11,7 +11,7 @@ async fn main() -> datafusion::common::Result<()> {
     let manifest = init_manifest();
     let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
 
-    let sql = "select * from wrenai.public.order_items_model";
+    let sql = "select customer_state from wrenai.public.orders_model";
     println!("Original SQL: \n{}", sql);
     let sql = transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
-        "select customer_state_cf from wrenai.public.order_items",
+        "select order_id, customer_state_cf from wrenai.public.order_items",
     )
     .await
     {
@@ -90,14 +90,14 @@ async fn main() -> Result<()> {
         }
     };
     println!("Transformed SQL: {}", transformed);
-    // let df = match ctx.sql(&transformed).await {
-    //     Ok(df) => df,
-    //     Err(e) => {
-    //         eprintln!("Error executing SQL: {}", e);
-    //         return Ok(());
-    //     }
-    // };
-    // df.show().await?;
+    let df = match ctx.sql(&transformed).await {
+        Ok(df) => df,
+        Err(e) => {
+            eprintln!("Error executing SQL: {}", e);
+            return Ok(());
+        }
+    };
+    df.show().await?;
     Ok(())
 }
 

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
-        "select totalprice from wrenai.public.orders",
+        "select totalprice from wrenai.public.customers",
     )
     .await
     {
@@ -112,6 +112,12 @@ fn init_manifest() -> Manifest {
                 .column(
                     ColumnBuilder::new("orders", "orders")
                         .relationship("orders_customer")
+                        .build(),
+                )
+                // It's a to-many-relationship chain
+                .column(
+                    ColumnBuilder::new_calculated("totalprice", "double")
+                        .expression("sum(orders.order_items.price)")
                         .build(),
                 )
                 .primary_key("id")


### PR DESCRIPTION
# Description
This PR allows the calculation to be used by another model through the relationship. Consider the case in `wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs`:
```rust
.column(
    ColumnBuilder::new("customer_state_cf", "varchar")
        .calculated(true)
        .expression("orders.customer_state")
        .build(),
)
```
We can add a calculated field in `order_items` to access the calculated field `customer_state` in `orders`.

# Known Issue
- Only allow one calculation in an expression currently. We will file another issue for it.