### PR TITLE
Fix `RemoveWrenPrefixRule` for being executed by DataFusion

### DIFF
--- a/wren-modeling-rs/core/src/mdl/context.rs
+++ b/wren-modeling-rs/core/src/mdl/context.rs
@@ -19,6 +19,9 @@ use crate::logical_plan::utils::create_schema;
 use crate::mdl::manifest::Model;
 use crate::mdl::{AnalyzedWrenMDL, WrenMDL};
 
+/// Apply Wren Rules to the context for sql generation.
+/// TODO: There're some issue for unparsing the datafusion optimized plans.
+///   Disable all the optimize rule for sql generation temporarily.
 pub async fn create_ctx_with_mdl(
     ctx: &SessionContext,
     analyzed_mdl: Arc<AnalyzedWrenMDL>,

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -1,3 +1,6 @@
+use crate::logical_plan::utils::from_qualified_name_str;
+use crate::mdl::context::create_ctx_with_mdl;
+use crate::mdl::manifest::{Column, Manifest, Model};
 use datafusion::execution::context::SessionState;
 use datafusion::prelude::SessionContext;
 use datafusion::{error::Result, sql::unparser::plan_to_sql};
@@ -6,10 +9,6 @@ use manifest::Relationship;
 use parking_lot::RwLock;
 use std::{collections::HashMap, sync::Arc};
 
-use crate::logical_plan::utils::from_qualified_name_str;
-use crate::mdl::context::create_ctx_with_mdl;
-use crate::mdl::manifest::{Column, Manifest, Model};
-
 pub mod builder;
 pub mod context;
 pub(crate) mod dataset;
@@ -17,6 +16,9 @@ pub mod lineage;
 pub mod manifest;
 pub mod utils;
 
+use crate::logical_plan::analyze::rule::{
+    ModelAnalyzeRule, ModelGenerationRule, RemoveWrenPrefixRule,
+};
 pub use dataset::Dataset;
 
 pub type SessionStateRef = Arc<RwLock<SessionState>>;
@@ -208,6 +210,20 @@ pub async fn transform_sql_with_ctx(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Apply Wren Rules to a given session context with a WrenMDL
+pub fn apply_wren_rules(ctx: &SessionContext, analyzed_wren_mdl: Arc<AnalyzedWrenMDL>) {
+    ctx.add_analyzer_rule(Arc::new(ModelAnalyzeRule::new(
+        Arc::clone(&analyzed_wren_mdl),
+        ctx.state_ref(),
+    )));
+    ctx.add_analyzer_rule(Arc::new(ModelGenerationRule::new(Arc::clone(
+        &analyzed_wren_mdl,
+    ))));
+    ctx.add_analyzer_rule(Arc::new(RemoveWrenPrefixRule::new(Arc::clone(
+        &analyzed_wren_mdl,
+    ))));
 }
 
 /// Analyze the decision point. It's same as the /v1/analysis/sql API in wren engine

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -213,7 +213,10 @@ pub async fn transform_sql_with_ctx(
 }
 
 /// Apply Wren Rules to a given session context with a WrenMDL
-pub async fn apply_wren_rules(ctx: &SessionContext, analyzed_wren_mdl: Arc<AnalyzedWrenMDL>) -> Result<()>{
+pub async fn apply_wren_rules(
+    ctx: &SessionContext,
+    analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
+) -> Result<()> {
     ctx.add_analyzer_rule(Arc::new(ModelAnalyzeRule::new(
         Arc::clone(&analyzed_wren_mdl),
         ctx.state_ref(),

--- a/wren-modeling-rs/sqllogictest/src/engine/runner.rs
+++ b/wren-modeling-rs/sqllogictest/src/engine/runner.rs
@@ -24,7 +24,6 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::prelude::SessionContext;
 use log::info;
 use sqllogictest::DBOutput;
-use wren_core::mdl::transform_sql_with_ctx;
 
 use super::{
     error::Result,
@@ -55,12 +54,6 @@ impl sqllogictest::AsyncDB for DataFusion {
             self.relative_path.display(),
             sql
         );
-        let sql = transform_sql_with_ctx(
-            self.ctx.session_ctx(),
-            Arc::clone(self.ctx.analyzed_wren_mdl()),
-            sql,
-        )
-        .await?;
         run_query(self.ctx.session_ctx(), sql).await
     }
 

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -249,9 +249,11 @@ async fn register_ecommerce_mdl(
                 .condition("orders.order_id = order_items.order_id")
                 .build(),
         )
-        .view(ViewBuilder::new("customer_view")
-            .statement("select * from wrenai.public.customers")
-            .build())
+        .view(
+            ViewBuilder::new("customer_view")
+                .statement("select * from wrenai.public.customers")
+                .build(),
+        )
         // TODO: support expression without alias inside view
         // .view(ViewBuilder::new("revenue_orders").statement("select order_id, sum(price) from wrenai.public.order_items group by order_id").build())
         // TODO: fix view with calculation

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -24,12 +24,11 @@ use datafusion::prelude::SessionConfig;
 use datafusion::prelude::{CsvReadOptions, SessionContext};
 use log::info;
 use tempfile::TempDir;
-
 use wren_core::mdl::builder::{
     ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder, ViewBuilder,
 };
 use wren_core::mdl::manifest::JoinType;
-use wren_core::mdl::AnalyzedWrenMDL;
+use wren_core::mdl::{apply_wren_rules, AnalyzedWrenMDL};
 
 use crate::engine::utils::read_dir_recursive;
 
@@ -297,17 +296,6 @@ async fn register_ecommerce_mdl(
         manifest,
         register_tables,
     )?);
-    // let new_state = ctx
-    //     .state()
-    //     .add_analyzer_rule(Arc::new(ModelAnalyzeRule::
-    //
-    // new(Arc::clone(&analyzed_mdl))))
-    //     .add_analyzer_rule(Arc::new(ModelGenerationRule::new(Arc::clone(
-    //         &analyzed_mdl,
-    //     ))))
-    //     // TODO: disable optimize_projections rule
-    //     // There are some conflict with the optimize rule, [datafusion::optimizer::optimize_projections::OptimizeProjections]
-    //     .with_optimizer_rules(vec![]);
-    // let ctx = SessionContext::new_with_state(new_state);
+    apply_wren_rules(ctx, Arc::clone(&analyzed_mdl));
     Ok((ctx.to_owned(), analyzed_mdl))
 }

--- a/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
@@ -1,7 +1,7 @@
 statement ok
-SELECT * FROM wrenai.public.orders_view
+SELECT * FROM wrenai.public.customer_view
 
-query TR
-SELECT * FROM wrenai.public.revenue_orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'
-----
-76754c0e642c8f99a8c3fcb8a14ac700 287.4
+#query TR
+#SELECT totalprice FROM wrenai.public.revenue_orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'
+#----
+#76754c0e642c8f99a8c3fcb8a14ac700 287.4

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -7,9 +7,8 @@ use datafusion::prelude::{CsvReadOptions, SessionContext};
 use wren_core::mdl::builder::{
     ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder,
 };
-use wren_core::mdl::context::create_ctx_with_mdl;
 use wren_core::mdl::manifest::{JoinType, Manifest};
-use wren_core::mdl::AnalyzedWrenMDL;
+use wren_core::mdl::{AnalyzedWrenMDL, apply_wren_rules};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -76,7 +75,7 @@ async fn main() -> Result<()> {
     ]);
     let analyzed_mdl =
         Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
-    let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl).await?;
+    apply_wren_rules(&ctx, analyzed_mdl).await?;
     let df = match ctx
         .sql("select totalprice from wrenai.public.customers")
         .await

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -8,7 +8,7 @@ use wren_core::mdl::builder::{
     ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder,
 };
 use wren_core::mdl::manifest::{JoinType, Manifest};
-use wren_core::mdl::{AnalyzedWrenMDL, apply_wren_rules};
+use wren_core::mdl::{apply_wren_rules, AnalyzedWrenMDL};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
# Description
- Fix the `RemoveWrenPrefixRule` for the correct plan schema.
- Provide an API for applying rules for an existing session context.
- Make sqlloigctests tests to apply rules directly.

## Fix the sqllogictests
I didn't find the sqllogictests is broken. So, many test cases are failed and skipped but I didn't know. I commented out some cases and I'll file the issues for them.