### PR TITLE
feat(core): support case sensitive identifier

### DIFF
--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -413,7 +413,7 @@ def test_dry_plan():
     assert response.status_code == 200
     assert (
         response.text
-        == "\"SELECT orders.orderkey, orders.order_cust_key FROM (SELECT orders.order_cust_key, orders.orderkey FROM (SELECT CONCAT(public.orders.o_orderkey, '_', public.orders.o_custkey) AS order_cust_key, public.orders.o_orderkey AS orderkey FROM public.orders) AS orders) AS orders LIMIT 1\""
+        == "\"select orders.orderkey, orders.order_cust_key from (select orders.order_cust_key, orders.orderkey from (select concat(public.orders.o_orderkey, '_', public.orders.o_custkey) as order_cust_key, public.orders.o_orderkey as orderkey from public.orders) as orders) as orders limit 1\""
     )
 
 

--- a/wren-modeling-py/src/lib.rs
+++ b/wren-modeling-py/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
                 .unwrap();
         assert_eq!(
             transformed_sql,
-            r#"SELECT customer.custkey, customer."name" FROM (SELECT customer.custkey, customer."name" FROM (SELECT main.customer.c_custkey AS custkey, main.customer.c_name AS "name" FROM main.customer) AS customer) AS customer"#
+            r#"select customer.custkey, customer."name" from (select customer.custkey, customer."name" from (select main.customer.c_custkey as custkey, main.customer.c_name as "name" from main.customer) as customer) as customer"#
         );
     }
 }

--- a/wren-modeling-py/tests/test_modeling_core.py
+++ b/wren-modeling-py/tests/test_modeling_core.py
@@ -30,5 +30,5 @@ def test_transform_sql():
     rewritten_sql = wren_core.transform_sql(manifest_str, sql)
     assert (
         rewritten_sql
-        == 'SELECT customer.custkey, customer."name" FROM (SELECT customer.custkey, customer."name" FROM (SELECT main.customer.c_custkey AS custkey, main.customer.c_name AS "name" FROM main.customer) AS customer) AS customer'
+        == 'select customer.custkey, customer."name" from (select customer.custkey, customer."name" from (select main.customer.c_custkey as custkey, main.customer.c_name as "name" from main.customer) as customer) as customer'
     )

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -25,7 +25,7 @@ use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::{JoinType, Model};
 use crate::mdl::utils::{
     create_remote_expr_for_model, create_wren_calculated_field_expr,
-    create_wren_expr_for_model, is_dag,
+    create_wren_expr_for_model, is_dag, quoted,
 };
 use crate::mdl::Dataset;
 use crate::mdl::{AnalyzedWrenMDL, ColumnReference, SessionStateRef};
@@ -216,14 +216,14 @@ impl ModelPlanNodeBuilder {
                     .insert(OrdExpr::new(expr_plan.clone()));
                 let expr_plan = Expr::Column(Column::from_qualified_name(format!(
                     "{}.{}",
-                    model_ref.table(),
-                    column.name()
+                    quoted(model_ref.table()),
+                    quoted(column.name()),
                 )));
                 self.required_exprs_buffer
                     .insert(OrdExpr::new(expr_plan.clone()));
             }
             self.fields.push_front((
-                Some(TableReference::bare(model.name())),
+                Some(TableReference::bare(quoted(model.name()))),
                 Arc::new(Field::new(
                     column.name(),
                     map_data_type(&column.r#type)?,
@@ -291,7 +291,7 @@ impl ModelPlanNodeBuilder {
         )?;
 
         for calculation_plan in calculate_iter {
-            let target_ref = TableReference::bare(calculation_plan.name());
+            let target_ref = TableReference::bare(quoted(calculation_plan.name()));
             let Some(join_key) = model.primary_key() else {
                 return plan_err!(
                     "Model {} should have primary key for calculation",
@@ -305,10 +305,10 @@ impl ModelPlanNodeBuilder {
                 JoinType::OneToOne,
                 format!(
                     "{}.{} = {}.{}",
-                    model_ref.table(),
-                    join_key,
-                    target_ref.table(),
-                    join_key,
+                    quoted(model_ref.table()),
+                    quoted(join_key),
+                    quoted(target_ref.table()),
+                    quoted(join_key),
                 ),
                 Box::new(relation_chain),
             );
@@ -565,7 +565,7 @@ fn get_remote_column_exp(
         )?
     } else {
         create_remote_expr_for_model(
-            &column.name,
+            quoted(&column.name).as_str(),
             model,
             analyzed_wren_mdl,
             session_state_ref,
@@ -714,7 +714,7 @@ impl ModelSourceNode {
                         continue;
                     }
                     fields_buffer.insert((
-                        Some(TableReference::bare(model.name())),
+                        Some(TableReference::bare(quoted(model.name()))),
                         Arc::new(Field::new(
                             column.name(),
                             map_data_type(&column.r#type)?,
@@ -754,7 +754,7 @@ impl ModelSourceNode {
                 }
 
                 fields_buffer.insert((
-                    Some(TableReference::bare(model.name())),
+                    Some(TableReference::bare(quoted(model.name()))),
                     Arc::new(Field::new(
                         column.name(),
                         map_data_type(&column.r#type)?,
@@ -855,7 +855,7 @@ impl CalculationPlanNode {
             )),
         ]
         .into_iter()
-        .map(|f| (Some(TableReference::bare(model.name())), f))
+        .map(|f| (Some(TableReference::bare(quoted(model.name()))), f))
         .collect();
         let dimensions = vec![create_wren_expr_for_model(
             &pk_column.name,

--- a/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/plan.rs
@@ -291,7 +291,7 @@ impl ModelPlanNodeBuilder {
         )?;
 
         for calculation_plan in calculate_iter {
-            let target_ref = TableReference::bare(quoted(calculation_plan.name()));
+            let target_ref = TableReference::bare(calculation_plan.name());
             let Some(join_key) = model.primary_key() else {
                 return plan_err!(
                     "Model {} should have primary key for calculation",
@@ -368,8 +368,8 @@ impl ModelPlanNodeBuilder {
         // The calculation column is provided by the CalculationPlanNode.
         let _ = &self.required_exprs_buffer.insert(OrdExpr::new(col(format!(
             "{}.{}",
-            column.name(),
-            column.name()
+            quoted(column.name()),
+            quoted(column.name()),
         ))));
 
         let mut partial_model_required_fields = HashMap::new();

--- a/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/relation_chain.rs
@@ -7,6 +7,7 @@ use crate::logical_plan::utils::create_schema;
 use crate::mdl;
 use crate::mdl::lineage::DatasetLink;
 use crate::mdl::manifest::JoinType;
+use crate::mdl::utils::quoted;
 use crate::mdl::Dataset;
 use crate::mdl::{AnalyzedWrenMDL, SessionStateRef};
 use datafusion::common::TableReference;
@@ -154,8 +155,8 @@ impl RelationChain {
                                 .map(|field| {
                                     col(format!(
                                         "{}.{}",
-                                        model_plan.plan_name,
-                                        field.name()
+                                        quoted(&model_plan.plan_name),
+                                        quoted(field.name()),
                                     ))
                                 })
                                 .for_each(|c| {
@@ -170,8 +171,8 @@ impl RelationChain {
                                 .map(|field| {
                                     col(format!(
                                         "{}.{}",
-                                        model_source_plan.model_name,
-                                        field.name()
+                                        quoted(&model_source_plan.model_name),
+                                        quoted(field.name()),
                                     ))
                                 })
                                 .for_each(|c| {
@@ -186,8 +187,10 @@ impl RelationChain {
                                 .map(|field| {
                                     col(format!(
                                         "{}.{}",
-                                        calculation_plan.calculation.column.name(),
-                                        field.name()
+                                        quoted(
+                                            calculation_plan.calculation.column.name()
+                                        ),
+                                        quoted(field.name()),
                                     ))
                                 })
                                 .for_each(|c| {
@@ -202,8 +205,8 @@ impl RelationChain {
                                 .map(|field| {
                                     col(format!(
                                         "{}.{}",
-                                        partial_model_plan.model_node.plan_name,
-                                        field.name()
+                                        quoted(&partial_model_plan.model_node.plan_name),
+                                        quoted(field.name()),
                                     ))
                                 })
                                 .for_each(|c| {
@@ -220,7 +223,8 @@ impl RelationChain {
                     let (Some(table_rf), f) = left.schema().qualified_field(index) else {
                         return plan_err!("Field not found");
                     };
-                    let qualified_name = format!("{}.{}", table_rf, f.name());
+                    let qualified_name =
+                        format!("{}.{}", table_rf.to_quoted_string(), quoted(f.name()));
                     required_exprs.insert(OrdExpr::new(col(qualified_name)));
                 }
 
@@ -230,7 +234,8 @@ impl RelationChain {
                     else {
                         return plan_err!("Field not found");
                     };
-                    let qualified_name = format!("{}.{}", table_rf, f.name());
+                    let qualified_name =
+                        format!("{}.{}", table_rf.to_quoted_string(), quoted(f.name()));
                     required_exprs.insert(OrdExpr::new(col(qualified_name)));
                 }
 

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -339,7 +339,7 @@ impl ModelAnalyzeRule {
                 .get_model(relation.table())
                 .is_some()
             {
-                Transformed::yes(col(format!(r#"{}.{}"#, alias_model, quoted(&name))))
+                Transformed::yes(col(format!("{}.{}", alias_model, quoted(&name))))
             } else {
                 // handle Wren View
                 // TODO: catalog and schema should be case sensitive

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -290,11 +290,7 @@ impl ModelAnalyzeRule {
         match expr {
             Expr::Column(Column { relation, name }) => {
                 if let Some(relation) = relation {
-                    Ok(self.rewrite_column_qualifier(
-                        relation,
-                        name,
-                        alias_model,
-                    ))
+                    Ok(self.rewrite_column_qualifier(relation, name, alias_model))
                 } else {
                     // TODO: catalog and schema should be case sensitive
                     let catalog_schema = format!(

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -292,7 +292,7 @@ impl ModelAnalyzeRule {
                 if let Some(relation) = relation {
                     Ok(self.rewrite_column_qualifier(
                         relation,
-                        quoted(&name),
+                        name,
                         alias_model,
                     ))
                 } else {
@@ -303,7 +303,7 @@ impl ModelAnalyzeRule {
                         self.analyzed_wren_mdl.wren_mdl().schema()
                     );
                     let name = name.replace(&catalog_schema, "");
-                    let ident = ident(quoted(&name));
+                    let ident = ident(&name);
                     Ok(Transformed::yes(ident))
                 }
             }
@@ -339,7 +339,7 @@ impl ModelAnalyzeRule {
                 .get_model(relation.table())
                 .is_some()
             {
-                Transformed::yes(col(format!(r#"{}.{}"#, alias_model, name)))
+                Transformed::yes(col(format!(r#"{}.{}"#, alias_model, quoted(&name))))
             } else {
                 // handle Wren View
                 // TODO: catalog and schema should be case sensitive
@@ -351,7 +351,7 @@ impl ModelAnalyzeRule {
                 let name = name.replace(&catalog_schema, "");
                 Transformed::yes(Expr::Column(Column::new(
                     Some(TableReference::bare(relation.table())),
-                    quoted(&name),
+                    &name,
                 )))
             }
         } else {

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -292,7 +292,6 @@ impl ModelAnalyzeRule {
                 if let Some(relation) = relation {
                     Ok(self.rewrite_column_qualifier(relation, name, alias_model))
                 } else {
-                    // TODO: catalog and schema should be case sensitive
                     let catalog_schema = format!(
                         "{}.{}.",
                         self.analyzed_wren_mdl.wren_mdl().catalog(),
@@ -338,7 +337,6 @@ impl ModelAnalyzeRule {
                 Transformed::yes(col(format!("{}.{}", alias_model, quoted(&name))))
             } else {
                 // handle Wren View
-                // TODO: catalog and schema should be case sensitive
                 let catalog_schema = format!(
                     "{}.{}.",
                     self.analyzed_wren_mdl.wren_mdl().catalog(),

--- a/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
+++ b/wren-modeling-rs/core/src/logical_plan/analyze/rule.rs
@@ -20,6 +20,7 @@ use crate::logical_plan::analyze::plan::{
 };
 use crate::logical_plan::utils::create_remote_table_source;
 use crate::mdl::manifest::Model;
+use crate::mdl::utils::quoted;
 use crate::mdl::{AnalyzedWrenMDL, SessionStateRef, WrenMDL};
 
 /// [ModelAnalyzeRule] responsible for analyzing the model plan node. Turn TableScan from a model to a ModelPlanNode.
@@ -92,7 +93,7 @@ impl ModelAnalyzeRule {
                     // transform ViewTable to a subquery plan
                     if let Some(logical_plan) = table_scan.source.get_logical_plan() {
                         let subquery = LogicalPlanBuilder::from(logical_plan.clone())
-                            .alias(table_name)?
+                            .alias(quoted(table_name))?
                             .build()?;
                         return Ok(Transformed::yes(subquery));
                     }
@@ -111,7 +112,7 @@ impl ModelAnalyzeRule {
                             )?),
                         });
                         let subquery = LogicalPlanBuilder::from(model_plan)
-                            .alias(model.name())?
+                            .alias(quoted(model.name()))?
                             .build()?;
                         used_columns.borrow_mut().clear();
                         Ok(Transformed::yes(subquery))
@@ -289,15 +290,21 @@ impl ModelAnalyzeRule {
         match expr {
             Expr::Column(Column { relation, name }) => {
                 if let Some(relation) = relation {
-                    Ok(self.rewrite_column_qualifier(relation, name, alias_model))
+                    Ok(self.rewrite_column_qualifier(
+                        relation,
+                        quoted(&name),
+                        alias_model,
+                    ))
                 } else {
+                    // TODO: catalog and schema should be case sensitive
                     let catalog_schema = format!(
                         "{}.{}.",
                         self.analyzed_wren_mdl.wren_mdl().catalog(),
                         self.analyzed_wren_mdl.wren_mdl().schema()
                     );
                     let name = name.replace(&catalog_schema, "");
-                    Ok(Transformed::yes(ident(name)))
+                    let ident = ident(quoted(&name));
+                    Ok(Transformed::yes(ident))
                 }
             }
             Expr::Alias(Alias {
@@ -332,9 +339,10 @@ impl ModelAnalyzeRule {
                 .get_model(relation.table())
                 .is_some()
             {
-                Transformed::yes(col(format!("{}.{}", alias_model, name)))
+                Transformed::yes(col(format!(r#"{}.{}"#, alias_model, name)))
             } else {
                 // handle Wren View
+                // TODO: catalog and schema should be case sensitive
                 let catalog_schema = format!(
                     "{}.{}.",
                     self.analyzed_wren_mdl.wren_mdl().catalog(),
@@ -343,7 +351,7 @@ impl ModelAnalyzeRule {
                 let name = name.replace(&catalog_schema, "");
                 Transformed::yes(Expr::Column(Column::new(
                     Some(TableReference::bare(relation.table())),
-                    name,
+                    quoted(&name),
                 )))
             }
         } else {
@@ -362,7 +370,7 @@ impl ModelAnalyzeRule {
                     unwrap_arc(Arc::clone(&input))
                 {
                     if node.as_any().downcast_ref::<ModelPlanNode>().is_some() {
-                        Some(alias.to_string())
+                        Some(alias.to_quoted_string())
                     } else {
                         None
                     }
@@ -556,7 +564,7 @@ impl ModelGenerationRule {
                         return Ok(Transformed::no(table_scan));
                     }
                     let result = LogicalPlanBuilder::from(table_scan)
-                        .alias(model.name.clone())?
+                        .alias(quoted(model.name()))?
                         .build()?;
                     Ok(Transformed::yes(result))
                 } else if let Some(calculation_plan) = extension
@@ -586,7 +594,7 @@ impl ModelGenerationRule {
                             }
                         };
                         let alias = LogicalPlanBuilder::from(result)
-                            .alias(calculation_plan.calculation.column.name())?
+                            .alias(quoted(calculation_plan.calculation.column.name()))?
                             .build()?;
                         Ok(Transformed::yes(alias))
                     } else {
@@ -602,7 +610,7 @@ impl ModelGenerationRule {
                     });
 
                     let subquery = LogicalPlanBuilder::from(plan)
-                        .alias(partial_model.model_node.plan_name())?
+                        .alias(quoted(partial_model.model_node.plan_name()))?
                         .build()?;
                     let source_plan = self.generate_model_internal(subquery)?.data;
                     let projection: Vec<_> = partial_model
@@ -613,7 +621,7 @@ impl ModelGenerationRule {
                         .collect();
                     let alias = LogicalPlanBuilder::from(source_plan)
                         .project(projection)?
-                        .alias(partial_model.model_node.plan_name.clone())?
+                        .alias(quoted(&partial_model.model_node.plan_name))?
                         .build()?;
                     Ok(Transformed::yes(alias))
                 } else {

--- a/wren-modeling-rs/core/src/logical_plan/utils.rs
+++ b/wren-modeling-rs/core/src/logical_plan/utils.rs
@@ -11,6 +11,7 @@ use petgraph::dot::{Config, Dot};
 use petgraph::Graph;
 
 use crate::mdl::lineage::DatasetLink;
+use crate::mdl::utils::quoted;
 use crate::mdl::Dataset;
 use crate::mdl::{
     manifest::{Column, Model},
@@ -138,7 +139,13 @@ pub fn format_qualified_name(
     dataset: &str,
     column: &str,
 ) -> String {
-    format!("{}.{}.{}.{}", catalog, schema, dataset, column)
+    format!(
+        "{}.{}.{}.{}",
+        quoted(catalog),
+        quoted(schema),
+        quoted(dataset),
+        quoted(column)
+    )
 }
 
 pub fn from_qualified_name(

--- a/wren-modeling-rs/core/src/mdl/dataset.rs
+++ b/wren-modeling-rs/core/src/mdl/dataset.rs
@@ -1,5 +1,6 @@
 use crate::logical_plan::utils::map_data_type;
 use crate::mdl::manifest::{Column, Metric, Model};
+use crate::mdl::utils::quoted;
 use crate::mdl::{RegisterTables, SessionStateRef};
 use datafusion::arrow::datatypes::DataType::Utf8;
 use datafusion::arrow::datatypes::Field;
@@ -114,7 +115,7 @@ impl Dataset {
                     .map(|c| c.to_field())
                     .collect::<Result<Vec<_>>>()?;
                 let arrow_schema = datafusion::arrow::datatypes::Schema::new(fields);
-                DFSchema::try_from_qualified_schema(&model.name, &arrow_schema)
+                DFSchema::try_from_qualified_schema(quoted(&model.name), &arrow_schema)
             }
             Dataset::Metric(_) => todo!(),
         }

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -205,3 +205,9 @@ pub struct View {
     #[serde(default)]
     pub properties: Vec<(String, String)>,
 }
+
+impl View {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -190,6 +190,8 @@ pub fn transform_sql(analyzed_mdl: Arc<AnalyzedWrenMDL>, sql: &str) -> Result<St
 }
 
 /// Transform the SQL based on the MDL with the SessionContext
+/// Wren engine will normalize the SQL to the lower case to solve the case sensitive
+/// issue for the Wren view
 pub async fn transform_sql_with_ctx(
     ctx: &SessionContext,
     analyzed_mdl: Arc<AnalyzedWrenMDL>,
@@ -211,7 +213,12 @@ pub async fn transform_sql_with_ctx(
     match plan_to_sql(&analyzed) {
         Ok(sql) => {
             // TODO: workaround to remove unnecessary catalog and schema of mdl
-            let replaced = sql.to_string().replace(&catalog_schema, "");
+            let replaced = sql
+                .to_string()
+                .replace(&catalog_schema, "")
+                // TODO: There're some issue about datafusion unparsing the expr column name with different case
+                // The workaround is to normalize the SQL to the lower case to support Wren View.
+                .to_lowercase();
             info!("wren-core planned SQL: {}", replaced);
             Ok(replaced)
         }

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -177,9 +177,9 @@ fn qualified_expr(
                 let mut parts: Vec<_> = qualifier
                     .to_vec()
                     .into_iter()
-                    .map(|q| Ident::with_quote('"', q))
+                    .map(|q| quoted_ident(&q))
                     .collect();
-                parts.push(Ident::with_quote('"', id.value.clone()));
+                parts.push(quoted_ident(id.value.as_str()));
                 *e = CompoundIdentifier(parts);
             }
         }
@@ -188,6 +188,12 @@ fn qualified_expr(
     Ok(expr.to_string())
 }
 
+#[inline]
+pub fn quoted_ident(s: &str) -> Ident {
+    Ident::with_quote('"', s)
+}
+
+#[inline]
 pub fn quoted(s: &str) -> String {
     format!("\"{}\"", s)
 }

--- a/wren-modeling-rs/core/src/mdl/utils.rs
+++ b/wren-modeling-rs/core/src/mdl/utils.rs
@@ -29,6 +29,11 @@ where
     g.is_directed() && !is_cyclic_directed(g)
 }
 
+/// Collect all identifiers in the expression. The output [Column] is unqualified.
+/// Because the number of the CompoundIdentifier elements length would be greater than 3 in Wren Core,
+/// we use the unqualified [Column] to represent the [CompoundIdentifier] in the expression.
+///
+/// For example, a [CompoundIdentifier] with 3 elements: `orders.customer.name` would be represented as `"orders.customer.name"`.
 pub fn collect_identifiers(expr: &str) -> Result<BTreeSet<Column>> {
     let wrapped = format!("select {}", expr);
     let parsed = Parser::parse_sql(&GenericDialect {}, &wrapped)?;

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -120,144 +120,144 @@ async fn register_ecommerce_mdl(
 ) -> Result<(SessionContext, Arc<AnalyzedWrenMDL>)> {
     let manifest = ManifestBuilder::new()
         .model(
-            ModelBuilder::new("customers")
+            ModelBuilder::new("Customers")
                 .table_reference("datafusion.public.customers")
-                .column(ColumnBuilder::new("city", "varchar").build())
-                .column(ColumnBuilder::new("id", "varchar").build())
-                .column(ColumnBuilder::new("state", "varchar").build())
-                .column(
-                    ColumnBuilder::new_calculated("city_state", "varchar")
-                        .expression("city || ' ' || state")
-                        .build(),
-                )
-                .primary_key("id")
+                .column(ColumnBuilder::new("City", "varchar").expression("city").build())
+                .column(ColumnBuilder::new("Id", "varchar").expression("id").build())
+                .column(ColumnBuilder::new("State", "varchar").expression("state").build())
+                // .column(
+                //     ColumnBuilder::new_calculated("City_state", "varchar")
+                //         .expression(r#""City" || ' ' || "State""#)
+                //         .build(),
+                // )
+                .primary_key("Id")
                 .build(),
         )
         .model(
-            ModelBuilder::new("order_items")
+            ModelBuilder::new("Order_items")
                 .table_reference("datafusion.public.order_items")
-                .column(ColumnBuilder::new("freight_value", "double").build())
-                .column(ColumnBuilder::new("id", "bigint").build())
-                .column(ColumnBuilder::new("item_number", "bigint").build())
-                .column(ColumnBuilder::new("order_id", "varchar").build())
-                .column(ColumnBuilder::new("price", "double").build())
-                .column(ColumnBuilder::new("product_id", "varchar").build())
-                .column(ColumnBuilder::new("shipping_limit_date", "varchar").build())
+                .column(ColumnBuilder::new("Freight_value", "double").expression("freight_value").build())
+                .column(ColumnBuilder::new("Id", "bigint").expression("id").build())
+                .column(ColumnBuilder::new("Item_number", "bigint").expression("item_number").build())
+                .column(ColumnBuilder::new("Order_id", "varchar").expression("order_id").build())
+                .column(ColumnBuilder::new("Price", "double").expression("price").build())
+                .column(ColumnBuilder::new("Product_id", "varchar").expression("product_id").build())
+                .column(ColumnBuilder::new("Shipping_limit_date", "varchar").expression("shipping_limit_date").build())
                 .column(
                     ColumnBuilder::new_relationship(
-                        "orders",
-                        "orders",
-                        "orders_order_items",
+                        "Orders",
+                        "Orders",
+                        "Orders_order_items",
                     )
                     .build(),
                 )
                 .column(
-                    ColumnBuilder::new_calculated("customer_state", "varchar")
-                        .expression("orders.customers.state")
+                    ColumnBuilder::new_calculated("Customer_state", "varchar")
+                        .expression(r#""Orders"."Customers"."State""#)
                         .build(),
                 )
                 // TODO: it cause a stack overflow issue.
                 // .column(
-                //     ColumnBuilder::new_calculated("customer_state_cf", "varchar")
-                //         .expression("orders.customer_state")
+                //     ColumnBuilder::new_calculated("Customer_state_cf", "varchar")
+                //         .expression(r#""Orders"."Customer_state""#)
                 //         .build(),
                 // )
                 // TODO: duplicate `orders.customer_state`
                 // .column(
-                //     ColumnBuilder::new_calculated("customer_state_cf_concat", "varchar")
-                //         .expression("orders.customer_state || '-test'")
+                //     ColumnBuilder::new_calculated("Customer_state_cf_concat", "varchar")
+                //         .expression(r#""Orders"."Customer_state" || '-test'"#)
                 //         .build(),
                 // )
                 // TODO: allow multiple calculation in an expression
                 // .column(
-                //     ColumnBuilder::new("customer_location", "varchar")
+                //     ColumnBuilder::new("Customer_location", "varchar")
                 //         .calculated(true)
-                //         .expression("orders.customer_state || '-' || orders.customer_city")
+                //         .expression(r#""Orders"."Customer_state" || '-' || "Orders."Customer_city""#)
                 //         .build(),
                 // )
                 // .column(
-                //     ColumnBuilder::new("customer_location", "varchar")
+                //     ColumnBuilder::new("Customer_location", "varchar")
                 //         .calculated(true)
-                //         .expression("orders.customers.state || '-' || orders.customers.city")
+                //         .expression(r#""Orders"."Customers"."State" || '-' || "Orders"."Customers"."City""#)
                 //         .build(),
                 // )
-                .primary_key("id")
+                .primary_key("Id")
                 .build(),
         )
         .model(
-            ModelBuilder::new("orders")
+            ModelBuilder::new("Orders")
                 .table_reference("datafusion.public.orders")
-                .column(ColumnBuilder::new("approved_timestamp", "varchar").build())
-                .column(ColumnBuilder::new("customer_id", "varchar").build())
-                .column(ColumnBuilder::new("delivered_carrier_date", "varchar").build())
-                .column(ColumnBuilder::new("estimated_delivery_date", "varchar").build())
-                .column(ColumnBuilder::new("order_id", "varchar").build())
-                .column(ColumnBuilder::new("purchase_timestamp", "varchar").build())
+                .column(ColumnBuilder::new("Approved_timestamp", "varchar").expression("approved_timestamp").build())
+                .column(ColumnBuilder::new("Customer_id", "varchar").expression("customer_id").build())
+                .column(ColumnBuilder::new("Delivered_carrier_date", "varchar").expression("delivered_carrier_date").build())
+                .column(ColumnBuilder::new("Estimated_delivery_date", "varchar").expression("estimated_delivery_date").build())
+                .column(ColumnBuilder::new("Order_id", "varchar").expression("order_id").build())
+                .column(ColumnBuilder::new("Purchase_timestamp", "varchar").expression("purchase_timestamp").build())
                 .column(
                     ColumnBuilder::new_relationship(
-                        "customers",
-                        "customers",
-                        "orders_customer",
+                        "Customers",
+                        "Customers",
+                        "Orders_customer",
                     )
                     .build(),
                 )
                 .column(
-                    ColumnBuilder::new_calculated("customer_state", "varchar")
-                        .expression("customers.state")
+                    ColumnBuilder::new_calculated("Customer_state", "varchar")
+                        .expression(r#""Customers"."State""#)
                         .build(),
                 )
                 // TODO: fix calcaultion with non-relationship column
                 // .column(
-                //     ColumnBuilder::new_calculated("customer_state_order_id", "varchar")
-                //         .expression("customers.state || ' ' || order_id")
+                //     ColumnBuilder::new_calculated("Customer_state_order_id", "varchar")
+                //         .expression(r#""Customers"."State" || ' ' || "Order_id""#)
                 //         .build(),
                 // )
                 .column(
                     ColumnBuilder::new_relationship(
-                        "order_items",
-                        "order_items",
-                        "orders_order_items",
+                        "Order_items",
+                        "Order_items",
+                        "Orders_order_items",
                     )
                     .build(),
                 )
                 .column(
-                    ColumnBuilder::new_calculated("totalprice", "double")
-                        .expression("sum(order_items.price)")
+                    ColumnBuilder::new_calculated("Totalprice", "double")
+                        .expression(r#"sum("Order_items"."Price")"#)
                         .build(),
                 )
                 .column(
-                    ColumnBuilder::new_calculated("customer_city", "varchar")
-                        .expression("customers.city")
+                    ColumnBuilder::new_calculated("Customer_city", "varchar")
+                        .expression(r#""Customers"."City""#)
                         .build(),
                 )
-                .primary_key("order_id")
+                .primary_key("Order_id")
                 .build(),
         )
         .relationship(
-            RelationshipBuilder::new("orders_customer")
-                .model("orders")
-                .model("customers")
+            RelationshipBuilder::new("Orders_customer")
+                .model("Orders")
+                .model("Customers")
                 .join_type(JoinType::ManyToOne)
-                .condition("orders.customer_id = customers.id")
+                .condition(r#""Orders"."Customer_id" = "Customers"."Id""#)
                 .build(),
         )
         .relationship(
-            RelationshipBuilder::new("orders_order_items")
-                .model("orders")
-                .model("order_items")
+            RelationshipBuilder::new("Orders_order_items")
+                .model("Orders")
+                .model("Order_items")
                 .join_type(JoinType::ManyToOne)
-                .condition("orders.order_id = order_items.order_id")
+                .condition(r#""Orders"."Order_id" = "Order_items"."Order_id""#)
                 .build(),
         )
         .view(
-            ViewBuilder::new("customer_view")
-                .statement("select * from wrenai.public.customers")
+            ViewBuilder::new("Customer_view")
+                .statement(r#"select * from wrenai.public."Customers""#)
                 .build(),
         )
-        .view(ViewBuilder::new("revenue_orders").statement("select order_id, sum(price) from wrenai.public.order_items group by order_id").build())
+        .view(ViewBuilder::new("Revenue_orders").statement(r#"select "Order_id", sum("Price") from wrenai.public."Order_items" group by "Order_id""#).build())
         .view(
-            ViewBuilder::new("revenue_orders_alias")
-                .statement("select order_id as order_id, sum(price) as totalprice from wrenai.public.order_items group by order_id")
+            ViewBuilder::new("Revenue_orders_alias")
+                .statement(r#"select "Order_id" as "Order_id", sum("Price") as "Totalprice" from wrenai.public."Order_items" group by "Order_id""#)
                 .build())
         .build();
     let mut register_tables = HashMap::new();

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -125,11 +125,11 @@ async fn register_ecommerce_mdl(
                 .column(ColumnBuilder::new("City", "varchar").expression("city").build())
                 .column(ColumnBuilder::new("Id", "varchar").expression("id").build())
                 .column(ColumnBuilder::new("State", "varchar").expression("state").build())
-                // .column(
-                //     ColumnBuilder::new_calculated("City_state", "varchar")
-                //         .expression(r#""City" || ' ' || "State""#)
-                //         .build(),
-                // )
+                .column(
+                    ColumnBuilder::new_calculated("City_state", "varchar")
+                        .expression(r#""City" || ' ' || "State""#)
+                        .build(),
+                )
                 .primary_key("Id")
                 .build(),
         )

--- a/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/model.slt
@@ -1,37 +1,37 @@
 statement ok
-SELECT * from wrenai.public.orders
+SELECT * from wrenai.public."Orders"
 
 statement ok
-select cast(freight_value as int) + cast(price as int) from wrenai.public.order_items
+select cast("Freight_value" as int) + cast("Price" as int) from wrenai.public."Order_items"
 
 statement ok
-select product_id from wrenai.public.order_items where cast(freight_value as double) > 10.0
+select "Product_id" from wrenai.public."Order_items" where cast("Freight_value" as double) > 10.0
 
 statement ok
-select product_id from wrenai.public.order_items where freight_value > 10.0
+select "Product_id" from wrenai.public."Order_items" where "Freight_value" > 10.0
 
 statement ok
-select product_id, min(price) from wrenai.public.order_items group by product_id
+select "Product_id", min("Price") from wrenai.public."Order_items" group by "Product_id"
 
 statement ok
-select product_id, min(price) from wrenai.public.order_items where freight_value > 10.0 group by product_id
+select "Product_id", min("Price") from wrenai.public."Order_items" where "Freight_value" > 10.0 group by "Product_id"
 
 statement ok
-select * from wrenai.public.order_items;
+select * from wrenai.public."Order_items";
 
 statement ok
-select * from wrenai.public.customers;
+select * from wrenai.public."Customers";
 
 statement ok
-select count(*) from wrenai.public.order_items;
+select count(*) from wrenai.public."Order_items";
 
 # check the count of order_items won't be increased by the relationship calculation
 query B
-select cnt1 = cnt2 from (select count(*) as cnt1 from (select customer_state from  wrenai.public.order_items)), (select count(*) as cnt2 from datafusion.public.order_items) limit 1;
+select cnt1 = cnt2 from (select count(*) as cnt1 from (select "Customer_state" from wrenai.public."Order_items")), (select count(*) as cnt2 from datafusion.public.order_items) limit 1;
 ----
 true
 
 query B
-select actual = expected from (select totalprice as actual from wrenai.public.orders where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'), (select sum(price) as expected from datafusion.public.order_items where order_id = '76754c0e642c8f99a8c3fcb8a14ac700') limit 1;
+select actual = expected from (select "Totalprice" as actual from wrenai.public."Orders" where "Order_id" = '76754c0e642c8f99a8c3fcb8a14ac700'), (select sum(price) as expected from datafusion.public.order_items where order_id = '76754c0e642c8f99a8c3fcb8a14ac700') limit 1;
 ----
 true

--- a/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
@@ -8,7 +8,7 @@ statement ok
 SELECT * FROM wrenai.public."Revenue_orders_alias"
 
 statement ok
-SELECT totalprice FROM wrenai.public."Revenue_orders_alias"
+SELECT "Totalprice" FROM wrenai.public."Revenue_orders_alias"
 
 query TR
 SELECT "Order_id", "Totalprice" FROM wrenai.public."Revenue_orders_alias" where "Order_id" = '76754c0e642c8f99a8c3fcb8a14ac700'

--- a/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
+++ b/wren-modeling-rs/sqllogictest/test_sql_files/view.slt
@@ -1,16 +1,16 @@
 statement ok
-SELECT * FROM wrenai.public.customer_view
+SELECT * FROM wrenai.public."Customer_view"
 
 statement ok
-SELECT * FROM wrenai.public.revenue_orders
+SELECT * FROM wrenai.public."Revenue_orders"
 
 statement ok
-SELECT * FROM wrenai.public.revenue_orders_alias
+SELECT * FROM wrenai.public."Revenue_orders_alias"
 
 statement ok
-SELECT totalprice FROM wrenai.public.revenue_orders_alias
+SELECT totalprice FROM wrenai.public."Revenue_orders_alias"
 
 query TR
-SELECT order_id, totalprice FROM wrenai.public.revenue_orders_alias where order_id = '76754c0e642c8f99a8c3fcb8a14ac700'
+SELECT "Order_id", "Totalprice" FROM wrenai.public."Revenue_orders_alias" where "Order_id" = '76754c0e642c8f99a8c3fcb8a14ac700'
 ----
 76754c0e642c8f99a8c3fcb8a14ac700 287.4


### PR DESCRIPTION
# Description
close #717 
After this changed, all name in the MDL will be case sensitive. Because the SQL text in the data fusion is lowercase by default, if the table or column name contains the uppercase, we should use it with quotes.

# Example
```rust
  let manifest = ManifestBuilder::new()
      .catalog("wrenai")
      .schema("public")
      .model(
          ModelBuilder::new("Customer")
              .table_reference("datafusion.public.customer")
              .column(ColumnBuilder::new("custkey", "int").build())
              .column(ColumnBuilder::new("name", "string").build())
              .build(),
      )
      .build();
```

When query the model `Customer`, we should use the following SQL
```sql
SELECT * FROM wrenai.public."Customer"
```

However, the column `custkey` is all lowercase. We can just query it without qutoes:
```sql
SELECT custeky FROM wrenai.public."Customer"
```