### PR TITLE
ci(integration-tests): add more activity types

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,13 @@ name: Integration tests
 
 on:
   pull_request:
-    types: [ labeled ]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}


### PR DESCRIPTION
We make the PR from `dependabot` with the label `v1-engine-changed`, but the PR does not trigger ci `integration-test`.
The CI needs more activity types for the PR created with the label.