### PR TITLE
fix(core): disable `optimize_projections` rule for SQL generation

### DIFF
--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -105,7 +105,7 @@ def test_query(postgres: PostgresContainer):
     assert len(result["data"]) == 1
     assert result["data"][0] == [
         "2024-01-01 23:59:59.000000",
-        "2024-01-01 23:59:59.000000 UTC",
+        "2024-01-01 23:59:59.000000",
         "1_370",
         370,
         "1996-01-02",

--- a/wren-modeling-py/src/lib.rs
+++ b/wren-modeling-py/src/lib.rs
@@ -71,8 +71,8 @@ mod tests {
                 .unwrap();
         assert_eq!(
             transformed_sql,
-            "SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM \
-            (SELECT main.customer.c_custkey, main.customer.c_name FROM main.customer) AS customer"
+            "SELECT customer.c_custkey, customer.c_name FROM \
+            (SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM main.customer) AS customer"
         );
     }
 }

--- a/wren-modeling-py/tests/test_modeling_core.py
+++ b/wren-modeling-py/tests/test_modeling_core.py
@@ -30,5 +30,5 @@ def test_transform_sql():
     rewritten_sql = wren_core.transform_sql(manifest_str, sql)
     assert (
         rewritten_sql
-        == 'SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM (SELECT main.customer.c_custkey, main.customer.c_name FROM main.customer) AS customer'
+        == 'SELECT customer.c_custkey, customer.c_name FROM (SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM main.customer) AS customer'
     )

--- a/wren-modeling-rs/core/src/mdl/context.rs
+++ b/wren-modeling-rs/core/src/mdl/context.rs
@@ -34,7 +34,6 @@ use datafusion::optimizer::eliminate_one_union::EliminateOneUnion;
 use datafusion::optimizer::eliminate_outer_join::EliminateOuterJoin;
 use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
 use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
-use datafusion::optimizer::OptimizerRule;
 use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
 use datafusion::optimizer::push_down_filter::PushDownFilter;
 use datafusion::optimizer::replace_distinct_aggregate::ReplaceDistinctWithAggregate;
@@ -43,6 +42,7 @@ use datafusion::optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion::optimizer::simplify_expressions::SimplifyExpressions;
 use datafusion::optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
 use datafusion::optimizer::unwrap_cast_in_comparison::UnwrapCastInComparison;
+use datafusion::optimizer::OptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
@@ -92,14 +92,11 @@ pub async fn create_ctx_with_mdl(
     let new_state = if is_local_runtime {
         //  The plan will be executed locally, so apply the default optimizer rules
         new_state
-    }
-    else {
+    } else {
         new_state.with_optimizer_rules(optimize_rule_for_unparsing())
     };
 
-    let new_state = new_state
-    .with_config(config)
-    .build();
+    let new_state = new_state.with_config(config).build();
     let ctx = SessionContext::new_with_state(new_state);
     register_table_with_mdl(&ctx, analyzed_mdl.wren_mdl()).await?;
     Ok(ctx)

--- a/wren-modeling-rs/core/src/mdl/context.rs
+++ b/wren-modeling-rs/core/src/mdl/context.rs
@@ -139,7 +139,7 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         Arc::new(UnwrapCastInComparison::new()),
         Arc::new(CommonSubexprEliminate::new()),
         Arc::new(EliminateGroupByConstant::new()),
-        // TODO
+        // TODO: This rule would generate a plan that is not supported by the current unparser
         // Arc::new(OptimizeProjections::new()),
     ]
 }

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -462,10 +462,9 @@ mod test {
         )
         .await?;
         assert_eq!(actual,
-                   "SELECT datafusion.public.customer.\"Custkey\" AS \"Custkey\", datafusion.public.customer.\"Name\" AS \"Name\" \
-                    FROM (SELECT datafusion.public.customer.\"Custkey\", \
-                    datafusion.public.customer.\"Name\" \
-                    FROM datafusion.public.customer) AS \"Customer\"");
+            "SELECT \"Customer\".\"Custkey\", \"Customer\".\"Name\" FROM \
+            (SELECT datafusion.public.customer.\"Custkey\" AS \"Custkey\", \
+            datafusion.public.customer.\"Name\" AS \"Name\" FROM datafusion.public.customer) AS \"Customer\"");
         Ok(())
     }
 

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -390,9 +390,8 @@ mod test {
                 "select orders.o_orderkey from test.test.orders left join test.test.customer on (orders.o_custkey = customer.c_custkey) where orders.o_totalprice > 10",
                 "select o_orderkey, sum(o_totalprice) from test.test.orders group by 1",
                 "select o_orderkey, count(*) from test.test.orders where orders.o_totalprice > 10 group by 1",
-                // TODO: calculated issue
-                // "select totalcost from test.test.profile",
-                // "select totalcost from profile",
+                "select totalcost from test.test.profile",
+                "select totalcost from profile",
         // TODO: support calculated without relationship
         //     "select orderkey_plus_custkey from orders",
         ];
@@ -412,8 +411,6 @@ mod test {
         Ok(())
     }
 
-    // TODO: wren view issue
-    #[ignore]
     #[tokio::test]
     async fn test_access_view() -> Result<()> {
         let test_data: PathBuf =

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -245,7 +245,7 @@ pub async fn transform_sql_with_ctx(
     sql: &str,
 ) -> Result<String> {
     info!("wren-core received SQL: {}", sql);
-    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl)).await?;
+    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl), false).await?;
     let plan = ctx.state().create_logical_plan(sql).await?;
     debug!("wren-core original plan:\n {plan}");
     let analyzed = ctx.state().optimize(&plan)?;

--- a/wren-modeling-rs/sqllogictest/src/test_context.rs
+++ b/wren-modeling-rs/sqllogictest/src/test_context.rs
@@ -301,7 +301,7 @@ async fn register_ecommerce_mdl(
         manifest,
         register_tables,
     )?);
-    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl)).await?;
+    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl), true).await?;
     Ok((ctx.to_owned(), analyzed_mdl))
 }
 
@@ -531,6 +531,6 @@ async fn register_tpch_mdl(
         manifest,
         register_tables,
     )?);
-    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl)).await?;
+    let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl), true).await?;
     Ok((ctx.to_owned(), analyzed_mdl))
 }


### PR DESCRIPTION
# Description
- After #819, we apply the optimization rule to simplify the generated SQL. However, DataFusion can't unparse the optimized plans well. Disable `optimize_projections` for a valid SQL result.