### PR TITLE
Create expressions by SessionContext API

### DIFF
--- a/wren-modeling-py/Cargo.lock
+++ b/wren-modeling-py/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "datafusion",
  "env_logger",
  "log",
+ "parking_lot",
  "petgraph",
  "petgraph-evcxr",
  "serde",

--- a/wren-modeling-py/Cargo.lock
+++ b/wren-modeling-py/Cargo.lock
@@ -139,9 +139,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "arrow"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae9728f104939be6d8d9b368a354b4929b0569160ea1641f0721b55a861ce38"
+checksum = "6127ea5e585a12ec9f742232442828ebaf264dfa5eefdd71282376c599562b77"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7029a5b3efbeafbf4a12d12dc16b8f9e9bff20a410b8c25c5d28acc089e1043"
+checksum = "7add7f39210b7d726e2a8efc0083e7bf06e8f2d15bdb4896b564dce4410fbf5d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33238427c60271710695f17742f45b1a5dc5bcfc5c15331c25ddfe7abf70d97"
+checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9b95e825ae838efaf77e366c00d3fc8cca78134c9db497d6bda425f2e7b7c1"
+checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
 dependencies = [
  "bytes",
  "half",
@@ -203,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cf8385a9d5b5fcde771661dd07652b79b9139fea66193eda6a88664400ccab"
+checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea5068bef430a86690059665e40034625ec323ffa4dd21972048eebb0127adc"
+checksum = "5f843490bd258c5182b66e888161bb6f198f49f3792f7c7f98198b924ae0f564"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -243,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb29be98f987bcf217b070512bb7afba2f65180858bca462edf4a39d84a23e10"
+checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc68f6523970aa6f7ce1dc9a33a7d9284cfb9af77d4ad3e617dbe5d79cc6ec8"
+checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2041380f94bd6437ab648e6c2085a045e45a0c44f91a1b9a4fe3fed3d379bfb1"
+checksum = "654e7f3724176b66ddfacba31af397c48e106fbe4d281c8144e7d237df5acfd7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb56ed1547004e12203652f12fe12e824161ff9d1e5cf2a7dc4ff02ba94f413"
+checksum = "e8008370e624e8e3c68174faaf793540287106cfda8ad1da862fdc53d8e096b4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575b42f1fc588f2da6977b94a5ca565459f5ab07b60545e17243fb9a7ed6d43e"
+checksum = "ca5e3a6b7fda8d9fe03f3b18a2d946354ea7f3c8e4076dbdb502ad50d9d44824"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -320,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32aae6a60458a2389c0da89c9de0b7932427776127da1a738e2efc21d32f3393"
+checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
 
 [[package]]
 name = "arrow-select"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36abaef8767b4220d7b4a8c2fe5ffc78b47db81b03d77e2136091c3ba39102"
+checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e435ada8409bcafc910bc3e0077f532a4daa20e99060a496685c0e3e53cc2597"
+checksum = "0fd04a6ea7de183648edbcb7a6dd925bbd04c210895f6384c780e27a9b54afcd"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -375,13 +375,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
+checksum = "e9ec96fe9a81b5e365f9db71fe00edc4fe4ca2cc7dcb7861f0603012a7caa210"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -498,9 +498,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "bzip2"
@@ -525,13 +525,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]
@@ -693,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f92d2d7a9cba4580900b32b009848d9eb35f1028ac84cdd6ddcf97612cd0068"
+checksum = "ab9d55a9cd2634818953809f75ebe5248b00dd43c3227efb2a51a2d5feaad54e"
 dependencies = [
  "ahash",
  "arrow",
@@ -747,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effed030d2c1667eb1e11df5372d4981eaf5d11a521be32220b3985ae5ba6971"
+checksum = "def66b642959e7f96f5d2da22e1f43d3bd35598f821e5ce351a0553e0f1b7367"
 dependencies = [
  "ahash",
  "arrow",
@@ -769,18 +768,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0091318129dad1359f08e4c6c71f855163c35bba05d1dbf983196f727857894"
+checksum = "f104bb9cb44c06c9badf8a0d7e0855e5f7fa5e395b887d7f835e8a9457dc1352"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-execution"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8385aba84fc4a06d3ebccfbcbf9b4f985e80c762fac634b49079f7cc14933fb1"
+checksum = "2ac0fd8b5d80bbca3fc3b6f40da4e9f6907354824ec3b18bbd83fee8cf5c3c3e"
 dependencies = [
  "arrow",
  "chrono",
@@ -799,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb192f0055d2ce64e38ac100abc18e4e6ae9734d3c28eee522bbbd6a32108a3"
+checksum = "2103d2cc16fb11ef1fa993a6cac57ed5cb028601db4b97566c90e5fa77aa1e68"
 dependencies = [
  "ahash",
  "arrow",
@@ -818,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c081ae5b7edd712b92767fb8ed5c0e32755682f8075707666cd70835807c0b"
+checksum = "a369332afd0ef5bd565f6db2139fb9f1dfdd0afa75a7f70f000b74208d76994f"
 dependencies = [
  "arrow",
  "base64",
@@ -830,7 +829,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-physical-expr",
  "hashbrown",
  "hex",
  "itertools",
@@ -845,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb28a4ea52c28a26990646986a27c4052829a2a2572386258679e19263f8b78"
+checksum = "92718db1aff70c47e5abf9fc975768530097059e5db7c7b78cd64b5e9a11fc77"
 dependencies = [
  "ahash",
  "arrow",
@@ -863,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-array"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b17c02a74cdc87380a56758ec27e7d417356bf806f33062700908929aedb8a"
+checksum = "30bb80f46ff3dcf4bb4510209c2ba9b8ce1b716ac8b7bf70c6bf7dca6260c831"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -876,6 +874,7 @@ dependencies = [
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions",
+ "datafusion-functions-aggregate",
  "itertools",
  "log",
  "paste",
@@ -883,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12172f2a6c9eb4992a51e62d709eeba5dedaa3b5369cce37ff6c2260e100ba76"
+checksum = "82f34692011bec4fdd6fc18c264bf8037b8625d801e6dd8f5111af15cb6d71d3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -897,14 +896,15 @@ dependencies = [
  "indexmap",
  "itertools",
  "log",
+ "paste",
  "regex-syntax",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3fce531b623e94180f6cd33d620ef01530405751b6ddd2fd96250cdbd78e2e"
+checksum = "45538630defedb553771434a437f7ca8f04b9b3e834344aafacecb27dc65d5e5"
 dependencies = [
  "ahash",
  "arrow",
@@ -918,7 +918,6 @@ dependencies = [
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate",
  "datafusion-physical-expr-common",
  "half",
  "hashbrown",
@@ -933,21 +932,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046400b6a2cc3ed57a7c576f5ae6aecc77804ac8e0186926b278b189305b2a77"
+checksum = "9d8a72b0ca908e074aaeca52c14ddf5c28d22361e9cb6bc79bb733cd6661b536"
 dependencies = [
+ "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
+ "hashbrown",
  "rand",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aed47f5a2ad8766260befb375b201592e86a08b260256e168ae4311426a2bff"
+checksum = "b504eae6107a342775e22e323e9103f7f42db593ec6103b28605b7b7b1405c4a"
 dependencies = [
  "ahash",
  "arrow",
@@ -979,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "39.0.0"
+version = "40.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fa92bb1fd15e46ce5fb6f1c85f3ac054592560f294429a28e392b5f9cd4255e"
+checksum = "e5db33f323f41b95ae201318ba654a9bf11113e58a51a1dff977b1a836d3d889"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1153,7 +1154,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1688,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.0.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c3b5322cc1bbf67f11c079c42be41a55949099b78732f7dba9e15edde40eab"
+checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1888,7 +1889,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1901,7 +1902,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -1954,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2059,22 +2060,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2166,7 +2167,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2194,7 +2195,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2216,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "tempfile"
@@ -2245,22 +2246,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2285,9 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2300,9 +2301,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2319,7 +2320,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2354,7 +2355,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -2440,9 +2441,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
@@ -2490,7 +2491,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-shared",
 ]
 
@@ -2512,7 +2513,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2562,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2578,51 +2579,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wren-core"
@@ -2662,47 +2663,47 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "fa556e971e7b568dc775c136fc9de8c779b1c2fc3a63defaafadffdbd3181afa"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
  "pkg-config",

--- a/wren-modeling-rs/Cargo.toml
+++ b/wren-modeling-rs/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 async-trait = "0.1.80"
-datafusion = { version = "39.0.0", features = ["backtrace"] }
+datafusion = { version = "40.0.0", features = ["backtrace"] }
 env_logger = "0.11.3"
 log = { version = "0.4.14" }
 petgraph = "0.6.5"

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -17,9 +17,9 @@ async-trait = { workspace = true }
 datafusion = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }
+parking_lot = "0.12.3"
 petgraph = "0.6.5"
 petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-parking_lot = "0.12.3"

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -22,3 +22,4 @@ petgraph-evcxr = "*"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+parking_lot = "0.12.3"

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -663,7 +663,9 @@ impl ModelSourceNode {
         for expr in required_exprs.iter() {
             if let Expr::Wildcard { qualifier } = expr {
                 let model = if let Some(model) = qualifier {
-                    let Some(model) = analyzed_wren_mdl.wren_mdl.get_model(model) else {
+                    let Some(model) =
+                        analyzed_wren_mdl.wren_mdl.get_model(&format!("{model}"))
+                    else {
                         return plan_err!("Model not found {}", &model);
                     };
                     model

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -7,9 +7,9 @@ use crate::logical_plan::utils::create_schema;
 use crate::mdl;
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::JoinType;
-use crate::mdl::{AnalyzedWrenMDL, Dataset};
+use crate::mdl::AnalyzedWrenMDL;
 use datafusion::catalog::TableReference;
-use datafusion::common::{internal_err, not_impl_err, plan_err, DFSchema, DFSchemaRef};
+use datafusion::common::{DFSchema, DFSchemaRef, internal_err, not_impl_err, plan_err};
 use datafusion::logical_expr::{
     col, Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
 };
@@ -17,6 +17,7 @@ use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
+use crate::mdl::dataset::Dataset;
 
 /// RelationChain is a chain of models that are connected by the relationship.
 /// The chain is used to generate the join plan for the model.

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -63,10 +63,14 @@ impl ModelAnalyzeRule {
                 let mut buffer = used_columns.borrow_mut();
                 buffer.clear();
                 let mut accum = HashSet::new();
-                let _ = utils::exprlist_to_columns(&aggregate.aggr_expr, &mut accum);
-                let _ = utils::exprlist_to_columns(&aggregate.group_expr, &mut accum);
+                let _ = &aggregate.aggr_expr.iter().for_each(|expr| {
+                    Expr::add_column_refs(expr, &mut accum);
+                });
+                let _ = &aggregate.group_expr.iter().for_each(|expr| {
+                    Expr::add_column_refs(expr, &mut accum);
+                });
                 accum.iter().for_each(|expr| {
-                    buffer.insert(Expr::Column(expr.clone()));
+                    buffer.insert(Expr::Column(expr.to_owned().clone()));
                 });
                 Ok(Transformed::no(LogicalPlan::Aggregate(aggregate)))
             }

--- a/wren-modeling-rs/core/src/logical_plan/context_provider.rs
+++ b/wren-modeling-rs/core/src/logical_plan/context_provider.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::datatypes::DataType;
 use datafusion::datasource::DefaultTableSource;
-use datafusion::logical_expr::builder::LogicalTableSource;
 use datafusion::{
     common::{plan_err, Result},
     config::ConfigOptions,
@@ -10,11 +9,11 @@ use datafusion::{
     sql::{planner::ContextProvider, TableReference},
 };
 
-use crate::mdl::manifest::{Column, Model};
-use crate::mdl::{utils, WrenMDL};
+use crate::mdl::WrenMDL;
 
-use super::utils::{create_table_source, map_data_type};
+use super::utils::create_table_source;
 
+#[deprecated(since = "0.8.0", note = "try to create plan by SessionContext instead")]
 /// WrenContextProvider is a ContextProvider implementation that uses the WrenMDL
 /// to provide table sources and other metadata.
 pub struct WrenContextProvider {
@@ -22,6 +21,7 @@ pub struct WrenContextProvider {
     tables: HashMap<String, Arc<dyn TableSource>>,
 }
 
+#[allow(deprecated)]
 impl WrenContextProvider {
     pub fn new(mdl: &WrenMDL) -> Result<Self> {
         let mut tables = HashMap::new();
@@ -57,6 +57,7 @@ impl WrenContextProvider {
     }
 }
 
+#[allow(deprecated)]
 impl ContextProvider for WrenContextProvider {
     fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
         let table_name = name.to_string();
@@ -84,175 +85,6 @@ impl ContextProvider for WrenContextProvider {
 
     fn options(&self) -> &ConfigOptions {
         &self.options
-    }
-
-    fn udf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn udaf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn udwf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-}
-
-/// RemoteContextProvider is a ContextProvider implementation that is used to provide
-/// the schema for the remote column in the column expression
-pub struct RemoteContextProvider {
-    options: ConfigOptions,
-    tables: HashMap<String, Arc<dyn TableSource>>,
-}
-
-impl RemoteContextProvider {
-    pub fn new(mdl: &WrenMDL) -> Result<Self> {
-        let tables = mdl
-            .manifest
-            .models
-            .iter()
-            .map(|model| {
-                let remove_provider = mdl.get_table(&model.table_reference);
-                let datasource = if let Some(table_provider) = remove_provider {
-                    Arc::new(DefaultTableSource::new(table_provider))
-                } else {
-                    create_remote_table_source(model, mdl)?
-                };
-                Ok((model.table_reference.clone(), datasource))
-            })
-            .collect::<Result<HashMap<_, _>>>()?;
-        Ok(Self {
-            tables,
-            options: Default::default(),
-        })
-    }
-}
-
-impl ContextProvider for RemoteContextProvider {
-    fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
-        match self.tables.get(name.to_string().as_str()) {
-            Some(table) => Ok(table.clone()),
-            _ => plan_err!("Table not found: {}", name.table()),
-        }
-    }
-
-    fn get_function_meta(&self, _name: &str) -> Option<Arc<ScalarUDF>> {
-        None
-    }
-
-    fn get_aggregate_meta(&self, _name: &str) -> Option<Arc<AggregateUDF>> {
-        None
-    }
-
-    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
-        None
-    }
-
-    fn get_window_meta(&self, _name: &str) -> Option<Arc<WindowUDF>> {
-        None
-    }
-
-    fn options(&self) -> &ConfigOptions {
-        &self.options
-    }
-
-    fn udf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn udaf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn udwf_names(&self) -> Vec<String> {
-        Vec::new()
-    }
-}
-
-fn create_remote_table_source(
-    model: &Model,
-    wren_mdl: &WrenMDL,
-) -> Result<Arc<dyn TableSource>> {
-    if let Some(table_provider) = wren_mdl.get_table(&model.table_reference) {
-        Ok(Arc::new(DefaultTableSource::new(table_provider)))
-    } else {
-        let schema = create_schema(model.get_physical_columns());
-        Ok(Arc::new(LogicalTableSource::new(schema?)))
-    }
-}
-
-fn create_schema(columns: Vec<Arc<Column>>) -> Result<SchemaRef> {
-    let fields: Vec<Field> = columns
-        .iter()
-        .filter(|c| !c.is_calculated)
-        .flat_map(|column| {
-            if column.expression.is_none() {
-                let data_type = if let Ok(data_type) = map_data_type(&column.r#type) {
-                    data_type
-                } else {
-                    // TODO optimize to use Datafusion's error type
-                    unimplemented!("Unsupported data type: {}", column.r#type)
-                };
-                vec![Field::new(&column.name, data_type, column.no_null)]
-            } else if let Ok(idents) =
-                utils::collect_identifiers(column.expression.as_ref().unwrap())
-            {
-                idents
-                    .iter()
-                    .map(|c| {
-                        // we don't know the data type or nullable of the remote table,
-                        // so we just mock a Int32 type and false here
-                        Field::new(&c.name, DataType::Int8, true)
-                    })
-                    .collect()
-            } else {
-                panic!(
-                    "Failed to collect identifiers from expression: {}",
-                    column.expression.as_ref().unwrap()
-                );
-            }
-        })
-        .collect();
-    Ok(SchemaRef::new(Schema::new_with_metadata(
-        fields,
-        HashMap::new(),
-    )))
-}
-
-pub(crate) struct DynamicContextProvider {
-    delegate: Box<dyn ContextProvider>,
-}
-
-impl DynamicContextProvider {
-    pub fn new(delegate: Box<dyn ContextProvider>) -> Self {
-        Self { delegate }
-    }
-}
-
-impl ContextProvider for DynamicContextProvider {
-    fn get_table_source(&self, name: TableReference) -> Result<Arc<dyn TableSource>> {
-        self.delegate.get_table_source(name)
-    }
-
-    fn get_function_meta(&self, _name: &str) -> Option<Arc<ScalarUDF>> {
-        None
-    }
-
-    fn get_aggregate_meta(&self, _name: &str) -> Option<Arc<AggregateUDF>> {
-        None
-    }
-
-    fn get_window_meta(&self, _name: &str) -> Option<Arc<WindowUDF>> {
-        None
-    }
-
-    fn get_variable_type(&self, _variable_names: &[String]) -> Option<DataType> {
-        None
-    }
-
-    fn options(&self) -> &ConfigOptions {
-        self.delegate.options()
     }
 
     fn udf_names(&self) -> Vec<String> {

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -11,8 +11,9 @@ use petgraph::Graph;
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::{
     manifest::{Column, Model},
-    Dataset, WrenMDL,
+    WrenMDL,
 };
+use crate::mdl::dataset::Dataset;
 
 pub fn map_data_type(data_type: &str) -> Result<DataType> {
     let result = match data_type {

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -9,11 +9,11 @@ use petgraph::dot::{Config, Dot};
 use petgraph::Graph;
 
 use crate::mdl::lineage::DatasetLink;
+use crate::mdl::Dataset;
 use crate::mdl::{
     manifest::{Column, Model},
     WrenMDL,
 };
-use crate::mdl::dataset::Dataset;
 
 pub fn map_data_type(data_type: &str) -> Result<DataType> {
     let result = match data_type {

--- a/wren-modeling-rs/core/src/mdl/context.rs
+++ b/wren-modeling-rs/core/src/mdl/context.rs
@@ -26,7 +26,10 @@ pub async fn create_ctx_with_mdl(
     let new_state = ctx
         .state()
         .with_analyzer_rules(vec![
-            Arc::new(ModelAnalyzeRule::new(Arc::clone(&analyzed_mdl))),
+            Arc::new(ModelAnalyzeRule::new(
+                Arc::clone(&analyzed_mdl),
+                ctx.state_ref(),
+            )),
             Arc::new(ModelGenerationRule::new(Arc::clone(&analyzed_mdl))),
             Arc::new(RemoveWrenPrefixRule::new(Arc::clone(&analyzed_mdl))),
         ])

--- a/wren-modeling-rs/core/src/mdl/dataset.rs
+++ b/wren-modeling-rs/core/src/mdl/dataset.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+use std::fmt::Display;
+use crate::mdl::manifest::{Column, Metric, Model};
+
+impl Model {
+    /// Physical columns are columns that can be selected from the model.
+    /// e.g. columns that are not a relationship column
+    pub fn get_physical_columns(&self) -> Vec<Arc<Column>> {
+        self.columns
+            .iter()
+            .filter(|c| c.relationship.is_none())
+            .map(Arc::clone)
+            .collect()
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn get_column(&self, column_name: &str) -> Option<Arc<Column>> {
+        self.columns
+            .iter()
+            .find(|c| c.name == column_name)
+            .map(Arc::clone)
+    }
+
+    pub fn primary_key(&self) -> Option<&str> {
+        self.primary_key.as_deref()
+    }
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub enum Dataset {
+    Model(Arc<Model>),
+    Metric(Arc<Metric>),
+}
+
+impl Dataset {
+    pub fn name(&self) -> &str {
+        match self {
+            Dataset::Model(model) => model.name(),
+            Dataset::Metric(metric) => metric.name(),
+        }
+    }
+
+    pub fn try_as_model(&self) -> Option<Arc<Model>> {
+        match self {
+            Dataset::Model(model) => Some(Arc::clone(model)),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Dataset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Dataset::Model(model) => write!(f, "{}", model.name()),
+            Dataset::Metric(metric) => write!(f, "{}", metric.name()),
+        }
+    }
+}

--- a/wren-modeling-rs/core/src/mdl/dataset.rs
+++ b/wren-modeling-rs/core/src/mdl/dataset.rs
@@ -1,6 +1,16 @@
-use std::sync::Arc;
-use std::fmt::Display;
+use crate::logical_plan::utils::map_data_type;
 use crate::mdl::manifest::{Column, Metric, Model};
+use crate::mdl::{RegisterTables, SessionStateRef};
+use datafusion::arrow::datatypes::DataType::Utf8;
+use datafusion::arrow::datatypes::Field;
+use datafusion::common::DFSchema;
+use datafusion::common::Result;
+use datafusion::logical_expr::sqlparser::ast::Expr::CompoundIdentifier;
+use datafusion::sql::sqlparser::ast::Expr::Identifier;
+use datafusion::sql::sqlparser::ast::{visit_expressions, Expr, Ident};
+use std::fmt::Display;
+use std::ops::ControlFlow;
+use std::sync::Arc;
 
 impl Model {
     /// Physical columns are columns that can be selected from the model.
@@ -29,6 +39,51 @@ impl Model {
     }
 }
 
+impl Column {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn expression(&self) -> Option<&str> {
+        self.expression.as_deref()
+    }
+
+    pub fn to_field(&self) -> Result<Field> {
+        let data_type = map_data_type(&self.r#type)?;
+        Ok(Field::new(&self.name, data_type, self.no_null))
+    }
+
+    pub fn to_remote_field(&self, session_state: SessionStateRef) -> Result<Vec<Field>> {
+        if self.expression().is_some() {
+            let session_state = session_state.read();
+            let expr = session_state.sql_to_expr(
+                self.expression().unwrap(),
+                session_state.config_options().sql_parser.dialect.as_str(),
+            )?;
+            let columns = Self::collect_columns(expr);
+            Ok(columns
+                .into_iter()
+                .map(|c| Field::new(c.value, Utf8, false))
+                .collect())
+        } else {
+            Ok(vec![self.to_field()?])
+        }
+    }
+
+    fn collect_columns(expr: Expr) -> Vec<Ident> {
+        let mut visited = vec![];
+        visit_expressions(&expr, |e| {
+            if let CompoundIdentifier(ids) = e {
+                ids.iter().cloned().for_each(|id| visited.push(id));
+            } else if let Identifier(id) = e {
+                visited.push(id.clone());
+            }
+            ControlFlow::<()>::Continue(())
+        });
+        visited
+    }
+}
+
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum Dataset {
     Model(Arc<Model>),
@@ -47,6 +102,58 @@ impl Dataset {
         match self {
             Dataset::Model(model) => Some(Arc::clone(model)),
             _ => None,
+        }
+    }
+
+    pub fn to_qualified_schema(&self) -> Result<DFSchema> {
+        match self {
+            Dataset::Model(model) => {
+                let fields = model
+                    .get_physical_columns()
+                    .iter()
+                    .map(|c| c.to_field())
+                    .collect::<Result<Vec<_>>>()?;
+                let arrow_schema = datafusion::arrow::datatypes::Schema::new(fields);
+                DFSchema::try_from_qualified_schema(&model.name, &arrow_schema)
+            }
+            Dataset::Metric(_) => todo!(),
+        }
+    }
+
+    /// Create the schema with the remote table name
+    pub fn to_remote_schema(
+        &self,
+        register_tables: Option<&RegisterTables>,
+        session_state: SessionStateRef,
+    ) -> Result<DFSchema> {
+        match self {
+            Dataset::Model(model) => {
+                let schema = register_tables
+                    .map(|rt| rt.get(&model.table_reference))
+                    .filter(|rt| rt.is_some())
+                    .map(|rt| rt.unwrap().schema());
+
+                if let Some(schema) = schema {
+                    DFSchema::try_from_qualified_schema(&model.table_reference, &schema)
+                } else {
+                    let fields: Vec<Field> = model
+                        .get_physical_columns()
+                        .iter()
+                        .filter(|c| !c.is_calculated)
+                        .map(|c| c.to_remote_field(Arc::clone(&session_state)))
+                        .collect::<Result<Vec<Vec<Field>>>>()?
+                        .iter()
+                        .flat_map(|c| c.clone())
+                        .collect();
+                    let arrow_schema = datafusion::arrow::datatypes::Schema::new(fields);
+
+                    DFSchema::try_from_qualified_schema(
+                        &model.table_reference,
+                        &arrow_schema,
+                    )
+                }
+            }
+            Dataset::Metric(_) => todo!(),
         }
     }
 }

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
 
-use datafusion::common::{internal_err, plan_err, Column};
+use datafusion::common::{Column, internal_err, plan_err};
 use datafusion::error::Result;
 use datafusion::sql::TableReference;
 use petgraph::Graph;
@@ -12,7 +12,7 @@ use crate::mdl::{utils, WrenMDL};
 
 use super::manifest::{JoinType, Relationship};
 use super::utils::{collect_identifiers, to_expr_queue};
-use super::Dataset;
+use crate::mdl::dataset::Dataset;
 
 pub struct Lineage {
     pub source_columns_map: HashMap<Column, HashSet<Column>>,
@@ -327,7 +327,8 @@ mod test {
     };
     use crate::mdl::lineage::Lineage;
     use crate::mdl::manifest::JoinType;
-    use crate::mdl::{Dataset, WrenMDL};
+    use crate::mdl::WrenMDL;
+    use crate::mdl::dataset::Dataset;
 
     #[test]
     fn test_collect_source_columns() -> Result<()> {

--- a/wren-modeling-rs/core/src/mdl/lineage.rs
+++ b/wren-modeling-rs/core/src/mdl/lineage.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
 
-use datafusion::common::{Column, internal_err, plan_err};
+use datafusion::common::{internal_err, plan_err, Column};
 use datafusion::error::Result;
 use datafusion::sql::TableReference;
 use petgraph::Graph;
@@ -12,7 +12,7 @@ use crate::mdl::{utils, WrenMDL};
 
 use super::manifest::{JoinType, Relationship};
 use super::utils::{collect_identifiers, to_expr_queue};
-use crate::mdl::dataset::Dataset;
+use crate::mdl::Dataset;
 
 pub struct Lineage {
     pub source_columns_map: HashMap<Column, HashSet<Column>>,
@@ -327,8 +327,8 @@ mod test {
     };
     use crate::mdl::lineage::Lineage;
     use crate::mdl::manifest::JoinType;
+    use crate::mdl::Dataset;
     use crate::mdl::WrenMDL;
-    use crate::mdl::dataset::Dataset;
 
     #[test]
     fn test_collect_source_columns() -> Result<()> {

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -39,33 +39,6 @@ pub struct Model {
     pub properties: Vec<(String, String)>,
 }
 
-impl Model {
-    /// Physical columns are columns that can be selected from the model.
-    /// e.g. columns that are not a relationship column
-    pub fn get_physical_columns(&self) -> Vec<Arc<Column>> {
-        self.columns
-            .iter()
-            .filter(|c| c.relationship.is_none())
-            .map(Arc::clone)
-            .collect()
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub fn get_column(&self, column_name: &str) -> Option<Arc<Column>> {
-        self.columns
-            .iter()
-            .find(|c| c.name == column_name)
-            .map(Arc::clone)
-    }
-
-    pub fn primary_key(&self) -> Option<&str> {
-        self.primary_key.as_deref()
-    }
-}
-
 mod table_reference {
     use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -123,12 +123,6 @@ pub struct Column {
     pub properties: Vec<(String, String)>,
 }
 
-impl Column {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Relationship {

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, sync::Arc};
 use datafusion::prelude::SessionContext;
 use datafusion::{error::Result, sql::unparser::plan_to_sql};
 use log::{debug, info};
-
+use dataset::Dataset;
 use manifest::Relationship;
 
 use crate::logical_plan::utils::from_qualified_name_str;
@@ -224,37 +224,6 @@ impl ColumnReference {
 
     pub fn get_qualified_name(&self) -> String {
         format!("{}.{}", self.dataset.name(), self.column.name)
-    }
-}
-
-#[derive(PartialEq, Eq, Hash, Debug, Clone)]
-pub enum Dataset {
-    Model(Arc<Model>),
-    Metric(Arc<Metric>),
-}
-
-impl Dataset {
-    pub fn name(&self) -> &str {
-        match self {
-            Dataset::Model(model) => model.name(),
-            Dataset::Metric(metric) => metric.name(),
-        }
-    }
-
-    pub fn try_as_model(&self) -> Option<Arc<Model>> {
-        match self {
-            Dataset::Model(model) => Some(Arc::clone(model)),
-            _ => None,
-        }
-    }
-}
-
-impl Display for Dataset {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Dataset::Model(model) => write!(f, "{}", model.name()),
-            Dataset::Metric(metric) => write!(f, "{}", metric.name()),
-        }
     }
 }
 

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -1,21 +1,25 @@
-use std::fmt::Display;
-use std::{collections::HashMap, sync::Arc};
-
+use datafusion::execution::context::SessionState;
 use datafusion::prelude::SessionContext;
 use datafusion::{error::Result, sql::unparser::plan_to_sql};
 use log::{debug, info};
-use dataset::Dataset;
 use manifest::Relationship;
+use parking_lot::RwLock;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::logical_plan::utils::from_qualified_name_str;
 use crate::mdl::context::create_ctx_with_mdl;
-use crate::mdl::manifest::{Column, Manifest, Metric, Model};
+use crate::mdl::manifest::{Column, Manifest, Model};
 
 pub mod builder;
 pub mod context;
+pub(crate) mod dataset;
 pub mod lineage;
 pub mod manifest;
 pub mod utils;
+
+pub use dataset::Dataset;
+
+pub type SessionStateRef = Arc<RwLock<SessionState>>;
 
 pub struct AnalyzedWrenMDL {
     pub wren_mdl: Arc<WrenMDL>,
@@ -53,11 +57,12 @@ impl AnalyzedWrenMDL {
     }
 }
 
+pub type RegisterTables = HashMap<String, Arc<dyn datafusion::datasource::TableProvider>>;
 // This is the main struct that holds the manifest and provides methods to access the models
 pub struct WrenMDL {
     pub manifest: Manifest,
     pub qualified_references: HashMap<datafusion::common::Column, ColumnReference>,
-    pub register_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>>,
+    pub register_tables: RegisterTables,
 }
 
 impl WrenMDL {
@@ -136,9 +141,7 @@ impl WrenMDL {
         self.register_tables.get(name).cloned()
     }
 
-    pub fn get_register_tables(
-        &self,
-    ) -> &HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> {
+    pub fn get_register_tables(&self) -> &RegisterTables {
         &self.register_tables
     }
 
@@ -276,14 +279,14 @@ mod test {
         let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl)?);
 
         let tests: Vec<&str> = vec![
-                "select orderkey + orderkey from test.test.orders",
-                "select orderkey from test.test.orders where orders.totalprice > 10",
-                "select orders.orderkey from test.test.orders left join test.test.customer on (orders.custkey = customer.custkey) where orders.totalprice > 10",
-                "select orderkey, min(totalprice) from test.test.orders group by 1",
-                "select orderkey, count(*) from test.test.orders where orders.totalprice > 10 group by 1",
-                "select min_totalcost from test.test.profile",
-        // TODO: support calculated without relationship
-        //     "select orderkey_plus_custkey from orders",
+            "select orderkey + orderkey from test.test.orders",
+            "select orderkey from test.test.orders where orders.totalprice > 10",
+            "select orders.orderkey from test.test.orders left join test.test.customer on (orders.custkey = customer.custkey) where orders.totalprice > 10",
+            "select orderkey, sum(totalprice) from test.test.orders group by 1",
+            "select orderkey, count(*) from test.test.orders where orders.totalprice > 10 group by 1",
+            "select totalcost from test.test.profile",
+            // TODO: support calculated without relationship
+            // "select orderkey_plus_custkey from orders",
         ];
 
         for sql in tests {
@@ -294,8 +297,8 @@ mod test {
                 sql,
             )
             .await?;
-            let after_roundtrip = plan_sql(&actual, Arc::clone(&analyzed_mdl)).await?;
-            println!("After roundtrip: {}", after_roundtrip);
+            // let after_roundtrip = plan_sql(&actual, Arc::clone(&analyzed_mdl)).await?;
+            // println!("After roundtrip: {}", after_roundtrip);
         }
 
         Ok(())

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -276,7 +276,7 @@ mod tests {
         let ctx = SessionContext::new();
         let model = analyzed_mdl.wren_mdl().get_model("customer").unwrap();
         let expr = super::create_wren_expr_for_model(
-            &"name".to_string(),
+            "name",
             Arc::clone(&model),
             ctx.state_ref(),
         )?;
@@ -296,7 +296,7 @@ mod tests {
         let ctx = SessionContext::new();
         let model = analyzed_mdl.wren_mdl().get_model("customer").unwrap();
         let expr = super::create_remote_expr_for_model(
-            &"c_name".to_string(),
+            "c_name",
             Arc::clone(&model),
             analyzed_mdl,
             ctx.state_ref(),

--- a/wren-modeling-rs/core/tests/data/mdl.json
+++ b/wren-modeling-rs/core/tests/data/mdl.json
@@ -13,7 +13,7 @@
         {
           "name": "custkey",
           "type": "integer",
-          "expression": "c_orderkey"
+          "expression": "c_custkey"
         },
         {
           "name": "name",
@@ -61,10 +61,10 @@
           "relationship": "CustomerProfile"
         },
         {
-          "name": "totalcost",
+          "name": "min_totalcost",
           "type": "integer",
           "isCalculated": true,
-          "expression": "sum(customer.orders.totalprice)"
+          "expression": "min(customer.orders.totalprice)"
         }
       ],
       "primaryKey": "custkey"

--- a/wren-modeling-rs/core/tests/data/mdl.json
+++ b/wren-modeling-rs/core/tests/data/mdl.json
@@ -61,10 +61,10 @@
           "relationship": "CustomerProfile"
         },
         {
-          "name": "min_totalcost",
+          "name": "totalcost",
           "type": "integer",
           "isCalculated": true,
-          "expression": "min(customer.orders.totalprice)"
+          "expression": "sum(customer.orders.totalprice)"
         }
       ],
       "primaryKey": "custkey"


### PR DESCRIPTION
# Description
As mentioned in https://github.com/Canner/wren-engine/pull/681#discussion_r1682494258, DataFusion moves many functions out of the core. If we used the context provider and created the expression by ourselves, we should register many functions for it. This PR uses `SessionCotnext#SessionState` to create what we need.