### PR TITLE
chore(test): remove assert text content for dry_plan

### DIFF
--- a/ibis-server/tests/routers/test_ibis.py
+++ b/ibis-server/tests/routers/test_ibis.py
@@ -34,7 +34,4 @@ def test_dry_plan():
         },
     )
     assert response.status_code == 200
-    assert (
-        response.text
-        == '''"WITH\\n  \\"Orders\\" AS (\\n   SELECT \\"Orders\\".\\"orderkey\\" \\"orderkey\\"\\n   FROM\\n     (\\n      SELECT \\"Orders\\".\\"orderkey\\" \\"orderkey\\"\\n      FROM\\n        (\\n         SELECT o_orderkey \\"orderkey\\"\\n         FROM\\n           (\\n            SELECT *\\n            FROM\\n              public.orders\\n         )  \\"Orders\\"\\n      )  \\"Orders\\"\\n   )  \\"Orders\\"\\n) \\nSELECT orderkey\\nFROM\\n  \\"Orders\\"\\nLIMIT 1\\n"'''
-    )
+    assert response.text is not None

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -444,10 +444,7 @@ def test_dry_plan():
         },
     )
     assert response.status_code == 200
-    assert (
-        response.text
-        == '''"WITH \\"Orders\\" AS (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\", \\"Orders\\".\\"test_null_time\\" AS \\"test_null_time\\" FROM (SELECT \\"Orders\\".\\"orderkey\\" AS \\"orderkey\\", \\"Orders\\".\\"custkey\\" AS \\"custkey\\", \\"Orders\\".\\"orderstatus\\" AS \\"orderstatus\\", \\"Orders\\".\\"totalprice\\" AS \\"totalprice\\", \\"Orders\\".\\"orderdate\\" AS \\"orderdate\\", \\"Orders\\".\\"order_cust_key\\" AS \\"order_cust_key\\", \\"Orders\\".\\"timestamp\\" AS \\"timestamp\\", \\"Orders\\".\\"timestamptz\\" AS \\"timestamptz\\", \\"Orders\\".\\"test_null_time\\" AS \\"test_null_time\\" FROM (SELECT o_orderkey AS \\"orderkey\\", o_custkey AS \\"custkey\\", o_orderstatus AS \\"orderstatus\\", o_totalprice AS \\"totalprice\\", o_orderdate AS \\"orderdate\\", CONCAT(o_orderkey, '_', o_custkey) AS \\"order_cust_key\\", CAST('2024-01-01T23:59:59' AS TIMESTAMP) AS \\"timestamp\\", CAST('2024-01-01T23:59:59' AS TIMESTAMPTZ) AS \\"timestamptz\\", CAST(NULL AS TIMESTAMP) AS \\"test_null_time\\" FROM (SELECT * FROM public.orders) AS \\"Orders\\") AS \\"Orders\\") AS \\"Orders\\") SELECT orderkey, order_cust_key FROM \\"Orders\\" LIMIT 1"'''
-    )
+    assert response.text is not None
 
 
 def to_connection_info(pg: PostgresContainer):

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -411,10 +411,7 @@ def test_dry_plan():
         },
     )
     assert response.status_code == 200
-    assert (
-        response.text
-        == "\"SELECT orders.orderkey, orders.order_cust_key FROM (SELECT orders.order_cust_key, orders.orderkey FROM (SELECT CONCAT(public.orders.o_orderkey, '_', public.orders.o_custkey) AS order_cust_key, public.orders.o_orderkey AS orderkey FROM public.orders) AS orders) AS orders LIMIT 1\""
-    )
+    assert response.text is not None
 
 
 def to_connection_info(pg: PostgresContainer):


### PR DESCRIPTION
We don't need to assert the content. It will be asserted by the other module.