### PR TITLE
fix(mssql): update tds version

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -64,6 +64,10 @@ class MSSqlConnectionInfo(BaseModel):
         default="FreeTDS",
         description="On Mac and Linux this is usually `FreeTDS. On Windows, it is usually `ODBC Driver 18 for SQL Server`",
     )
+    tds_version: str = Field(default="8.0", alias="TDS_Version")
+    kwargs: dict[str, str] | None = Field(
+        description="Additional keyword arguments to pass to PyODBC", default=None
+    )
 
 
 class MySqlConnectionInfo(BaseModel):

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -103,6 +103,8 @@ class DataSourceExtension(Enum):
             user=info.user.get_secret_value(),
             password=info.password.get_secret_value(),
             driver=info.driver,
+            TDS_Version=info.tds_version,
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod


### PR DESCRIPTION
We found an error.
```
('42000', '[42000] [FreeTDS][SQL Server]Unicode data in a Unicode-only collation or ntext data cannot be sent to clients using DB-Library (such as ISQL) or ODBC version 3.7 or earlier. (4004) (SQLFetch)')
```
The default TDS or ODBC version in the base image `python:3.11-slim-buster`(Debian 10) may be too low.
The default TDS version is `4.2`. Update the version, and it will be fine.
You can execute `tsql -C` in the container will get this.
```
# tsql -C
Compile-time settings (established with the "configure" script)
                            Version: freetds v1.00.104
             freetds.conf directory: /etc/freetds
     MS db-lib source compatibility: no
        Sybase binary compatibility: yes
                      Thread safety: yes
                      iconv library: yes
                        TDS version: 4.2
                              iODBC: no
                           unixodbc: yes
              SSPI "trusted" logins: no
                           Kerberos: yes
                            OpenSSL: no
                             GnuTLS: yes
                               MARS: no
```

Reference:
https://www.freetds.org/userguide/choosingtdsprotocol.htm
https://learn.microsoft.com/en-us/sql/relational-databases/security/networking/tds-8