### PR TITLE
fix(core): fix the behaviors of dynamic query

### DIFF
--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -179,7 +179,6 @@ def test_query(clickhouse: ClickHouseContainer):
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
         None,
-        "Customer#000000370",
     ]
     assert result["dtypes"] == {
         "orderkey": "int32",
@@ -191,7 +190,6 @@ def test_query(clickhouse: ClickHouseContainer):
         "timestamp": "object",
         "timestamptz": "object",
         "test_null_time": "object",
-        "customer_name": "object",
     }
 
 

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -167,7 +167,7 @@ def test_query(clickhouse: ClickHouseContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == 10
+    assert len(result["columns"]) == 9
     assert len(result["data"]) == 1
     assert result["data"][0] == [
         1,
@@ -207,7 +207,7 @@ def test_query_with_connection_url(clickhouse: ClickHouseContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == 10
+    assert len(result["columns"]) == 9
     assert len(result["data"]) == 1
     assert result["data"][0][0] == 1
     assert result["dtypes"] is not None

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -103,7 +103,7 @@ def test_query(postgres: PostgresContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["columns"]) == 9
     assert len(result["data"]) == 1
     assert result["data"][0] == [
         1,
@@ -141,7 +141,7 @@ def test_query_with_connection_url(postgres: PostgresContainer):
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["columns"]) == 9
     assert len(result["data"]) == 1
     assert result["data"][0][0] == 1
     assert result["dtypes"] is not None

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
@@ -103,7 +103,8 @@ public class WrenSqlRewrite
                 if (!tableRequiredFields.containsKey(tableName)) {
                     Relationable relationable = wrenMDL.getRelationable(tableName)
                             .orElseThrow(() -> new IllegalArgumentException(format("dataset not found: %s", tableName)));
-                    tableRequiredFields.put(tableName, relationable.getColumns().stream().filter(column -> !column.isCalculated()).map(Column::getName).collect(toImmutableSet()));                }
+                    tableRequiredFields.put(tableName, relationable.getColumns().stream().filter(column -> !column.isCalculated()).map(Column::getName).collect(toImmutableSet()));
+                }
             });
 
             ImmutableList.Builder<QueryDescriptor> descriptorsBuilder = ImmutableList.builder();

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/WrenSqlRewrite.java
@@ -103,8 +103,7 @@ public class WrenSqlRewrite
                 if (!tableRequiredFields.containsKey(tableName)) {
                     Relationable relationable = wrenMDL.getRelationable(tableName)
                             .orElseThrow(() -> new IllegalArgumentException(format("dataset not found: %s", tableName)));
-                    tableRequiredFields.put(tableName, relationable.getColumns().stream().map(Column::getName).collect(toImmutableSet()));
-                }
+                    tableRequiredFields.put(tableName, relationable.getColumns().stream().filter(column -> !column.isCalculated()).map(Column::getName).collect(toImmutableSet()));                }
             });
 
             ImmutableList.Builder<QueryDescriptor> descriptorsBuilder = ImmutableList.builder();

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -373,7 +373,12 @@ public final class StatementAnalyzer
                 // TODO handle target.*
             }
             else {
-                analysis.addCollectedColumns(scope.getRelationType().getFields());
+                List<Field> fields = scope.getRelationType()
+                        .getFields()
+                        .stream()
+                        .filter(f -> f.getSourceColumn().map(c -> !c.isCalculated()).orElse(true))
+                        .collect(toImmutableList());
+                analysis.addCollectedColumns(fields);
                 scope.getRelationType().getFields().stream().map(field ->
                                 field.getRelationAlias().map(DereferenceExpression::from)
                                         .orElse(DereferenceExpression.from(QualifiedName.of(field.getTableName().getSchemaTableName().getTableName(), field.getColumnName()))))

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -19,6 +19,7 @@ import io.trino.sql.QueryUtil;
 import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.AstVisitor;
+import io.trino.sql.tree.DefaultTraversalVisitor;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FrameBound;
@@ -387,8 +388,20 @@ public final class StatementAnalyzer
             ExpressionAnalysis expressionAnalysis = analyzeExpression(singleColumn.getExpression(), scope);
 
             if (expressionAnalysis.isRequireRelation()) {
-                analysis.addRequiredSourceNode(scope.getRelationId().getSourceNode()
-                        .orElseThrow(() -> new IllegalArgumentException("count(*) should have a followed source")));
+                Node source = scope.getRelationId().getSourceNode()
+                        .orElseThrow(() -> new IllegalArgumentException("count(*) should have a followed source"));
+
+                // collect only the source node that is a table for generating the required column for models
+                DefaultTraversalVisitor<Void> visitor = new DefaultTraversalVisitor<>()
+                {
+                    @Override
+                    protected Void visitTable(Table node, Void scope)
+                    {
+                        analysis.addRequiredSourceNode(node);
+                        return null;
+                    }
+                };
+                visitor.process(source, null);
             }
         }
 

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -87,7 +87,6 @@ public class TestWrenWithDuckDB
                         column("custkey", "integer"),
                         column("orderstatus", "varchar"),
                         column("totalprice", "DECIMAL(15,2)"),
-                        column("nation_name", "varchar"),
                         column("orderdate", "date")));
         assertThat(queryResultDto.getData().size()).isEqualTo(100);
     }
@@ -139,7 +138,6 @@ public class TestWrenWithDuckDB
                         column("custkey", "integer"),
                         column("orderstatus", "varchar"),
                         column("totalprice", "DECIMAL(15,2)"),
-                        column("nation_name", "varchar"),
                         column("orderdate", "date")));
         assertThat(queryResultDto.getData().size()).isEqualTo(100);
 
@@ -161,7 +159,6 @@ public class TestWrenWithDuckDB
                         column("custkey", "integer"),
                         column("orderstatus", "varchar"),
                         column("totalprice", "DECIMAL(15,2)"),
-                        column("nation_name", "varchar"),
                         column("orderdate", "date")));
         assertThat(queryResultDto.getData().size()).isEqualTo(100);
     }
@@ -220,5 +217,17 @@ public class TestWrenWithDuckDB
 
         queryResultDto = query(manifest, "select count(*) from Orders a JOIN Customer b ON a.custkey = b.custkey");
         assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(15000);
+    }
+
+    @Test
+    public void testSelectAllExcludeCalculatedField()
+    {
+        QueryResultDto queryResultDto = query(manifest, "select * from Orders limit 100");
+        assertThat(queryResultDto.getColumns())
+                .isEqualTo(List.of(column("orderkey", "INTEGER"),
+                        column("custkey", "INTEGER"),
+                        column("orderstatus", "VARCHAR"),
+                        column("totalprice", "DECIMAL(15,2)"),
+                        column("orderdate", "DATE")));
     }
 }

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -205,4 +205,20 @@ public class TestWrenWithDuckDB
         QueryResultDto queryResultDto = query(manifest, "select count(*) from \"Orders\" where nation_name = 'ALGERIA'");
         assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(691);
     }
+
+    @Test
+    public void testCountJoin()
+    {
+        QueryResultDto queryResultDto = query(manifest, "select count(*) from Orders a");
+        assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(15000);
+
+        queryResultDto = query(manifest, "select count(*) from Orders, Customer");
+        assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(22500000);
+
+        queryResultDto = query(manifest, "select count(*) from Orders a, Customer b");
+        assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(22500000);
+
+        queryResultDto = query(manifest, "select count(*) from Orders a JOIN Customer b ON a.custkey = b.custkey");
+        assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(15000);
+    }
 }

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -198,4 +198,11 @@ public class TestWrenWithDuckDB
                 .isEqualTo(List.of(column("totalprice", "DECIMAL(15,2)")));
         assertThat(queryResultDto.getData().size()).isEqualTo(100);
     }
+
+    @Test
+    public void testCountWithCalculatedFieldFilter()
+    {
+        QueryResultDto queryResultDto = query(manifest, "select count(*) from \"Orders\" where nation_name = 'ALGERIA'");
+        assertThat(queryResultDto.getData().getFirst()[0]).isEqualTo(691);
+    }
 }


### PR DESCRIPTION
# Description
- Fix `count(*)` query with the filter that invokes any calculated field.
- Fix `count(*)` for a query with the relation `table` or `join`.
- Fix selecting wildcard from a model should exclude the calculated fields.