### PR TITLE
fix(mssql): use msodbcsql instead of tdsodbc

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -54,16 +54,13 @@ jobs:
             ~/.cargo/git/db/
             wren-modeling-py/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('wren-modeling-py/Cargo.lock') }}
-      - name: Install FreeTDS to be a ODBC driver
+      - name: Install MS ODBC SQL driver
         run: |
-          sudo apt-get update -y && sudo apt-get install -y unixodbc-dev freetds-dev tdsodbc
-          cat << EOF > free.tds.ini
-          [FreeTDS]
-          Description = FreeTDS driver
-          Driver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
-          Setup = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
-          EOF
-          sudo odbcinst -i -d -f free.tds.ini
+          sudo apt-get update
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo tee /etc/apt/trusted.gpg.d/microsoft.asc
+          curl https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+          sudo apt-get update
+          sudo ACCEPT_EULA=Y apt-get -y install unixodbc-dev msodbcsql18
       - name: Install dependencies
         run: just install
       - name: Run tests

--- a/ibis-server/Dockerfile
+++ b/ibis-server/Dockerfile
@@ -34,33 +34,19 @@ RUN just install --without dev
 
 FROM python:3.11-slim-buster AS runtime
 
+# Add microsoft package list
+RUN apt-get update \
+    && apt-get install -y curl gnupg \
+    && curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update
+
+# Install msodbcsql 18 driver for mssql
+RUN ACCEPT_EULA=Y apt-get -y install unixodbc-dev msodbcsql18
+
 # libpq-dev is required for psycopg2
-# unixodbc-dev, freetds-dev and tdsodbc are required for pyodbc
-RUN apt-get update  \
-    && apt-get -y install libpq-dev \
-    && apt-get -y install unixodbc-dev freetds-dev tdsodbc \
+RUN apt-get -y install libpq-dev \
     && rm -rf /var/lib/apt/lists/*
-
-ARG TARGETPLATFORM
-
-# Install FreeTDS driver
-RUN <<EOT
-if [ "$TARGETPLATFORM" = "linux/amd64" ]; then
-  export FREE_TDS_PATH=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so;
-elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then
-  export FREE_TDS_PATH=/usr/lib/aarch64-linux-gnu/odbc/libtdsodbc.so;
-else \
-  echo "Unsupported platform: $TARGETPLATFORM"; exit 1;
-fi && \
-echo "FREE_TDS_PATH is set to $FREE_TDS_PATH"
-cat <<EOF > free.tds.ini
-[FreeTDS]
-Description = FreeTDS driver
-Driver = ${FREE_TDS_PATH}
-Setup = ${FREE_TDS_PATH}
-EOF
-odbcinst -i -d -f free.tds.ini
-EOT
 
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -65,10 +65,8 @@ class MSSqlConnectionInfo(BaseModel):
     database: SecretStr
     user: SecretStr
     password: SecretStr
-    driver: str = Field(
-        default="FreeTDS",
-        description="On Mac and Linux this is usually `FreeTDS. On Windows, it is usually `ODBC Driver 18 for SQL Server`",
-    )
+    driver: str = Field(default="ODBC Driver 18 for SQL Server")
+    kwargs: dict[str, str] | None = None
 
 
 class MySqlConnectionInfo(BaseModel):

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -110,6 +110,7 @@ class DataSourceExtension(Enum):
             user=info.user.get_secret_value(),
             password=info.password.get_secret_value(),
             driver=info.driver,
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod

--- a/ibis-server/docs/development.md
+++ b/ibis-server/docs/development.md
@@ -59,15 +59,21 @@ Please see [How to Add a New Data Source](how-to-add-data-source.md) for more in
 
 
 ## Troubleshooting
-### MS SQL Server Tests
-If you're having trouble running tests related to MS SQL Server, you may need to install the appropriate driver. For Linux or macOS, we recommend installing the `unixodbc` and `freetds` packages.
-After installation, run `odbcinst -j` to check the path of the `odbcinst.ini` file. Then, find the path of `libtdsodbc.so` in freetds and add the following content to the odbcinst.ini file:
-```ini
-[FreeTDS]
-Description = FreeTDS driver
-Driver = /opt/homebrew/Cellar/freetds/1.4.17/lib/libtdsodbc.so
-Setup = /opt/homebrew/Cellar/freetds/1.4.17/lib/libtdsodbc.so
-FileUsage = 1
-```
-Adjust the paths as necessary for your system.
+### No driver for MS SQL Server
+If you want to run tests related to MS SQL Server, you may need to install the `Microsoft ODBC 18 driver`. \
+You can follow the instructions to install the driver:
+- [Microsoft ODBC driver for SQL Server (Linux)](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server).
+- [Microsoft ODBC driver for SQL Server (macOS)](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos).
+- [Microsoft ODBC driver for SQL Server (Windows)](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server).
 
+### [ODBC Driver 18 for SQL Server]SSL Provider: [error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:self signed certificate]
+If you encounter this error, you can add the `TrustServerCertificate` parameter to the connection string.
+```json
+{
+  "connectionInfo": {
+    "kwargs": {
+      "TrustServerCertificate": "YES"
+    }
+  }
+}
+```

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -75,7 +75,9 @@ def mssql(request) -> SqlServerContainer:
     mssql = SqlServerContainer(
         "mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04", dialect="mssql+pyodbc"
     ).start()
-    engine = sqlalchemy.create_engine(f"{mssql.get_connection_url()}?driver=FreeTDS")
+    engine = sqlalchemy.create_engine(
+        f"{mssql.get_connection_url()}?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=YES"
+    )
     pd.read_parquet(file_path("resource/tpch/data/orders.parquet")).to_sql(
         "orders", engine, index=False
     )
@@ -387,6 +389,7 @@ def to_connection_info(mssql: SqlServerContainer):
         "user": mssql.username,
         "password": mssql.password,
         "database": mssql.dbname,
+        "kwargs": {"TrustServerCertificate": "YES"},
     }
 
 


### PR DESCRIPTION
## Description
We found the `tdsodbc` version in the Debian 10 is 1.0 and may be too old not to support the `Azure SQL database`.
We will use `Microsoft ODBC 18 driver` instead of tdsodbc.
It will support SQL server version `2014` or later.

The msodbcsql driver 18.0 supports 2012, but the version is not on `ARM`.
We will use the latest MS ODBC 18 driver for arm64 and amd64. The latest version does not support 2012.

## Additional information
[Operating system support](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/system-requirements?view=sql-server-ver16#operating-system-support)
[SQL version compatibility](https://learn.microsoft.com/en-us/sql/connect/odbc/windows/system-requirements-installation-and-driver-files?view=sql-server-ver16#sql-version-compatibility)