### PR TITLE
feat(core): handle JoinType serde using `SCREAMING_SNAKE_CASE` and `snake_case` style

### DIFF
--- a/wren-modeling-rs/core/src/mdl/builder.rs
+++ b/wren-modeling-rs/core/src/mdl/builder.rs
@@ -430,8 +430,7 @@ mod test {
     }
 
     #[test]
-    fn test_join_type_case_insensitive()
-    {
+    fn test_join_type_case_insensitive() {
         let case = ["one_to_one", "ONE_TO_ONE"];
         let expected = JoinType::OneToOne;
         for case in case.iter() {

--- a/wren-modeling-rs/core/src/mdl/builder.rs
+++ b/wren-modeling-rs/core/src/mdl/builder.rs
@@ -430,6 +430,39 @@ mod test {
     }
 
     #[test]
+    fn test_join_type_case_insensitive()
+    {
+        let case = ["one_to_one", "ONE_TO_ONE"];
+        let expected = JoinType::OneToOne;
+        for case in case.iter() {
+            assert_serde(&format!("\"{}\"", case), expected);
+        }
+
+        let case = ["one_to_many", "ONE_TO_MANY"];
+        let expected = JoinType::OneToMany;
+        for case in case.iter() {
+            assert_serde(&format!("\"{}\"", case), expected);
+        }
+
+        let case = ["many_to_one", "MANY_TO_ONE"];
+        let expected = JoinType::ManyToOne;
+        for case in case.iter() {
+            assert_serde(&format!("\"{}\"", case), expected);
+        }
+
+        let case = ["many_to_many", "MANY_TO_MANY"];
+        let expected = JoinType::ManyToMany;
+        for case in case.iter() {
+            assert_serde(&format!("\"{}\"", case), expected);
+        }
+    }
+
+    fn assert_serde(json_str: &str, expected: JoinType) {
+        let actual: JoinType = serde_json::from_str(json_str).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_metric_roundtrip() {
         let model = MetricBuilder::new("test")
             .dimension(ColumnBuilder::new("dim", "integer").build())

--- a/wren-modeling-rs/core/src/mdl/manifest.rs
+++ b/wren-modeling-rs/core/src/mdl/manifest.rs
@@ -134,13 +134,16 @@ pub struct Relationship {
     pub properties: Vec<(String, String)>,
 }
 
-// handle case insensitive
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum JoinType {
+    #[serde(alias = "one_to_one")]
     OneToOne,
+    #[serde(alias = "one_to_many")]
     OneToMany,
+    #[serde(alias = "many_to_one")]
     ManyToOne,
+    #[serde(alias = "many_to_many")]
     ManyToMany,
 }
 

--- a/wren-modeling-rs/core/tests/data/mdl.json
+++ b/wren-modeling-rs/core/tests/data/mdl.json
@@ -123,13 +123,13 @@
     {
       "name": "CustomerOrders",
       "models": ["customer", "orders"],
-      "joinType": "one_to_many",
+      "joinType": "ONE_TO_MANY",
       "condition": "customer.custkey = orders.custkey"
     },
     {
       "name" : "CustomerProfile",
       "models": ["customer", "profile"],
-      "joinType": "one_to_one",
+      "joinType": "ONE_TO_ONE",
       "condition": "customer.custkey = profile.custkey"
     }
   ],


### PR DESCRIPTION
# Description
close #718 
Refer to [serde doc](https://serde.rs/container-attrs.html#rename_all), we use `SCREMING_SNAKE_CASE` and add alias for `snake_case`.
The Join type is supported serialized from both of the styles now.
```
one_to_one,  ONE_TO_ONE
```