### PR TITLE
feat(ibis): adjust json data type and format

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -9,11 +9,6 @@ connection_info_field = Field(alias="connectionInfo")
 class QueryDTO(BaseModel):
     sql: str
     manifest_str: str = manifest_str_field
-    column_dtypes: dict[str, str] | None = Field(
-        alias="columnDtypes",
-        description="If this field is set, it will forcibly convert the type.",
-        default=None,
-    )
     connection_info: ConnectionInfo = connection_info_field
 
 

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -34,9 +34,7 @@ def query(
     if dry_run:
         connector.dry_run(rewritten_sql)
         return Response(status_code=204)
-    return JSONResponse(
-        to_json(connector.query(rewritten_sql, limit=limit), dto.column_dtypes)
-    )
+    return JSONResponse(to_json(connector.query(rewritten_sql, limit=limit)))
 
 
 @router.post("/{data_source}/validate/{rule_name}")

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -32,9 +32,7 @@ def query(
     if dry_run:
         connector.dry_run(rewritten_sql)
         return Response(status_code=204)
-    return JSONResponse(
-        to_json(connector.query(rewritten_sql, limit=limit), dto.column_dtypes)
-    )
+    return JSONResponse(to_json(connector.query(rewritten_sql, limit=limit)))
 
 
 @router.post("/dry-plan")

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -1,38 +1,41 @@
-import calendar
-import datetime
 import decimal
 
 import orjson
 import pandas as pd
+from pandas.core.dtypes.common import is_datetime64_any_dtype
 
 
 def to_json(df: pd.DataFrame) -> dict:
+    for column in df.columns:
+        if is_datetime64_any_dtype(df[column].dtype):
+            df[column] = _to_datetime_and_format(df[column])
     return _to_json_obj(df)
+
+
+def _to_datetime_and_format(series: pd.Series) -> pd.Series:
+    return series.apply(
+        lambda d: d.strftime(
+            "%Y-%m-%d %H:%M:%S.%f" + (" %Z" if series.dt.tz is not None else "")
+        )
+        if not pd.isnull(d)
+        else d
+    )
 
 
 def _to_json_obj(df: pd.DataFrame) -> dict:
     data = df.to_dict(orient="split", index=False)
 
-    def default(d):
-        if pd.isnull(d):
+    def default(obj):
+        if pd.isna(obj):
             return None
-        if isinstance(d, decimal.Decimal):
-            return float(d)
-        elif isinstance(d, pd.Timestamp):
-            return d.value // 10**6
-        elif isinstance(d, datetime.datetime):
-            return int(d.timestamp())
-        elif isinstance(d, datetime.date):
-            return calendar.timegm(d.timetuple()) * 1000
-        else:
-            raise d
+        if isinstance(obj, decimal.Decimal):
+            return str(obj)
+        raise TypeError
 
     json_obj = orjson.loads(
         orjson.dumps(
             data,
-            option=orjson.OPT_SERIALIZE_NUMPY
-            | orjson.OPT_PASSTHROUGH_DATETIME
-            | orjson.OPT_SERIALIZE_UUID,
+            option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_SERIALIZE_UUID,
             default=default,
         )
     )

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -6,29 +6,8 @@ import orjson
 import pandas as pd
 
 
-def to_json(df: pd.DataFrame, column_dtypes: dict[str, str] | None) -> dict:
-    if column_dtypes:
-        _to_specific_types(df, column_dtypes)
+def to_json(df: pd.DataFrame) -> dict:
     return _to_json_obj(df)
-
-
-def _to_specific_types(df: pd.DataFrame, column_dtypes: dict[str, str]):
-    for column, dtype in column_dtypes.items():
-        if dtype == "datetime64":
-            df[column] = _to_datetime_and_format(df[column])
-        else:
-            df[column] = df[column].astype(dtype)
-
-
-def _to_datetime_and_format(series: pd.Series) -> pd.Series:
-    series = pd.to_datetime(series, errors="coerce")
-    return series.apply(
-        lambda d: d.strftime(
-            "%Y-%m-%d %H:%M:%S.%f" + (" %Z" if series.dt.tz is not None else "")
-        )
-        if not pd.isnull(d)
-        else d
-    )
 
 
 def _to_json_obj(df: pd.DataFrame) -> dict:

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -96,10 +96,10 @@ def test_query():
         370,
         "O",
         172799.49,
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
     ]
     assert result["dtypes"] == {
@@ -109,8 +109,8 @@ def test_query():
         "totalprice": "float64",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -115,49 +115,6 @@ def test_query():
     }
 
 
-def test_query_with_column_dtypes():
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int64",
-        "custkey": "int64",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_without_manifest():
     response = client.post(
         url=f"{base_url}/query",

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -213,52 +213,6 @@ def test_query_with_connection_url(clickhouse: ClickHouseContainer):
     assert result["dtypes"] is not None
 
 
-def test_query_with_column_dtypes(clickhouse: ClickHouseContainer):
-    connection_info = to_connection_info(clickhouse)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == 10
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-        "Customer#000000370",
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int32",
-        "custkey": "int32",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "object",
-        "customer_name": "object",
-    }
-
-
 def test_query_with_limit(clickhouse: ClickHouseContainer):
     connection_info = to_connection_info(clickhouse)
     response = client.post(

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -173,11 +173,11 @@ def test_query(clickhouse: ClickHouseContainer):
         1,
         370,
         "O",
-        172799.49,
-        820540800000,
+        "172799.49",
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
         "Customer#000000370",
     ]
@@ -188,8 +188,8 @@ def test_query(clickhouse: ClickHouseContainer):
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "object",
         "customer_name": "object",
     }
@@ -296,7 +296,7 @@ def test_query_to_many_relationship(clickhouse: ClickHouseContainer):
     result = response.json()
     assert len(result["columns"]) == 1
     assert len(result["data"]) == 1
-    assert result["data"][0] == [2860895.79]
+    assert result["data"][0] == ["2860895.79"]
     assert result["dtypes"] == {
         "totalprice": "object",
     }

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -150,50 +150,6 @@ def test_query_with_connection_url(mssql: SqlServerContainer):
     assert result["dtypes"] is not None
 
 
-def test_query_with_column_dtypes(mssql: SqlServerContainer):
-    connection_info = to_connection_info(mssql)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int32",
-        "custkey": "int32",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_without_manifest(mssql: SqlServerContainer):
     connection_info = to_connection_info(mssql)
     response = client.post(

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -110,10 +110,10 @@ def test_query(mssql: SqlServerContainer):
         370,
         "O",
         "172799.49",
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
     ]
     assert result["dtypes"] == {
@@ -123,8 +123,8 @@ def test_query(mssql: SqlServerContainer):
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_mysql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mysql.py
@@ -118,10 +118,10 @@ def test_query(mysql: MySqlContainer):
         370,
         "O",
         "172799.49",
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000",
         None,
     ]
     assert result["dtypes"] == {
@@ -131,8 +131,8 @@ def test_query(mysql: MySqlContainer):
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_mysql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mysql.py
@@ -155,50 +155,6 @@ def test_query_with_connection_url(mysql: MySqlContainer):
     assert result["dtypes"] is not None
 
 
-def test_query_with_column_dtypes(mysql: MySqlContainer):
-    connection_info = to_connection_info(mysql)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int32",
-        "custkey": "int32",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_without_manifest(mysql: MySqlContainer):
     connection_info = to_connection_info(mysql)
     response = client.post(

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -172,50 +172,6 @@ def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_
         )
 
 
-def test_query_with_column_dtypes(postgres: PostgresContainer):
-    connection_info = to_connection_info(postgres)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int32",
-        "custkey": "int32",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_with_limit(postgres: PostgresContainer):
     connection_info = to_connection_info(postgres)
     response = client.post(

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -110,10 +110,10 @@ def test_query(postgres: PostgresContainer):
         370,
         "O",
         "172799.49",
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
     ]
     assert result["dtypes"] == {
@@ -123,8 +123,8 @@ def test_query(postgres: PostgresContainer):
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_snowflake.py
+++ b/ibis-server/tests/routers/v2/connector/test_snowflake.py
@@ -98,11 +98,11 @@ def test_query():
         1,
         36901,
         "O",
-        173665.47,
-        820540800000,
+        "173665.47",
+        "1996-01-02 00:00:00.000000",
         "1_36901",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
     ]
     assert result["dtypes"] == {
@@ -112,8 +112,8 @@ def test_query():
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_snowflake.py
+++ b/ibis-server/tests/routers/v2/connector/test_snowflake.py
@@ -118,49 +118,6 @@ def test_query():
     }
 
 
-def test_query_with_column_dtypes():
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" ORDER BY "orderkey" LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        36901,
-        "O",
-        173665.47,
-        "1996-01-02 00:00:00.000000",
-        "1_36901",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int64",
-        "custkey": "int64",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_without_manifest():
     response = client.post(
         url=f"{base_url}/query",

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -89,10 +89,10 @@ def test_query(trino: TrinoContainer):
         370,
         "O",
         172799.49,
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
         None,
     ]
     assert result["dtypes"] == {
@@ -102,8 +102,8 @@ def test_query(trino: TrinoContainer):
         "totalprice": "float64",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
         "test_null_time": "datetime64[ns]",
     }
 

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -126,50 +126,6 @@ def test_query_with_connection_url(trino: TrinoContainer):
     assert result["dtypes"] is not None
 
 
-def test_query_with_column_dtypes(trino: TrinoContainer):
-    connection_info = to_connection_info(trino)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-        None,
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int64",
-        "custkey": "int64",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-        "test_null_time": "datetime64[ns]",
-    }
-
-
 def test_query_with_limit(trino: TrinoContainer):
     connection_info = to_connection_info(trino)
     response = client.post(

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -144,48 +144,6 @@ def test_query_with_connection_url(postgres: PostgresContainer):
     assert result["dtypes"] is not None
 
 
-def test_query_with_column_dtypes(postgres: PostgresContainer):
-    connection_info = to_connection_info(postgres)
-    response = client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            "columnDtypes": {
-                "totalprice": "float",
-                "orderdate": "datetime64",
-                "timestamp": "datetime64",
-                "timestamptz": "datetime64",
-            },
-        },
-    )
-    assert response.status_code == 200
-    result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-    assert len(result["data"]) == 1
-    assert result["data"][0] == [
-        1,
-        370,
-        "O",
-        172799.49,
-        "1996-01-02 00:00:00.000000",
-        "1_370",
-        "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
-    ]
-    assert result["dtypes"] == {
-        "orderkey": "int32",
-        "custkey": "int32",
-        "orderstatus": "object",
-        "totalprice": "float64",
-        "orderdate": "object",
-        "order_cust_key": "object",
-        "timestamp": "object",
-        "timestamptz": "object",
-    }
-
-
 def test_query_with_limit(postgres: PostgresContainer):
     connection_info = to_connection_info(postgres)
     response = client.post(

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -109,10 +109,10 @@ def test_query(postgres: PostgresContainer):
         370,
         "O",
         "172799.49",
-        820540800000,
+        "1996-01-02",
         "1_370",
-        1704153599000,
-        1704153599000,
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -121,8 +121,8 @@ def test_query(postgres: PostgresContainer):
         "totalprice": "object",
         "orderdate": "object",
         "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
+        "timestamp": "object",
+        "timestamptz": "object",
     }
 
 


### PR DESCRIPTION
We abandoned the unused feature `column_dtypes`.
If the dtype is datetime, we will format the data to string when building JSON.