### PR TITLE
chore(ibis): remove workaround since ibis update

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -21,7 +21,7 @@ class QueryClickHouseDTO(QueryDTO):
 
 
 class QueryMSSqlDTO(QueryDTO):
-    connection_info: MSSqlConnectionInfo = connection_info_field
+    connection_info: ConnectionUrl | MSSqlConnectionInfo = connection_info_field
 
 
 class QueryMySqlDTO(QueryDTO):

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -124,9 +124,6 @@ def test_query(mssql: SqlServerContainer):
     }
 
 
-@pytest.mark.skip(
-    reason="ibis does not support mssql using connection url, wait fix PR in ibis repo"
-)
 def test_query_with_connection_url(mssql: SqlServerContainer):
     connection_url = to_connection_url(mssql)
     response = client.post(
@@ -352,4 +349,4 @@ def to_connection_info(mssql: SqlServerContainer):
 
 def to_connection_url(mssql: SqlServerContainer):
     info = to_connection_info(mssql)
-    return f"mssql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"
+    return f"mssql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}?driver=FreeTDS"


### PR DESCRIPTION
Due to certain issues in previous versions of Ibis, we implemented workarounds. Now that Ibis has fixed these issues, let's remove these workarounds.