### PR TITLE
fix(ibis): determine the data is null or not

### DIFF
--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -35,17 +35,18 @@ def _to_json_obj(df: pd.DataFrame) -> dict:
     data = df.to_dict(orient="split", index=False)
 
     def default(d):
-        match d:
-            case decimal.Decimal():
-                return float(d)
-            case pd.Timestamp():
-                return d.value // 10**6
-            case datetime.datetime():
-                return int(d.timestamp())
-            case datetime.date():
-                return calendar.timegm(d.timetuple()) * 1000
-            case _:
-                raise d
+        if pd.isnull(d):
+            return None
+        if isinstance(d, decimal.Decimal):
+            return float(d)
+        elif isinstance(d, pd.Timestamp):
+            return d.value // 10**6
+        elif isinstance(d, datetime.datetime):
+            return int(d.timestamp())
+        elif isinstance(d, datetime.date):
+            return calendar.timegm(d.timetuple()) * 1000
+        else:
+            raise d
 
     json_obj = orjson.loads(
         orjson.dumps(

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -55,6 +55,11 @@ manifest = {
                     "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -95,6 +100,7 @@ def test_query():
         "1_370",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -105,6 +111,7 @@ def test_query():
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -136,6 +143,7 @@ def test_query_with_column_dtypes():
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -146,6 +154,7 @@ def test_query_with_column_dtypes():
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -53,6 +53,11 @@ manifest = {
                     "type": "timestamp",
                 },
                 {
+                    "name": "test_null_time",
+                    "expression": "toDateTime64(NULL, 9)",
+                    "type": "timestamp",
+                },
+                {
                     "name": "customer",
                     "type": "Customer",
                     "relationship": "OrdersCustomer",
@@ -162,7 +167,7 @@ def test_query(clickhouse: ClickHouseContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == 9
+    assert len(result["columns"]) == 10
     assert len(result["data"]) == 1
     assert result["data"][0] == [
         1,
@@ -173,6 +178,7 @@ def test_query(clickhouse: ClickHouseContainer):
         "1_370",
         1704153599000,
         1704153599000,
+        None,
         "Customer#000000370",
     ]
     assert result["dtypes"] == {
@@ -184,6 +190,7 @@ def test_query(clickhouse: ClickHouseContainer):
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "object",
         "customer_name": "object",
     }
 
@@ -200,7 +207,7 @@ def test_query_with_connection_url(clickhouse: ClickHouseContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == 9
+    assert len(result["columns"]) == 10
     assert len(result["data"]) == 1
     assert result["data"][0][0] == 1
     assert result["dtypes"] is not None
@@ -224,7 +231,7 @@ def test_query_with_column_dtypes(clickhouse: ClickHouseContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == 9
+    assert len(result["columns"]) == 10
     assert len(result["data"]) == 1
     assert result["data"][0] == [
         1,
@@ -235,6 +242,7 @@ def test_query_with_column_dtypes(clickhouse: ClickHouseContainer):
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
         "Customer#000000370",
     ]
     assert result["dtypes"] == {
@@ -246,6 +254,7 @@ def test_query_with_column_dtypes(clickhouse: ClickHouseContainer):
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "object",
         "customer_name": "object",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -52,6 +52,11 @@ manifest = {
                     "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -109,6 +114,7 @@ def test_query(mssql: SqlServerContainer):
         "1_370",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -119,6 +125,7 @@ def test_query(mssql: SqlServerContainer):
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -172,6 +179,7 @@ def test_query_with_column_dtypes(mssql: SqlServerContainer):
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -182,6 +190,7 @@ def test_query_with_column_dtypes(mssql: SqlServerContainer):
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 

--- a/ibis-server/tests/routers/v2/connector/test_mysql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mysql.py
@@ -53,6 +53,11 @@ manifest = {
                     "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -117,6 +122,7 @@ def test_query(mysql: MySqlContainer):
         "1_370",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -127,6 +133,7 @@ def test_query(mysql: MySqlContainer):
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -177,6 +184,7 @@ def test_query_with_column_dtypes(mysql: MySqlContainer):
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -187,6 +195,7 @@ def test_query_with_column_dtypes(mysql: MySqlContainer):
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -54,6 +54,11 @@ manifest = {
                     "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -109,6 +114,7 @@ def test_query(postgres: PostgresContainer):
         "1_370",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -119,6 +125,7 @@ def test_query(postgres: PostgresContainer):
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -194,6 +201,7 @@ def test_query_with_column_dtypes(postgres: PostgresContainer):
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -204,6 +212,7 @@ def test_query_with_column_dtypes(postgres: PostgresContainer):
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -437,7 +446,7 @@ def test_dry_plan():
     assert response.status_code == 200
     assert (
         response.text
-        == '''"WITH \\"Orders\\" AS (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\" FROM (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\" FROM (SELECT o_orderkey AS \\"orderkey\\", o_custkey AS \\"custkey\\", o_orderstatus AS \\"orderstatus\\", o_totalprice AS \\"totalprice\\", o_orderdate AS \\"orderdate\\", CONCAT(o_orderkey, '_', o_custkey) AS \\"order_cust_key\\", CAST('2024-01-01T23:59:59' AS TIMESTAMP) AS \\"timestamp\\", CAST('2024-01-01T23:59:59' AS TIMESTAMPTZ) AS \\"timestamptz\\" FROM (SELECT * FROM public.orders) AS \\"Orders\\") AS \\"Orders\\") AS \\"Orders\\") SELECT orderkey, order_cust_key FROM \\"Orders\\" LIMIT 1"'''
+        == '''"WITH \\"Orders\\" AS (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\", \\"Orders\\".\\"test_null_time\\" AS \\"test_null_time\\" FROM (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\", \\"Orders\\".\\"test_null_time\\" AS \\"test_null_time\\" FROM (SELECT o_orderkey AS \\"orderkey\\", o_custkey AS \\"custkey\\", o_orderstatus AS \\"orderstatus\\", o_totalprice AS \\"totalprice\\", o_orderdate AS \\"orderdate\\", CONCAT(o_orderkey, '_', o_custkey) AS \\"order_cust_key\\", CAST('2024-01-01T23:59:59' AS TIMESTAMP) AS \\"timestamp\\", CAST('2024-01-01T23:59:59' AS TIMESTAMPTZ) AS \\"timestamptz\\", CAST(NULL AS TIMESTAMP) AS \\"test_null_time\\" FROM (SELECT * FROM public.orders) AS \\"Orders\\") AS \\"Orders\\") AS \\"Orders\\") SELECT orderkey, order_cust_key FROM \\"Orders\\" LIMIT 1"'''
     )
 
 

--- a/ibis-server/tests/routers/v2/connector/test_snowflake.py
+++ b/ibis-server/tests/routers/v2/connector/test_snowflake.py
@@ -58,6 +58,11 @@ manifest = {
                     "expression": "cast('2024-01-01T23:59:59' as timestamp with time zone)",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -98,6 +103,7 @@ def test_query():
         "1_36901",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -108,6 +114,7 @@ def test_query():
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -139,6 +146,7 @@ def test_query_with_column_dtypes():
         "1_36901",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -149,6 +157,7 @@ def test_query_with_column_dtypes():
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -49,6 +49,11 @@ manifest = {
                     "expression": "with_timezone(TIMESTAMP '2024-01-01 23:59:59', 'UTC')",
                     "type": "timestamp",
                 },
+                {
+                    "name": "test_null_time",
+                    "expression": "cast(NULL as timestamp)",
+                    "type": "timestamp",
+                },
             ],
             "primaryKey": "orderkey",
         },
@@ -88,6 +93,7 @@ def test_query(trino: TrinoContainer):
         "1_370",
         1704153599000,
         1704153599000,
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -98,6 +104,7 @@ def test_query(trino: TrinoContainer):
         "order_cust_key": "object",
         "timestamp": "datetime64[ns]",
         "timestamptz": "datetime64[ns, UTC]",
+        "test_null_time": "datetime64[ns]",
     }
 
 
@@ -148,6 +155,7 @@ def test_query_with_column_dtypes(trino: TrinoContainer):
         "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
+        None,
     ]
     assert result["dtypes"] == {
         "orderkey": "int64",
@@ -158,6 +166,7 @@ def test_query_with_column_dtypes(trino: TrinoContainer):
         "order_cust_key": "object",
         "timestamp": "object",
         "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
     }
 
 


### PR DESCRIPTION
If the data is null when the column type is a timestamp, data in the pandas dataframe will be a `NaT`(Not a Time) object. It could not be serialized to JSON in `orjson` ([issue](https://github.com/ijl/orjson/issues/249), [test case]( https://github.com/ijl/orjson/blob/master/test/test_numpy.py#L799)).

NaT is a type of `numpy`. The numpy provides a function [isnat](https://numpy.org/doc/stable/reference/generated/numpy.isnat.html) to determine it. But it will raise an error when the input is `pandas.NaT`. Fortunately, pandas provide a function [isnull](https://pandas.pydata.org/docs/reference/api/pandas.isnull.html) that could cover this type and also cover `NaN`.