### PR TITLE
fix(core): fix the field resolving for the relationship column

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
@@ -80,9 +80,7 @@ public class ExpressionAnalyzer
         {
             QualifiedName qualifiedName = getQualifiedName(node);
             if (qualifiedName != null) {
-                scope.getRelationType().getFields().stream()
-                        .filter(field -> field.canResolve(qualifiedName))
-                        .findAny()
+                scope.getRelationType().resolveAnyField(qualifiedName)
                         .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             }
             else {
@@ -97,9 +95,7 @@ public class ExpressionAnalyzer
         protected Void visitIdentifier(Identifier node, Void context)
         {
             QualifiedName qualifiedName = QualifiedName.of(ImmutableList.of(node));
-            scope.getRelationType().getFields().stream()
-                    .filter(field -> field.canResolve(qualifiedName))
-                    .findAny()
+            scope.getRelationType().resolveAnyField(qualifiedName)
                     .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             return null;
         }
@@ -108,9 +104,7 @@ public class ExpressionAnalyzer
         protected Void visitSubscriptExpression(SubscriptExpression node, Void context)
         {
             QualifiedName qualifiedName = getQualifiedName(node.getBase());
-            scope.getRelationType().getFields().stream()
-                    .filter(field -> field.canResolve(qualifiedName))
-                    .findAny()
+            scope.getRelationType().resolveAnyField(qualifiedName)
                     .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             return null;
         }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/Field.java
@@ -32,9 +32,13 @@ public class Field
     // e.g. select table.col_1 from select * from table; => is this legal ? this is false
     private final Optional<QualifiedName> relationAlias;
     private final CatalogSchemaTableName tableName;
+    // the name of the column in the table
     private final String columnName;
+    // the name of the dataset where the column comes from
     private final Optional<String> sourceDatasetName;
+    // the name of the column in the dataset where the column comes from
     private final Optional<Column> sourceColumn;
+    // the name of the column in the query (If the column is aliased, this is the alias, otherwise it's the column name)
     private final Optional<String> name;
 
     private Field(


### PR DESCRIPTION
# Description
The relationship column should be ignored when resolving the corresponding field. Otherwise, the resolved columns will always contain the relationship column.

Use `RelationType.resolveAnyField` to follow the same behavior.