### PR TITLE
fix(mssql): import custom dialects from ibis library for sqlglot

### DIFF
--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -1,3 +1,4 @@
+import importlib
 from abc import ABC, abstractmethod
 
 import httpx
@@ -11,6 +12,9 @@ from app.model import UnprocessableEntityError
 from app.model.data_source import DataSource
 
 wren_engine_endpoint = get_config().wren_engine_endpoint
+
+# To register custom dialects from ibis library for sqlglot
+importlib.import_module("ibis.backends.sql.dialects")
 
 
 class Rewriter(ABC):


### PR DESCRIPTION
Resolve https://github.com/Canner/WrenAI/issues/581

Ibis implements the MSSQL dialect for sqlglot. If we use sqlglot before using Ibis, the MSSQL dialect will not be registered in sqlglot. Therefore, we need to import the dialect from Ibis before using sqlglot.