### PR TITLE
chore(core): remove legacy command and config for example and script

### DIFF
--- a/docker/build-local.sh
+++ b/docker/build-local.sh
@@ -15,7 +15,6 @@ popd
 
 WORK_DIR="$(mktemp -d)"
 cp ${SOURCE_DIR}wren-server/target/wren-server-${WREN_VERSION}-executable.jar ${WORK_DIR}
-cp -r ${SOURCE_DIR}wren-sqlglot-server ${WORK_DIR}
 cp ./entrypoint.sh ${WORK_DIR}
 
 CONTAINER="wren-engine:${WREN_VERSION}"

--- a/example/duckdb-tpch-example/etc/config.properties
+++ b/example/duckdb-tpch-example/etc/config.properties
@@ -15,7 +15,6 @@
 #
 node.environment=production
 wren.directory=/usr/src/app/etc/mdl
-wren.experimental-enable-dynamic-fields=false
 wren.datasource.type=duckdb
 duckdb.connector.init-sql-path=/usr/src/app/etc/duckdb-init.sql
 duckdb.connector.session-sql-path=/usr/src/app/etc/duckdb-session.sql


### PR DESCRIPTION
# Description
- `wren-sqlglot-server` is a legacy module.
- `wren.experimental-enable-dynamic-fields` should be true by default now.