### PR TITLE
Enhance the analysis API for the location of Join Criteria and source columns

### DIFF
--- a/ibis-server/tests/routers/v2/test_analysis.py
+++ b/ibis-server/tests/routers/v2/test_analysis.py
@@ -101,6 +101,7 @@ def test_analysis_sql_select_all_customer():
             "expression": "custkey",
             "nodeLocation": {"line": 1, "column": 8},
             "sourceDataset": "customer",
+            "sourceColumn": "custkey",
         },
     ]
     assert result[0]["selectItems"][1]["nodeLocation"] == {"line": 1, "column": 8}
@@ -132,6 +133,7 @@ def test_analysis_sql_group_by_customer():
                 "expression": "custkey",
                 "nodeLocation": {"line": 1, "column": 8},
                 "sourceDataset": "customer",
+                "sourceColumn": "custkey",
             },
         ],
     }
@@ -163,14 +165,16 @@ def test_analysis_sql_join_customer_orders():
     }
     assert result[0]["relation"]["exprSources"] == [
         {
-            "expression": "o.custkey",
-            "nodeLocation": {"line": 1, "column": 55},
-            "sourceDataset": "orders",
-        },
-        {
             "expression": "c.custkey",
             "nodeLocation": {"line": 1, "column": 43},
             "sourceDataset": "customer",
+            "sourceColumn": "custkey",
+        },
+        {
+            "expression": "o.custkey",
+            "nodeLocation": {"line": 1, "column": 55},
+            "sourceDataset": "orders",
+            "sourceColumn": "custkey",
         },
     ]
 
@@ -194,6 +198,7 @@ def test_analysis_sql_where_clause():
             "expression": "custkey",
             "nodeLocation": {"line": 1, "column": 30},
             "sourceDataset": "customer",
+            "sourceColumn": "custkey",
         },
     ]
     assert result[0]["filter"]["right"]["type"] == "AND"
@@ -216,6 +221,7 @@ def test_analysis_sql_group_by_multiple_columns():
                 "expression": "custkey",
                 "nodeLocation": {"line": 1, "column": 8},
                 "sourceDataset": "customer",
+                "sourceColumn": "custkey",
             },
         ],
     }
@@ -227,6 +233,7 @@ def test_analysis_sql_group_by_multiple_columns():
                 "expression": "name",
                 "nodeLocation": {"line": 1, "column": 27},
                 "sourceDataset": "customer",
+                "sourceColumn": "name",
             },
         ],
     }
@@ -238,6 +245,7 @@ def test_analysis_sql_group_by_multiple_columns():
                 "expression": "nationkey",
                 "nodeLocation": {"line": 1, "column": 61},
                 "sourceDataset": "customer",
+                "sourceColumn": "nationkey",
             },
         ],
     }
@@ -259,6 +267,7 @@ def test_analysis_sql_order_by():
             "expression": "custkey",
             "nodeLocation": {"line": 1, "column": 8},
             "sourceDataset": "customer",
+            "sourceColumn": "custkey",
         },
     ]
     assert result[0]["sortings"][0]["nodeLocation"] == {"line": 1, "column": 45}

--- a/ibis-server/tests/routers/v2/test_analysis.py
+++ b/ibis-server/tests/routers/v2/test_analysis.py
@@ -154,7 +154,13 @@ def test_analysis_sql_join_customer_orders():
     assert result[0]["relation"]["left"]["nodeLocation"] == {"line": 1, "column": 15}
     assert result[0]["relation"]["right"]["type"] == "TABLE"
     assert result[0]["relation"]["right"]["nodeLocation"] == {"line": 1, "column": 31}
-    assert result[0]["relation"]["criteria"] == "ON (c.custkey = o.custkey)"
+    assert (
+        result[0]["relation"]["criteria"]["expression"] == "ON (c.custkey = o.custkey)"
+    )
+    assert result[0]["relation"]["criteria"]["nodeLocation"] == {
+        "line": 1,
+        "column": 43,
+    }
     assert result[0]["relation"]["exprSources"] == [
         {
             "expression": "o.custkey",

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
@@ -33,6 +33,7 @@ public class Field
     private final CatalogSchemaTableName tableName;
     private final String columnName;
     private final Optional<String> sourceDatasetName;
+    private final Optional<String> sourceColumnName;
     private final Optional<String> name;
 
     private Field(
@@ -40,13 +41,15 @@ public class Field
             CatalogSchemaTableName tableName,
             String columnName,
             String name,
-            String sourceDatasetName)
+            String sourceDatasetName,
+            String sourceColumnName)
     {
         this.relationAlias = Optional.ofNullable(relationAlias);
         this.tableName = requireNonNull(tableName, "modelName is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.name = Optional.ofNullable(name);
         this.sourceDatasetName = Optional.ofNullable(sourceDatasetName);
+        this.sourceColumnName = Optional.ofNullable(sourceColumnName);
     }
 
     public Optional<QualifiedName> getRelationAlias()
@@ -72,6 +75,11 @@ public class Field
     public Optional<String> getSourceDatasetName()
     {
         return sourceDatasetName;
+    }
+
+    public Optional<String> getSourceColumnName()
+    {
+        return sourceColumnName;
     }
 
     public boolean matchesPrefix(Optional<QualifiedName> prefix)
@@ -120,6 +128,7 @@ public class Field
                 ", columnName='" + columnName + '\'' +
                 ", name=" + name +
                 ", sourceDatasetName=" + sourceDatasetName +
+                ", sourceColumnName=" + sourceColumnName +
                 '}';
     }
 
@@ -135,6 +144,7 @@ public class Field
         private String columnName;
         private String name;
         private String sourceModelName;
+        private String sourceColumnName;
 
         public Builder() {}
 
@@ -145,6 +155,7 @@ public class Field
             this.columnName = field.columnName;
             this.name = field.name.orElse(null);
             this.sourceModelName = field.sourceDatasetName.orElse(null);
+            this.sourceColumnName = field.sourceColumnName.orElse(null);
             return this;
         }
 
@@ -178,9 +189,15 @@ public class Field
             return this;
         }
 
+        public Builder sourceColumnName(String sourceColumnName)
+        {
+            this.sourceColumnName = sourceColumnName;
+            return this;
+        }
+
         public Field build()
         {
-            return new Field(relationAlias, tableName, columnName, name, sourceModelName);
+            return new Field(relationAlias, tableName, columnName, name, sourceModelName, sourceColumnName);
         }
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -237,6 +237,7 @@ public final class StatementAnalyzer
                                         .name(f.getName().orElse(f.getColumnName()))
                                         .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
                                         .sourceModelName(f.getSourceDatasetName().orElse(null))
+                                        .sourceColumnName(f.getSourceColumnName().orElse(null))
                                         .build())));
                     }
                     else {
@@ -253,6 +254,7 @@ public final class StatementAnalyzer
                                         .name(name)
                                         .tableName(toCatalogSchemaTableName(sessionContext, scopeName))
                                         .sourceModelName(f.getSourceDatasetName().orElse(null))
+                                        .sourceColumnName(f.getSourceColumnName().orElse(null))
                                         .build());
                                 continue;
                             }
@@ -280,6 +282,7 @@ public final class StatementAnalyzer
                                 .columnName(column.getName())
                                 .name(column.getName())
                                 .sourceModelName(tableName.getSchemaTableName().getTableName())
+                                .sourceColumnName(column.getName())
                                 .build())
                         .collect(toImmutableList());
             }
@@ -293,6 +296,7 @@ public final class StatementAnalyzer
                                 .columnName(column.getName())
                                 .name(column.getName())
                                 .sourceModelName(tableName.getSchemaTableName().getTableName())
+                                .sourceColumnName(column.getName())
                                 .build())
                         .collect(toImmutableList());
             }
@@ -304,12 +308,14 @@ public final class StatementAnalyzer
                                 .columnName(cumulativeMetric.getWindow().getName())
                                 .name(cumulativeMetric.getWindow().getName())
                                 .sourceModelName(tableName.getSchemaTableName().getTableName())
+                                .sourceColumnName(cumulativeMetric.getWindow().getName())
                                 .build(),
                         Field.builder()
                                 .tableName(tableName)
                                 .columnName(cumulativeMetric.getMeasure().getName())
                                 .name(cumulativeMetric.getMeasure().getName())
                                 .sourceModelName(tableName.getSchemaTableName().getTableName())
+                                .sourceColumnName(cumulativeMetric.getMeasure().getName())
                                 .build());
             }
             return ImmutableList.of();

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/DecisionPointAnalyzer.java
@@ -140,6 +140,7 @@ public class DecisionPointAnalyzer
                                         List.of(new ExprSource(
                                                 field.getName().orElse(field.getColumnName()),
                                                 field.getTableName().getSchemaTableName().getTableName(),
+                                                field.getSourceColumnName().orElse(null),
                                                 node.getLocation().orElse(null)))));
                             });
                 }
@@ -164,6 +165,7 @@ public class DecisionPointAnalyzer
                                 List.of(new ExprSource(
                                         field.getName().orElse(field.getColumnName()),
                                         field.getTableName().getSchemaTableName().getTableName(),
+                                        field.getSourceColumnName().orElse(null),
                                         node.getLocation().orElse(null)))));
                     });
                 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExprSource.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExprSource.java
@@ -18,7 +18,7 @@ import io.trino.sql.tree.NodeLocation;
 
 import java.util.Objects;
 
-public record ExprSource(String expression, String sourceDataset, NodeLocation nodeLocation)
+public record ExprSource(String expression, String sourceDataset, String sourceColumn, NodeLocation nodeLocation)
 {
     @Override
     public boolean equals(Object o)
@@ -34,12 +34,13 @@ public record ExprSource(String expression, String sourceDataset, NodeLocation n
         ExprSource that = (ExprSource) o;
         return Objects.equals(expression, that.expression) &&
                 Objects.equals(sourceDataset, that.sourceDataset)
+                && Objects.equals(sourceColumn, that.sourceColumn)
                 && Objects.equals(nodeLocation, that.nodeLocation);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(expression, sourceDataset, nodeLocation);
+        return Objects.hash(expression, sourceDataset, sourceColumn, nodeLocation);
     }
 }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExpressionLocationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/ExpressionLocationAnalyzer.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.wren.base.sqlrewrite.analyzer.decisionpoint;
+
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.DefaultTraversalVisitor;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeLocation;
+
+import java.util.Optional;
+
+/**
+ * Try to find the most left-side location of an expression.
+ * For example, the binary expression "a + b" will return the location of "a".
+ * The comparison expression "a = b" will return the location of "a".
+ * The location of the expression itself will be returned if it is not a binary or comparison expression.
+ */
+public class ExpressionLocationAnalyzer
+{
+    private ExpressionLocationAnalyzer() {}
+
+    public static Optional<NodeLocation> analyze(Node node)
+    {
+        Visitor visitor = new Visitor();
+        visitor.process(node, null);
+        return visitor.nodeLocation;
+    }
+
+    static class Visitor
+            extends DefaultTraversalVisitor<Void>
+    {
+        private Optional<NodeLocation> nodeLocation = Optional.empty();
+
+        @Override
+        protected Void visitExpression(Expression node, Void context)
+        {
+            nodeLocation = node.getLocation();
+            return null;
+        }
+
+        @Override
+        protected Void visitComparisonExpression(ComparisonExpression node, Void context)
+        {
+            nodeLocation = node.getLeft().getLocation();
+            return null;
+        }
+
+        @Override
+        protected Void visitArithmeticBinary(ArithmeticBinaryExpression node, Void context)
+        {
+            nodeLocation = node.getLeft().getLocation();
+            return null;
+        }
+    }
+}

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalysis.java
@@ -17,13 +17,14 @@ package io.wren.base.sqlrewrite.analyzer.decisionpoint;
 import io.trino.sql.tree.NodeLocation;
 
 import java.util.List;
+import java.util.Objects;
 
 import static io.wren.base.Utils.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public abstract class RelationAnalysis
 {
-    static JoinRelation join(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria, List<ExprSource> exprSources, NodeLocation nodeLocation)
+    static JoinRelation join(Type type, String alias, RelationAnalysis left, RelationAnalysis right, JoinCriteria criteria, List<ExprSource> exprSources, NodeLocation nodeLocation)
     {
         checkArgument(type != Type.TABLE && type != Type.SUBQUERY, "type should be a join type");
         return new JoinRelation(type, alias, left, right, criteria, exprSources, nodeLocation);
@@ -82,10 +83,10 @@ public abstract class RelationAnalysis
     {
         private final RelationAnalysis left;
         private final RelationAnalysis right;
-        private final String criteria;
+        private final JoinCriteria criteria;
         private final List<ExprSource> exprSources;
 
-        public JoinRelation(Type type, String alias, RelationAnalysis left, RelationAnalysis right, String criteria, List<ExprSource> exprSources, NodeLocation nodeLocation)
+        public JoinRelation(Type type, String alias, RelationAnalysis left, RelationAnalysis right, JoinCriteria criteria, List<ExprSource> exprSources, NodeLocation nodeLocation)
         {
             super(type, alias, nodeLocation);
             this.left = requireNonNull(left, "left is null");
@@ -104,7 +105,7 @@ public abstract class RelationAnalysis
             return right;
         }
 
-        public String getCriteria()
+        public JoinCriteria getCriteria()
         {
             return criteria;
         }
@@ -112,6 +113,62 @@ public abstract class RelationAnalysis
         public List<ExprSource> getExprSources()
         {
             return exprSources;
+        }
+    }
+
+    public static class JoinCriteria
+    {
+        public static JoinCriteria joinCriteria(String expression, NodeLocation nodeLocation)
+        {
+            return new JoinCriteria(expression, nodeLocation);
+        }
+
+        private final String expression;
+        private final NodeLocation nodeLocation;
+
+        public JoinCriteria(String expression, NodeLocation nodeLocation)
+        {
+            this.expression = expression;
+            this.nodeLocation = nodeLocation;
+        }
+
+        public String getExpression()
+        {
+            return expression;
+        }
+
+        public NodeLocation getNodeLocation()
+        {
+            return nodeLocation;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            JoinCriteria that = (JoinCriteria) o;
+            return Objects.equals(expression, that.expression) &&
+                    Objects.equals(nodeLocation, that.nodeLocation);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(expression, nodeLocation);
+        }
+
+        @Override
+        public String toString()
+        {
+            return "JoinCriteria{" +
+                    "expression='" + expression + '\'' +
+                    ", nodeLocation=" + nodeLocation +
+                    '}';
         }
     }
 

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -29,6 +29,7 @@ import io.trino.sql.tree.JoinOn;
 import io.trino.sql.tree.JoinUsing;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.NaturalJoin;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.PatternRecognitionRelation;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.QuerySpecification;
@@ -50,6 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.trino.sql.tree.DereferenceExpression.getQualifiedName;
+import static io.wren.base.sqlrewrite.analyzer.decisionpoint.RelationAnalysis.JoinCriteria.joinCriteria;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
@@ -129,9 +131,10 @@ public class RelationAnalyzer
             Scope scope = analysis.getScope(node);
             List<ExprSource> exprSources = node.getCriteria().map(criteria -> analyzeCriteria(criteria, scope))
                     .orElse(null);
+            Optional<NodeLocation> criteriaLocation = node.getCriteria().flatMap(this::findLocation);
             return new RelationAnalysis.JoinRelation(
                     RelationAnalysis.Type.valueOf(format("%s_JOIN", node.getType())),
-                    null, left, right, node.getCriteria().map(this::formatCriteria).orElse(null),
+                    null, left, right, joinCriteria(node.getCriteria().map(this::formatCriteria).orElse(null), criteriaLocation.orElse(null)),
                     exprSources,
                     node.getLocation().orElse(null));
         }
@@ -155,6 +158,16 @@ public class RelationAnalyzer
                     throw new IllegalArgumentException("Unsupported join criteria: " + criteria);
             }
             return builder.toString();
+        }
+
+        private Optional<NodeLocation> findLocation(JoinCriteria criteria)
+        {
+            return switch (criteria) {
+                case JoinOn joinOn -> joinOn.getNodes().stream().findAny().flatMap(ExpressionLocationAnalyzer::analyze);
+                case JoinUsing joinUsing -> joinUsing.getColumns().stream().findAny().flatMap(ExpressionLocationAnalyzer::analyze);
+                case NaturalJoin ignored -> Optional.empty();
+                default -> throw new IllegalArgumentException("Unsupported join criteria: " + criteria);
+            };
         }
 
         private List<ExprSource> analyzeCriteria(JoinCriteria criteria, Scope scope)

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -261,7 +261,7 @@ public class RelationAnalyzer
         {
             scope.getRelationType().resolveFields(QualifiedName.of(node.getValue()))
                     .stream().filter(field -> field.getSourceDatasetName().isPresent())
-                    .forEach(field -> exprSources.add(new ExprSource(node.getValue(), field.getSourceDatasetName().get(), node.getLocation().orElse(null))));
+                    .forEach(field -> exprSources.add(new ExprSource(node.getValue(), field.getSourceDatasetName().get(), field.getSourceColumnName().orElse(null), node.getLocation().orElse(null))));
             return null;
         }
 
@@ -271,7 +271,7 @@ public class RelationAnalyzer
             Optional.ofNullable(getQualifiedName(node)).ifPresent(qualifiedName ->
                     scope.getRelationType().resolveFields(qualifiedName)
                             .stream().filter(field -> field.getSourceDatasetName().isPresent())
-                            .forEach(field -> exprSources.add(new ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get(), node.getLocation().orElse(null)))));
+                            .forEach(field -> exprSources.add(new ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get(), field.getSourceColumnName().orElse(null), node.getLocation().orElse(null)))));
             return null;
         }
     }

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
@@ -43,6 +43,7 @@ import static io.wren.base.sqlrewrite.Utils.parseSql;
 import static io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionExpressionAnalyzer.INCLUDE_FUNCTION_CALL;
 import static io.wren.base.sqlrewrite.analyzer.decisionpoint.DecisionExpressionAnalyzer.INCLUDE_MATHEMATICAL_OPERATION;
 import static io.wren.base.sqlrewrite.analyzer.decisionpoint.QueryAnalysis.GroupByKey;
+import static io.wren.base.sqlrewrite.analyzer.decisionpoint.RelationAnalysis.JoinCriteria.joinCriteria;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDecisionPointAnalyzer
@@ -227,7 +228,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE);
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 29));
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("orders");
-            assertThat(joinRelation.getCriteria()).isEqualTo("ON (customer.custkey = orders.custkey)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 39)));
             assertThat(joinRelation.getExprSources().get(0).nodeLocation()).isEqualTo(new NodeLocation(1, 39));
             assertThat(joinRelation.getExprSources().get(1).nodeLocation()).isEqualTo(new NodeLocation(1, 58));
         }
@@ -251,7 +252,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE);
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 30));
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("orders");
-            assertThat(joinRelation.getCriteria()).isEqualTo("ON (customer.custkey = orders.custkey)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 40)));
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
                     new ExprSource("customer.custkey", "customer", new NodeLocation(1, 40)),
@@ -296,7 +297,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE);
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 83));
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("lineitem");
-            assertThat(joinRelation.getCriteria()).isEqualTo("ON (orders.orderkey = lineitem.orderkey)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (orders.orderkey = lineitem.orderkey)", new NodeLocation(1, 95)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
                     new ExprSource("lineitem.orderkey", "lineitem", new NodeLocation(1, 113)),
                     new ExprSource("orders.orderkey", "orders", new NodeLocation(1, 95))));
@@ -318,7 +319,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getAlias()).isNull();
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE);
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("orders");
-            assertThat(joinRelation.getCriteria()).isEqualTo("USING (custkey)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("USING (custkey)", new NodeLocation(1, 43)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
                     new ExprSource("custkey", "customer", new NodeLocation(1, 43)),
                     new ExprSource("custkey", "orders", new NodeLocation(1, 43))));
@@ -340,7 +341,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getAlias()).isNull();
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE);
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("customer");
-            assertThat(joinRelation.getCriteria()).isEqualTo("USING (custkey, name)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("USING (custkey, name)", new NodeLocation(1, 45)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
                     new ExprSource("custkey", "customer", new NodeLocation(1, 45)),
                     new ExprSource("name", "customer", new NodeLocation(1, 54))));
@@ -365,7 +366,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getType()).isEqualTo(RelationAnalysis.Type.SUBQUERY);
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 30));
             assertThat(((SubqueryRelation) joinRelation.getRight()).getBody().size()).isEqualTo(1);
-            assertThat(joinRelation.getCriteria()).isEqualTo("ON (customer.custkey = orders.custkey)");
+            assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 92)));
             assertThat(joinRelation.getExprSources().size()).isEqualTo(1);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
                     new ExprSource("customer.custkey", "customer", new NodeLocation(1, 92))));

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/analyzer/TestDecisionPointAnalyzer.java
@@ -108,10 +108,10 @@ public class TestDecisionPointAnalyzer
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getSelectItems().size()).isEqualTo(2);
         assertThat(result.get(0).getSelectItems().get(0).getExpression()).isEqualTo("custkey");
-        assertThat(result.get(0).getSelectItems().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 8))));
+        assertThat(result.get(0).getSelectItems().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 8))));
         assertThat(result.get(0).getSelectItems().get(0).getNodeLocation()).isEqualTo(new NodeLocation(1, 8));
         assertThat(result.get(0).getSelectItems().get(1).getExpression()).isEqualTo("name");
-        assertThat(result.get(0).getSelectItems().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("name", "customer", new NodeLocation(1, 17))));
+        assertThat(result.get(0).getSelectItems().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("name", "customer", "name", new NodeLocation(1, 17))));
         assertThat(result.get(0).getSelectItems().get(1).getNodeLocation()).isEqualTo(new NodeLocation(1, 17));
 
         statement = parseSql("SELECT * FROM customer");
@@ -149,14 +149,14 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getSelectItems().get(0).getProperties().get(INCLUDE_MATHEMATICAL_OPERATION)).isEqualTo("false");
         assertThat(result.get(0).getSelectItems().get(0).getNodeLocation()).isEqualTo(new NodeLocation(1, 8));
         assertThat(result.get(0).getSelectItems().get(1).getExpression()).isEqualTo("date_trunc('MONTH', orderdate)");
-        assertThat(result.get(0).getSelectItems().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("orderdate", "orders", new NodeLocation(1, 37))));
+        assertThat(result.get(0).getSelectItems().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("orderdate", "orders", "orderdate", new NodeLocation(1, 37))));
         assertThat(result.get(0).getSelectItems().get(1).getProperties().get(INCLUDE_FUNCTION_CALL)).isEqualTo("true");
         assertThat(result.get(0).getSelectItems().get(1).getProperties().get(INCLUDE_MATHEMATICAL_OPERATION)).isEqualTo("false");
         assertThat(result.get(0).getSelectItems().get(1).getNodeLocation()).isEqualTo(new NodeLocation(1, 17));
         assertThat(result.get(0).getSelectItems().get(2).getExpression()).isEqualTo("(custkey + orderkey)");
         assertThat(result.get(0).getSelectItems().get(2).getExprSources())
-                .isEqualTo(List.of(new ExprSource("orderkey", "orders", new NodeLocation(1, 59)),
-                        new ExprSource("custkey", "orders", new NodeLocation(1, 49))));
+                .isEqualTo(List.of(new ExprSource("orderkey", "orders", "orderkey", new NodeLocation(1, 59)),
+                        new ExprSource("custkey", "orders", "custkey", new NodeLocation(1, 49))));
         assertThat(result.get(0).getSelectItems().get(2).getProperties().get(INCLUDE_FUNCTION_CALL)).isEqualTo("false");
         assertThat(result.get(0).getSelectItems().get(2).getProperties().get(INCLUDE_MATHEMATICAL_OPERATION)).isEqualTo("true");
         assertThat(result.get(0).getSelectItems().get(2).getNodeLocation()).isEqualTo(new NodeLocation(1, 49));
@@ -229,8 +229,8 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 29));
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("orders");
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 39)));
-            assertThat(joinRelation.getExprSources().get(0).nodeLocation()).isEqualTo(new NodeLocation(1, 39));
-            assertThat(joinRelation.getExprSources().get(1).nodeLocation()).isEqualTo(new NodeLocation(1, 58));
+            assertThat(joinRelation.getExprSources().get(0).nodeLocation()).isEqualTo(new NodeLocation(1, 58));
+            assertThat(joinRelation.getExprSources().get(1).nodeLocation()).isEqualTo(new NodeLocation(1, 39));
         }
         else {
             throw new AssertionError("wrong type");
@@ -255,8 +255,8 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 40)));
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("customer.custkey", "customer", new NodeLocation(1, 40)),
-                    new ExprSource("orders.custkey", "orders", new NodeLocation(1, 59))));
+                    new ExprSource("customer.custkey", "customer", "custkey", new NodeLocation(1, 40)),
+                    new ExprSource("orders.custkey", "orders", "custkey", new NodeLocation(1, 59))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -271,8 +271,8 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getRight().getNodeLocation()).isEqualTo(new NodeLocation(1, 32));
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("c.custkey", "customer", new NodeLocation(1, 44)),
-                    new ExprSource("o.custkey", "orders", new NodeLocation(1, 56))));
+                    new ExprSource("c.custkey", "customer", "custkey", new NodeLocation(1, 44)),
+                    new ExprSource("o.custkey", "orders", "custkey", new NodeLocation(1, 56))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -299,8 +299,8 @@ public class TestDecisionPointAnalyzer
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("lineitem");
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (orders.orderkey = lineitem.orderkey)", new NodeLocation(1, 95)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("lineitem.orderkey", "lineitem", new NodeLocation(1, 113)),
-                    new ExprSource("orders.orderkey", "orders", new NodeLocation(1, 95))));
+                    new ExprSource("lineitem.orderkey", "lineitem", "orderkey", new NodeLocation(1, 113)),
+                    new ExprSource("orders.orderkey", "orders", "orderkey", new NodeLocation(1, 95))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -321,8 +321,8 @@ public class TestDecisionPointAnalyzer
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("orders");
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("USING (custkey)", new NodeLocation(1, 43)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("custkey", "customer", new NodeLocation(1, 43)),
-                    new ExprSource("custkey", "orders", new NodeLocation(1, 43))));
+                    new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 43)),
+                    new ExprSource("custkey", "orders", "custkey", new NodeLocation(1, 43))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -343,8 +343,8 @@ public class TestDecisionPointAnalyzer
             assertThat(((TableRelation) joinRelation.getRight()).getTableName()).isEqualTo("customer");
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("USING (custkey, name)", new NodeLocation(1, 45)));
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("custkey", "customer", new NodeLocation(1, 45)),
-                    new ExprSource("name", "customer", new NodeLocation(1, 54))));
+                    new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 45)),
+                    new ExprSource("name", "customer", "name", new NodeLocation(1, 54))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -369,7 +369,7 @@ public class TestDecisionPointAnalyzer
             assertThat(joinRelation.getCriteria()).isEqualTo(joinCriteria("ON (customer.custkey = orders.custkey)", new NodeLocation(1, 92)));
             assertThat(joinRelation.getExprSources().size()).isEqualTo(1);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("customer.custkey", "customer", new NodeLocation(1, 92))));
+                    new ExprSource("customer.custkey", "customer", "custkey", new NodeLocation(1, 92))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -387,7 +387,7 @@ public class TestDecisionPointAnalyzer
         if (result.get(0).getFilter() instanceof ExpressionAnalysis) {
             ExpressionAnalysis expressionAnalysis = (ExpressionAnalysis) result.get(0).getFilter();
             assertThat(expressionAnalysis.getNode()).isEqualTo("(custkey = 1)");
-            assertThat(expressionAnalysis.getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 30))));
+            assertThat(expressionAnalysis.getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 30))));
         }
         else {
             throw new AssertionError("wrong type");
@@ -402,7 +402,7 @@ public class TestDecisionPointAnalyzer
             LogicalAnalysis logicalAnalysis = (LogicalAnalysis) result.get(0).getFilter();
             assertThat(logicalAnalysis.getLeft().getType()).isEqualTo(FilterAnalysis.Type.EXPR);
             assertThat(((ExpressionAnalysis) logicalAnalysis.getLeft()).getNode()).isEqualTo("(custkey = 1)");
-            assertThat(((ExpressionAnalysis) logicalAnalysis.getLeft()).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 30))));
+            assertThat(((ExpressionAnalysis) logicalAnalysis.getLeft()).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 30))));
             assertThat(logicalAnalysis.getRight().getType()).isEqualTo(FilterAnalysis.Type.EXPR);
             assertThat(((ExpressionAnalysis) logicalAnalysis.getRight()).getNode()).isEqualTo("(name = 'test')");
         }
@@ -475,8 +475,8 @@ public class TestDecisionPointAnalyzer
                 assertThat(((ExpressionAnalysis) andLogicalAnalysis.getLeft()).getNode()).isEqualTo("(name = 'test')");
                 assertThat(andLogicalAnalysis.getRight().getType()).isEqualTo(FilterAnalysis.Type.EXPR);
                 assertThat(((ExpressionAnalysis) andLogicalAnalysis.getRight()).getNode()).isEqualTo("IF(((nationkey = 1) OR (nationkey = 2)), true, false)");
-                assertThat(((ExpressionAnalysis) andLogicalAnalysis.getRight()).getExprSources()).isEqualTo(List.of(new ExprSource("nationkey", "customer", new NodeLocation(1, 66)),
-                        new ExprSource("nationkey", "customer", new NodeLocation(1, 83))));
+                assertThat(((ExpressionAnalysis) andLogicalAnalysis.getRight()).getExprSources()).isEqualTo(List.of(new ExprSource("nationkey", "customer", "nationkey", new NodeLocation(1, 83)),
+                        new ExprSource("nationkey", "customer", "nationkey", new NodeLocation(1, 66))));
             }
         }
     }
@@ -491,7 +491,7 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new GroupByKey("custkey",
                         new NodeLocation(1, 49),
-                        List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 49)))));
+                        List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 49)))));
 
         statement = parseSql("SELECT c.custkey, count(*) FROM customer c GROUP BY c.custkey");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -500,7 +500,7 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new GroupByKey("c.custkey",
                         new NodeLocation(1, 53),
-                        List.of(new ExprSource("c.custkey", "customer", new NodeLocation(1, 53)))));
+                        List.of(new ExprSource("c.custkey", "customer", "custkey", new NodeLocation(1, 53)))));
 
         statement = parseSql("SELECT custkey, count(*) FROM customer GROUP BY custkey, name");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -509,11 +509,11 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new GroupByKey("custkey",
                         new NodeLocation(1, 49),
-                        List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 49)))));
+                        List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 49)))));
         assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(
                 new GroupByKey("name",
                         new NodeLocation(1, 58),
-                        List.of(new ExprSource("name", "customer", new NodeLocation(1, 58)))));
+                        List.of(new ExprSource("name", "customer", "name", new NodeLocation(1, 58)))));
 
         statement = parseSql("SELECT custkey, count(*) FROM customer GROUP BY (custkey, name), nationkey");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -522,15 +522,15 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new GroupByKey("custkey",
                         new NodeLocation(1, 50),
-                        List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 50)))));
+                        List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 50)))));
         assertThat(result.get(0).getGroupByKeys().get(0).get(1)).isEqualTo(
                 new GroupByKey("name",
                         new NodeLocation(1, 59),
-                        List.of(new ExprSource("name", "customer", new NodeLocation(1, 59)))));
+                        List.of(new ExprSource("name", "customer", "name", new NodeLocation(1, 59)))));
         assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(
                 new GroupByKey("nationkey",
                         new NodeLocation(1, 66),
-                        List.of(new ExprSource("nationkey", "customer", new NodeLocation(1, 66)))));
+                        List.of(new ExprSource("nationkey", "customer", "nationkey", new NodeLocation(1, 66)))));
 
         statement = parseSql("SELECT custkey, count(*) FROM customer GROUP BY 1");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -540,7 +540,7 @@ public class TestDecisionPointAnalyzer
                 new GroupByKey("custkey",
                         // provide the location of the source node if it's an index
                         new NodeLocation(1, 49),
-                        List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 8)))));
+                        List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 8)))));
 
         statement = parseSql("SELECT c.custkey, count(*) FROM customer c GROUP BY 1");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -550,7 +550,7 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new GroupByKey("c.custkey",
                         new NodeLocation(1, 53),
-                        List.of(new ExprSource("c.custkey", "customer", new NodeLocation(1, 8)))));
+                        List.of(new ExprSource("c.custkey", "customer", "custkey", new NodeLocation(1, 8)))));
 
         statement = parseSql("SELECT custkey, count(*), name FROM customer GROUP BY 1, 3, nationkey");
         result = DecisionPointAnalyzer.analyze(statement, DEFAULT_SESSION_CONTEXT, mdl);
@@ -560,15 +560,15 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getGroupByKeys().get(1).size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().get(2).size()).isEqualTo(1);
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
-                new GroupByKey("custkey", new NodeLocation(1, 55), List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 8)))));
+                new GroupByKey("custkey", new NodeLocation(1, 55), List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 8)))));
         assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(
                 new GroupByKey("name",
                         new NodeLocation(1, 58),
-                        List.of(new ExprSource("name", "customer", new NodeLocation(1, 27)))));
+                        List.of(new ExprSource("name", "customer", "name", new NodeLocation(1, 27)))));
         assertThat(result.get(0).getGroupByKeys().get(2).get(0)).isEqualTo(
                 new GroupByKey("nationkey",
                         new NodeLocation(1, 61),
-                        List.of(new ExprSource("nationkey", "customer", new NodeLocation(1, 61)))));
+                        List.of(new ExprSource("nationkey", "customer", "nationkey", new NodeLocation(1, 61)))));
     }
 
     @Test
@@ -580,7 +580,7 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getSortings().size()).isEqualTo(1);
         assertThat(result.get(0).getSortings().get(0).getExpression()).isEqualTo("custkey");
         assertThat(result.get(0).getSortings().get(0).getOrdering()).isEqualTo(SortItem.Ordering.ASCENDING);
-        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 45))));
+        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 45))));
         assertThat(result.get(0).getSortings().get(0).getNodeLocation()).isEqualTo(new NodeLocation(1, 45));
 
         statement = parseSql("SELECT custkey, name FROM customer ORDER BY custkey ASC, name DESC");
@@ -600,11 +600,11 @@ public class TestDecisionPointAnalyzer
         assertThat(result.get(0).getSortings().size()).isEqualTo(2);
         assertThat(result.get(0).getSortings().get(0).getExpression()).isEqualTo("custkey");
         assertThat(result.get(0).getSortings().get(0).getOrdering()).isEqualTo(SortItem.Ordering.ASCENDING);
-        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", new NodeLocation(1, 8))));
+        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new ExprSource("custkey", "customer", "custkey", new NodeLocation(1, 8))));
         assertThat(result.get(0).getSortings().get(0).getNodeLocation()).isEqualTo(new NodeLocation(1, 45));
         assertThat(result.get(0).getSortings().get(1).getExpression()).isEqualTo("name");
         assertThat(result.get(0).getSortings().get(1).getOrdering()).isEqualTo(SortItem.Ordering.DESCENDING);
-        assertThat(result.get(0).getSortings().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("name", "customer", new NodeLocation(1, 17))));
+        assertThat(result.get(0).getSortings().get(1).getExprSources()).isEqualTo(List.of(new ExprSource("name", "customer", "name", new NodeLocation(1, 17))));
         assertThat(result.get(0).getSortings().get(1).getNodeLocation()).isEqualTo(new NodeLocation(1, 52));
     }
 
@@ -641,8 +641,8 @@ public class TestDecisionPointAnalyzer
         if (mainBody.getRelation() instanceof JoinRelation joinRelation) {
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("t1.custkey", "customer", new NodeLocation(2, 29)),
-                    new ExprSource("t2.custkey", "orders", new NodeLocation(2, 42))));
+                    new ExprSource("t1.custkey", "customer", "custkey", new NodeLocation(2, 29)),
+                    new ExprSource("t2.custkey", "orders", "custkey", new NodeLocation(2, 42))));
         }
 
         statement = parseSql("""
@@ -657,8 +657,8 @@ public class TestDecisionPointAnalyzer
         if (mainBody.getRelation() instanceof JoinRelation joinRelation) {
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("t1.custkey", "customer", new NodeLocation(2, 29)),
-                    new ExprSource("t2.custkey", "orders", new NodeLocation(2, 42))));
+                    new ExprSource("t1.custkey", "customer", "custkey", new NodeLocation(2, 29)),
+                    new ExprSource("t2.custkey", "orders", "custkey", new NodeLocation(2, 42))));
         }
 
         statement = parseSql("""
@@ -673,8 +673,8 @@ public class TestDecisionPointAnalyzer
         if (mainBody.getRelation() instanceof JoinRelation joinRelation) {
             assertThat(joinRelation.getExprSources().size()).isEqualTo(2);
             assertThat(Set.copyOf(joinRelation.getExprSources())).isEqualTo(Set.of(
-                    new ExprSource("t1.custkey", "customer", new NodeLocation(2, 33)),
-                    new ExprSource("t2.custkey", "orders", new NodeLocation(2, 50))));
+                    new ExprSource("t1.custkey", "customer", "custkey", new NodeLocation(2, 33)),
+                    new ExprSource("t2.custkey", "orders", "custkey", new NodeLocation(2, 50))));
         }
     }
 

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -165,7 +165,7 @@ public class AnalysisResource
 
     private static QueryAnalysisDto.ExprSourceDto toExprSourceDto(ExprSource exprSource)
     {
-        return new QueryAnalysisDto.ExprSourceDto(exprSource.expression(), exprSource.sourceDataset(), toNodeLocationDto(exprSource.nodeLocation()));
+        return new QueryAnalysisDto.ExprSourceDto(exprSource.expression(), exprSource.sourceDataset(), exprSource.sourceColumn(), toNodeLocationDto(exprSource.nodeLocation()));
     }
 
     private static QueryAnalysisDto.GroupByKeyDto toGroupByKeyDto(QueryAnalysis.GroupByKey groupByKey)

--- a/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/AnalysisResource.java
@@ -135,7 +135,7 @@ public class AnalysisResource
                     joinRelation.getAlias(),
                     toRelationAnalysisDto(joinRelation.getLeft()),
                     toRelationAnalysisDto(joinRelation.getRight()),
-                    joinRelation.getCriteria(),
+                    joinCriteriaDto(joinRelation.getCriteria()),
                     null,
                     null,
                     joinRelation.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList(),
@@ -173,6 +173,11 @@ public class AnalysisResource
         return new QueryAnalysisDto.GroupByKeyDto(groupByKey.getExpression(),
                 toNodeLocationDto(groupByKey.getNodeLocation()),
                 groupByKey.getExprSources().stream().map(AnalysisResource::toExprSourceDto).toList());
+    }
+
+    private static QueryAnalysisDto.JoinCriteriaDto joinCriteriaDto(RelationAnalysis.JoinCriteria joinCriteria)
+    {
+        return new QueryAnalysisDto.JoinCriteriaDto(joinCriteria.getExpression(), toNodeLocationDto(joinCriteria.getNodeLocation()));
     }
 
     private static NodeLocationDto toNodeLocationDto(NodeLocation nodeLocation)

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -143,7 +143,7 @@ public class QueryAnalysisDto
         private String alias;
         private RelationAnalysisDto left;
         private RelationAnalysisDto right;
-        private String criteria;
+        private JoinCriteriaDto criteria;
         private String tableName;
         private List<QueryAnalysisDto> body;
         private List<ExprSourceDto> exprSources;
@@ -155,7 +155,7 @@ public class QueryAnalysisDto
                 String alias,
                 RelationAnalysisDto left,
                 RelationAnalysisDto right,
-                String criteria,
+                JoinCriteriaDto criteria,
                 String tableName,
                 List<QueryAnalysisDto> body,
                 List<ExprSourceDto> exprSources,
@@ -197,7 +197,7 @@ public class QueryAnalysisDto
         }
 
         @JsonProperty
-        public String getCriteria()
+        public JoinCriteriaDto getCriteria()
         {
             return criteria;
         }
@@ -218,6 +218,31 @@ public class QueryAnalysisDto
         public List<ExprSourceDto> getExprSources()
         {
             return exprSources;
+        }
+
+        @JsonProperty
+        public NodeLocationDto getNodeLocation()
+        {
+            return nodeLocation;
+        }
+    }
+
+    public static class JoinCriteriaDto
+    {
+        private String expression;
+        private NodeLocationDto nodeLocation;
+
+        @JsonCreator
+        public JoinCriteriaDto(String expression, NodeLocationDto nodeLocation)
+        {
+            this.expression = expression;
+            this.nodeLocation = nodeLocation;
+        }
+
+        @JsonProperty
+        public String getExpression()
+        {
+            return expression;
         }
 
         @JsonProperty

--- a/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
+++ b/wren-main/src/main/java/io/wren/main/web/dto/QueryAnalysisDto.java
@@ -356,13 +356,15 @@ public class QueryAnalysisDto
     {
         private String expression;
         private String sourceDataset;
+        private String sourceColumn;
         private NodeLocationDto nodeLocation;
 
         @JsonCreator
-        public ExprSourceDto(String expression, String sourceDataset, NodeLocationDto nodeLocation)
+        public ExprSourceDto(String expression, String sourceDataset, String sourceColumn, NodeLocationDto nodeLocation)
         {
             this.expression = expression;
             this.sourceDataset = sourceDataset;
+            this.sourceColumn = sourceColumn;
             this.nodeLocation = nodeLocation;
         }
 
@@ -376,6 +378,12 @@ public class QueryAnalysisDto
         public String getSourceDataset()
         {
             return sourceDataset;
+        }
+
+        @JsonProperty
+        public String getSourceColumn()
+        {
+            return sourceColumn;
         }
 
         @JsonProperty
@@ -395,14 +403,15 @@ public class QueryAnalysisDto
             }
             ExprSourceDto that = (ExprSourceDto) o;
             return Objects.equals(expression, that.expression) &&
-                    Objects.equals(sourceDataset, that.sourceDataset)
-                    && Objects.equals(nodeLocation, that.nodeLocation);
+                    Objects.equals(sourceDataset, that.sourceDataset) &&
+                    Objects.equals(sourceColumn, that.sourceColumn) &&
+                    Objects.equals(nodeLocation, that.nodeLocation);
         }
 
         @Override
         public int hashCode()
         {
-            return Objects.hash(expression, sourceDataset, nodeLocation);
+            return Objects.hash(expression, sourceDataset, sourceColumn, nodeLocation);
         }
 
         @Override
@@ -411,6 +420,7 @@ public class QueryAnalysisDto
             return "ExprSourceDto{" +
                     "expression='" + expression + '\'' +
                     ", sourceDataset='" + sourceDataset + '\'' +
+                    ", sourceColumn='" + sourceColumn + '\'' +
                     ", nodeLocation=" + nodeLocation +
                     '}';
         }

--- a/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
@@ -128,7 +128,7 @@ public class TestAnalysisResource
         // all of select item match the star symbol position
         assertThat(result.get(0).getSelectItems().get(0).getNodeLocation()).isEqualTo(nodeLocationDto(1, 8));
         assertThat(result.get(0).getSelectItems().get(0).getExprSources())
-                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8))));
+                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", "custkey", nodeLocationDto(1, 8))));
         assertThat(result.get(0).getSelectItems().get(1).getNodeLocation()).isEqualTo(nodeLocationDto(1, 8));
         assertThat(result.get(0).getRelation().getTableName()).isEqualTo("customer");
         assertThat(result.get(0).getRelation().getNodeLocation()).isEqualTo(nodeLocationDto(1, 15));
@@ -146,7 +146,7 @@ public class TestAnalysisResource
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(
                 new QueryAnalysisDto.GroupByKeyDto("custkey",
                 nodeLocationDto(1, 49),
-                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8)))));
+                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", "custkey", nodeLocationDto(1, 8)))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "select * from customer c join orders o on c.custkey = o.custkey"));
         assertThat(result.size()).isEqualTo(1);
@@ -162,8 +162,8 @@ public class TestAnalysisResource
         assertThat(result.get(0).getRelation().getCriteria().getExpression()).isEqualTo("ON (c.custkey = o.custkey)");
         assertThat(result.get(0).getRelation().getCriteria().getNodeLocation()).isEqualTo(nodeLocationDto(1, 43));
         assertThat(Set.copyOf(result.get(0).getRelation().getExprSources()))
-                .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer", nodeLocationDto(1, 43)),
-                        new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders", nodeLocationDto(1, 55))));
+                .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer", "custkey", nodeLocationDto(1, 43)),
+                        new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders", "custkey", nodeLocationDto(1, 55))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT * FROM customer WHERE custkey = 1 OR (name = 'test' AND address = 'test')"));
         assertThat(result.size()).isEqualTo(1);
@@ -175,7 +175,7 @@ public class TestAnalysisResource
         assertThat(result.get(0).getFilter().getType()).isEqualTo(FilterAnalysis.Type.OR.name());
         assertThat(result.get(0).getFilter().getLeft().getType()).isEqualTo(FilterAnalysis.Type.EXPR.name());
         assertThat(assertThat(result.get(0).getFilter().getLeft().getExprSources())
-                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 30)))));
+                .isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", "custkey", nodeLocationDto(1, 30)))));
         assertThat(result.get(0).getFilter().getRight().getType()).isEqualTo(FilterAnalysis.Type.AND.name());
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT custkey, count(*), name FROM customer GROUP BY 1, 3, nationkey"));
@@ -183,20 +183,20 @@ public class TestAnalysisResource
         assertThat(result.get(0).getGroupByKeys().size()).isEqualTo(3);
         assertThat(result.get(0).getGroupByKeys().get(0).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("custkey",
                 nodeLocationDto(1, 55),
-                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8)))));
+                List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", "custkey", nodeLocationDto(1, 8)))));
         assertThat(result.get(0).getGroupByKeys().get(1).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("name",
                 nodeLocationDto(1, 58),
-                List.of(new QueryAnalysisDto.ExprSourceDto("name", "customer", nodeLocationDto(1, 27)))));
+                List.of(new QueryAnalysisDto.ExprSourceDto("name", "customer", "name", nodeLocationDto(1, 27)))));
         assertThat(result.get(0).getGroupByKeys().get(2).get(0)).isEqualTo(new QueryAnalysisDto.GroupByKeyDto("nationkey",
                 nodeLocationDto(1, 61),
-                List.of(new QueryAnalysisDto.ExprSourceDto("nationkey", "customer", nodeLocationDto(1, 61)))));
+                List.of(new QueryAnalysisDto.ExprSourceDto("nationkey", "customer", "nationkey", nodeLocationDto(1, 61)))));
 
         result = getSqlAnalysis(new SqlAnalysisInputDto(manifest, "SELECT custkey, name FROM customer ORDER BY 1 ASC, 2 DESC"));
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.get(0).getSortings().size()).isEqualTo(2);
         assertThat(result.get(0).getSortings().get(0).getExpression()).isEqualTo("custkey");
         assertThat(result.get(0).getSortings().get(0).getOrdering()).isEqualTo(SortItem.Ordering.ASCENDING.name());
-        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", nodeLocationDto(1, 8))));
+        assertThat(result.get(0).getSortings().get(0).getExprSources()).isEqualTo(List.of(new QueryAnalysisDto.ExprSourceDto("custkey", "customer", "custkey", nodeLocationDto(1, 8))));
         assertThat(result.get(0).getSortings().get(0).getNodeLocation()).isEqualTo(nodeLocationDto(1, 45));
         assertThat(result.get(0).getSortings().get(1).getExpression()).isEqualTo("name");
         assertThat(result.get(0).getSortings().get(1).getOrdering()).isEqualTo(SortItem.Ordering.DESCENDING.name());

--- a/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
+++ b/wren-tests/src/test/java/io/wren/testing/TestAnalysisResource.java
@@ -159,7 +159,8 @@ public class TestAnalysisResource
         assertThat(result.get(0).getRelation().getLeft().getNodeLocation()).isEqualTo(nodeLocationDto(1, 15));
         assertThat(result.get(0).getRelation().getRight().getType()).isEqualTo(RelationAnalysis.Type.TABLE.name());
         assertThat(result.get(0).getRelation().getRight().getNodeLocation()).isEqualTo(nodeLocationDto(1, 31));
-        assertThat(result.get(0).getRelation().getCriteria()).isEqualTo("ON (c.custkey = o.custkey)");
+        assertThat(result.get(0).getRelation().getCriteria().getExpression()).isEqualTo("ON (c.custkey = o.custkey)");
+        assertThat(result.get(0).getRelation().getCriteria().getNodeLocation()).isEqualTo(nodeLocationDto(1, 43));
         assertThat(Set.copyOf(result.get(0).getRelation().getExprSources()))
                 .isEqualTo(Set.of(new QueryAnalysisDto.ExprSourceDto("c.custkey", "customer", nodeLocationDto(1, 43)),
                         new QueryAnalysisDto.ExprSourceDto("o.custkey", "orders", nodeLocationDto(1, 55))));


### PR DESCRIPTION
close #683 
close #690 

# JoinCriteria Location
The location of the join criteria is the most left-side expression. Because of the limitation of trino parser, we can't dedicate the precision location of the join type syntax (`ON` or `USING`). For example:
```
SELECT * FROM a JOIN b ON a.a1 = b.b1
```
The location of the criteria is the location of `a.a1`.