### PR TITLE
feat(core): implement file-based remote function register

### DIFF
--- a/ibis-server/app/config.py
+++ b/ibis-server/app/config.py
@@ -19,6 +19,7 @@ class Config:
     def __init__(self):
         load_dotenv(override=True)
         self.wren_engine_endpoint = os.getenv("WREN_ENGINE_ENDPOINT")
+        self.remote_function_list_path = os.getenv("REMOTE_FUNCTION_LIST_PATH")
         self.validate_wren_engine_endpoint(self.wren_engine_endpoint)
         self.diagnose = False
         self.init_logger()
@@ -56,6 +57,9 @@ class Config:
             self.logger_diagnose()
         else:
             self.init_logger()
+
+    def set_remote_function_list_path(self, path: str):
+        self.remote_function_list_path = path
 
 
 config = Config()

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
 
+from app.config import get_config
 from app.dependencies import verify_query_dto
 from app.mdl.rewriter import Rewriter
 from app.model import (
@@ -18,6 +19,7 @@ from app.model.validator import Validator
 from app.util import to_json
 
 router = APIRouter(prefix="/connector")
+config = get_config()
 
 
 @router.post("/{data_source}/query", dependencies=[Depends(verify_query_dto)])

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -3,7 +3,6 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import JSONResponse
 
-from app.config import get_config
 from app.dependencies import verify_query_dto
 from app.mdl.rewriter import Rewriter
 from app.model import (
@@ -19,7 +18,6 @@ from app.model.validator import Validator
 from app.util import to_json
 
 router = APIRouter(prefix="/connector")
-config = get_config()
 
 
 @router.post("/{data_source}/query", dependencies=[Depends(verify_query_dto)])

--- a/ibis-server/tests/resource/functions.csv
+++ b/ibis-server/tests/resource/functions.csv
@@ -1,0 +1,5 @@
+function_type,name,return_type,description
+scalar,add_two,int,"Adds two numbers together."
+aggregate,median,int,"Returns the median value of a numeric column."
+window,max_if,int,"If the condition is true, returns the maximum value in the window."
+scalar,unistr,varchar,"Postgres: Evaluate escaped Unicode characters in the argument".

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -387,6 +387,8 @@ with TestClient(app) as client:
             "unistr": "object",
         }
 
+        config.set_remote_function_list_path(None)
+
     def _to_connection_info(pg: PostgresContainer):
         return {
             "host": pg.get_container_host_ip(),

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -363,11 +363,11 @@ with TestClient(app) as client:
         assert response.status_code == 200
         assert response.text is not None
 
-    def test_query_with_remote_function(postgres: PostgresContainer):
+    def test_query_with_remote_function(manifest_str, postgres: PostgresContainer):
         config = get_config()
         config.set_remote_function_list_path(file_path("resource/functions.csv"))
 
-        connection_info = to_connection_info(postgres)
+        connection_info = _to_connection_info(postgres)
         response = client.post(
             url=f"{base_url}/query",
             json={

--- a/ibis-server/tests/routers/v3/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v3/connector/test_postgres.py
@@ -7,6 +7,7 @@ import sqlalchemy
 from fastapi.testclient import TestClient
 from testcontainers.postgres import PostgresContainer
 
+from app.config import get_config
 from app.main import app
 from app.model.validator import rules
 from tests.confest import file_path
@@ -361,6 +362,30 @@ with TestClient(app) as client:
         )
         assert response.status_code == 200
         assert response.text is not None
+
+    def test_query_with_remote_function(postgres: PostgresContainer):
+        config = get_config()
+        config.set_remote_function_list_path(file_path("resource/functions.csv"))
+
+        connection_info = to_connection_info(postgres)
+        response = client.post(
+            url=f"{base_url}/query",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": manifest_str,
+                "sql": "SELECT unistr(o_orderstatus) FROM wren.public.orders LIMIT 1",
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["columns"]) == 1
+        assert len(result["data"]) == 1
+        assert result["data"][0] == [
+            "O",
+        ]
+        assert result["dtypes"] == {
+            "unistr": "object",
+        }
 
     def _to_connection_info(pg: PostgresContainer):
         return {

--- a/ibis-server/tests/test_main.py
+++ b/ibis-server/tests/test_main.py
@@ -22,6 +22,7 @@ def test_config():
     assert response.status_code == 200
     assert response.json() == {
         "wren_engine_endpoint": "http://localhost:8080",
+        "remote_function_list_path": None,
         "diagnose": False,
     }
 

--- a/wren-modeling-py/Cargo.lock
+++ b/wren-modeling-py/Cargo.lock
@@ -77,6 +77,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +572,12 @@ dependencies = [
  "phf",
  "phf_codegen",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "comfy-table"
@@ -1042,6 +1097,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1415,12 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2426,6 +2510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +2716,9 @@ name = "wren-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "csv",
  "datafusion",
+ "env_logger",
  "log",
  "parking_lot",
  "petgraph",
@@ -2642,8 +2734,12 @@ name = "wren-modeling-py"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "csv",
+ "env_logger",
+ "log",
  "pyo3",
  "pyo3-build-config",
+ "serde",
  "serde_json",
  "thiserror",
  "wren-core",

--- a/wren-modeling-py/Cargo.toml
+++ b/wren-modeling-py/Cargo.toml
@@ -17,6 +17,10 @@ wren-core = { path = "../wren-modeling-rs/core" }
 base64 = "0.22.1"
 serde_json = "1.0.117"
 thiserror = "1.0"
+csv = "1.3.0"
+serde = { version = "1.0.210", features = ["derive"] }
+env_logger = "0.11.5"
+log = "0.4.22"
 
 [build-dependencies]
 pyo3-build-config = "0.21.2"

--- a/wren-modeling-py/src/lib.rs
+++ b/wren-modeling-py/src/lib.rs
@@ -3,35 +3,64 @@ use std::sync::Arc;
 use base64::prelude::*;
 use pyo3::prelude::*;
 
+use crate::errors::CoreError;
+use crate::remote_functions::RemoteFunction;
+use log::debug;
 use wren_core::mdl;
 use wren_core::mdl::manifest::Manifest;
 use wren_core::mdl::AnalyzedWrenMDL;
 
-use crate::errors::CoreError;
-
 mod errors;
+mod remote_functions;
 
 #[pyfunction]
-fn transform_sql(mdl_base64: &str, sql: &str) -> Result<String, CoreError> {
+fn transform_sql(
+    mdl_base64: &str,
+    remote_functions: Vec<RemoteFunction>,
+    sql: &str,
+) -> Result<String, CoreError> {
     let mdl_json_bytes = BASE64_STANDARD
         .decode(mdl_base64)
         .map_err(CoreError::from)?;
     let mdl_json = String::from_utf8(mdl_json_bytes).map_err(CoreError::from)?;
     let manifest = serde_json::from_str::<Manifest>(&mdl_json)?;
+    let remote_functions: Vec<mdl::function::RemoteFunction> = remote_functions
+        .into_iter()
+        .map(|f| f.into())
+        .collect::<Vec<_>>();
 
     let Ok(analyzed_mdl) = AnalyzedWrenMDL::analyze(manifest) else {
         return Err(CoreError::new("Failed to analyze manifest"));
     };
-    match mdl::transform_sql(Arc::new(analyzed_mdl), sql) {
+    match mdl::transform_sql(Arc::new(analyzed_mdl), &remote_functions, sql) {
         Ok(transformed_sql) => Ok(transformed_sql),
         Err(e) => Err(CoreError::new(&e.to_string())),
+    }
+}
+
+#[pyfunction]
+fn read_remote_function_list(path: Option<&str>) -> Vec<RemoteFunction> {
+    debug!(
+        "Reading remote function list from {}",
+        path.unwrap_or("path is not provided")
+    );
+    if let Some(path) = path {
+        csv::Reader::from_path(path)
+            .unwrap()
+            .into_deserialize::<RemoteFunction>()
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>()
+    } else {
+        vec![]
     }
 }
 
 #[pymodule]
 #[pyo3(name = "wren_core")]
 fn wren_core_wrapper(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    env_logger::init();
     m.add_function(wrap_pyfunction!(transform_sql, m)?)?;
+    m.add_function(wrap_pyfunction!(read_remote_function_list, m)?)?;
     Ok(())
 }
 
@@ -41,7 +70,7 @@ mod tests {
     use base64::Engine;
     use serde_json::Value;
 
-    use crate::transform_sql;
+    use crate::{read_remote_function_list, transform_sql};
 
     #[test]
     fn test_transform_sql() {
@@ -66,13 +95,26 @@ mod tests {
         }"#;
         let v: Value = serde_json::from_str(data).unwrap();
         let mdl_base64: String = BASE64_STANDARD.encode(v.to_string().as_bytes());
-        let transformed_sql =
-            transform_sql(&mdl_base64, "SELECT * FROM my_catalog.my_schema.customer")
-                .unwrap();
+        let transformed_sql = transform_sql(
+            &mdl_base64,
+            vec![],
+            "SELECT * FROM my_catalog.my_schema.customer",
+        )
+        .unwrap();
         assert_eq!(
             transformed_sql,
             "SELECT customer.c_custkey, customer.c_name FROM \
             (SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM main.customer) AS customer"
         );
+    }
+
+    #[test]
+    fn test_read_remote_function_list() {
+        let path = "tests/functions.csv";
+        let remote_functions = read_remote_function_list(Some(path));
+        assert_eq!(remote_functions.len(), 3);
+
+        let remote_function = read_remote_function_list(None);
+        assert_eq!(remote_function.len(), 0);
     }
 }

--- a/wren-modeling-py/src/remote_functions.rs
+++ b/wren-modeling-py/src/remote_functions.rs
@@ -1,0 +1,36 @@
+use pyo3::pyclass;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use wren_core::mdl::function::FunctionType;
+
+#[pyclass]
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RemoteFunction {
+    pub function_type: String,
+    pub name: String,
+    pub return_type: String,
+    pub description: Option<String>,
+}
+
+impl From<wren_core::mdl::function::RemoteFunction> for RemoteFunction {
+    fn from(remote_function: wren_core::mdl::function::RemoteFunction) -> Self {
+        Self {
+            function_type: remote_function.function_type.to_string(),
+            name: remote_function.name,
+            return_type: remote_function.return_type,
+            description: remote_function.description,
+        }
+    }
+}
+
+impl From<RemoteFunction> for wren_core::mdl::function::RemoteFunction {
+    fn from(remote_function: RemoteFunction) -> wren_core::mdl::function::RemoteFunction {
+        wren_core::mdl::function::RemoteFunction {
+            function_type: FunctionType::from_str(&remote_function.function_type)
+                .unwrap(),
+            name: remote_function.name,
+            return_type: remote_function.return_type,
+            description: remote_function.description,
+        }
+    }
+}

--- a/wren-modeling-py/tests/functions.csv
+++ b/wren-modeling-py/tests/functions.csv
@@ -1,0 +1,4 @@
+function_type,name,return_type,description
+scalar,add_two,int,"Adds two numbers together."
+aggregate,median,int,"Returns the median value of a numeric column."
+window,max_if,int,"If the condition is true, returns the maximum value in the window."

--- a/wren-modeling-py/tests/test_modeling_core.py
+++ b/wren-modeling-py/tests/test_modeling_core.py
@@ -27,8 +27,19 @@ manifest_str = base64.b64encode(json.dumps(manifest).encode("utf-8")).decode("ut
 
 def test_transform_sql():
     sql = "SELECT * FROM my_catalog.my_schema.customer"
-    rewritten_sql = wren_core.transform_sql(manifest_str, sql)
+    rewritten_sql = wren_core.transform_sql(manifest_str, [], sql)
     assert (
         rewritten_sql
         == 'SELECT customer.c_custkey, customer.c_name FROM (SELECT main.customer.c_custkey AS c_custkey, main.customer.c_name AS c_name FROM main.customer) AS customer'
     )
+
+def test_read_function_list():
+    path = "tests/functions.csv"
+    functions = wren_core.read_remote_function_list(path)
+    assert len(functions) == 3
+
+    rewritten_sql = wren_core.transform_sql(manifest_str, functions, "SELECT add_two(c_custkey) FROM my_catalog.my_schema.customer")
+    assert rewritten_sql == 'SELECT add_two(customer.c_custkey) FROM (SELECT customer.c_custkey FROM (SELECT main.customer.c_custkey AS c_custkey FROM main.customer) AS customer) AS customer'
+
+    functions = wren_core.read_remote_function_list(None)
+    assert len(functions) == 0

--- a/wren-modeling-rs/benchmarks/src/tpch/run.rs
+++ b/wren-modeling-rs/benchmarks/src/tpch/run.rs
@@ -57,7 +57,7 @@ impl RunOpt {
             let start = Instant::now();
             let sql = &get_query_sql(query_id)?;
             for query in sql {
-                transform_sql_with_ctx(&ctx, Arc::clone(&mdl), query).await?;
+                transform_sql_with_ctx(&ctx, Arc::clone(&mdl), &[], query).await?;
             }
 
             let elapsed = start.elapsed(); //.as_secs_f64() * 1000.0;

--- a/wren-modeling-rs/core/Cargo.toml
+++ b/wren-modeling-rs/core/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = { workspace = true }
+csv = "1.3.0"
 datafusion = { workspace = true, default-features = false, features = [
     "nested_expressions",
     "crypto_expressions",
@@ -22,6 +23,7 @@ datafusion = { workspace = true, default-features = false, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }
+env_logger = { workspace = true }
 log = { workspace = true }
 parking_lot = "0.12.3"
 petgraph = "0.6.5"

--- a/wren-modeling-rs/core/src/mdl/function.rs
+++ b/wren-modeling-rs/core/src/mdl/function.rs
@@ -6,7 +6,50 @@ use datafusion::logical_expr::{
     Accumulator, AggregateUDFImpl, ColumnarValue, PartitionEvaluator, ScalarUDFImpl,
     Signature, TypeSignature, Volatility, WindowUDFImpl,
 };
+use serde::{Deserialize, Serialize};
 use std::any::Any;
+use std::fmt::Display;
+use std::str::FromStr;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RemoteFunction {
+    pub function_type: FunctionType,
+    pub name: String,
+    pub return_type: String,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum FunctionType {
+    Scalar,
+    Aggregate,
+    Window,
+}
+
+impl Display for FunctionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            FunctionType::Scalar => "scalar".to_string(),
+            FunctionType::Aggregate => "aggregate".to_string(),
+            FunctionType::Window => "window".to_string(),
+        };
+        write!(f, "{}", str)
+    }
+}
+
+impl FromStr for FunctionType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "scalar" => Ok(FunctionType::Scalar),
+            "aggregate" => Ok(FunctionType::Aggregate),
+            "window" => Ok(FunctionType::Window),
+            _ => Err(format!("Unknown function type: {}", s)),
+        }
+    }
+}
 
 /// A scalar UDF that will be bypassed when planning logical plan.
 /// This is used to register the remote function to the context. The function should not be

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -379,7 +379,7 @@ mod test {
         let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl)?);
         let _ = mdl::transform_sql(
             Arc::clone(&analyzed_mdl),
-            &vec![],
+            &[],
             "select o_orderkey + o_orderkey from test.test.orders",
         )?;
         Ok(())
@@ -415,7 +415,7 @@ mod test {
             let actual = mdl::transform_sql_with_ctx(
                 &SessionContext::new(),
                 Arc::clone(&analyzed_mdl),
-                &vec![],
+                &[],
                 sql,
             )
             .await?;
@@ -443,7 +443,7 @@ mod test {
         let actual = mdl::transform_sql_with_ctx(
             &SessionContext::new(),
             Arc::clone(&analyzed_mdl),
-            &vec![],
+            &[],
             sql,
         )
         .await?;
@@ -471,7 +471,7 @@ mod test {
         let actual = mdl::transform_sql_with_ctx(
             &SessionContext::new(),
             Arc::clone(&analyzed_mdl),
-            &vec![],
+            &[],
             sql,
         )
         .await?;

--- a/wren-modeling-rs/core/src/mdl/mod.rs
+++ b/wren-modeling-rs/core/src/mdl/mod.rs
@@ -1,13 +1,18 @@
 use crate::logical_plan::analyze::expand_view::ExpandWrenViewRule;
 use crate::logical_plan::analyze::model_anlayze::ModelAnalyzeRule;
 use crate::logical_plan::analyze::model_generation::ModelGenerationRule;
-use crate::logical_plan::utils::from_qualified_name_str;
+use crate::logical_plan::utils::{from_qualified_name_str, map_data_type};
 use crate::mdl::context::{create_ctx_with_mdl, register_table_with_mdl, WrenDataSource};
+use crate::mdl::function::{
+    ByPassAggregateUDF, ByPassScalarUDF, ByPassWindowFunction, FunctionType,
+    RemoteFunction,
+};
 use crate::mdl::manifest::{Column, Manifest, Model, View};
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionState;
 use datafusion::logical_expr::sqlparser::keywords::ALL_KEYWORDS;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::prelude::SessionContext;
 use datafusion::sql::unparser::dialect::{Dialect, IntervalStyle};
 use datafusion::sql::unparser::Unparser;
@@ -227,24 +232,34 @@ impl WrenMDL {
 }
 
 /// Transform the SQL based on the MDL
-pub fn transform_sql(analyzed_mdl: Arc<AnalyzedWrenMDL>, sql: &str) -> Result<String> {
+pub fn transform_sql(
+    analyzed_mdl: Arc<AnalyzedWrenMDL>,
+    remote_functions: &[RemoteFunction],
+    sql: &str,
+) -> Result<String> {
     let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(transform_sql_with_ctx(
         &SessionContext::new(),
         analyzed_mdl,
+        remote_functions,
         sql,
     ))
 }
 
 /// Transform the SQL based on the MDL with the SessionContext
-/// Wren engine will normalize the SQL to the lower case to solve the case sensitive
+/// Wren engine will normalize the SQL to the lower case to solve the case-sensitive
 /// issue for the Wren view
 pub async fn transform_sql_with_ctx(
     ctx: &SessionContext,
     analyzed_mdl: Arc<AnalyzedWrenMDL>,
+    remote_functions: &[RemoteFunction],
     sql: &str,
 ) -> Result<String> {
     info!("wren-core received SQL: {}", sql);
+    remote_functions.iter().for_each(|remote_function| {
+        debug!("Registering remote function: {:?}", remote_function);
+        register_remote_function(ctx, remote_function);
+    });
     let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl), false).await?;
     let plan = ctx.state().create_logical_plan(sql).await?;
     debug!("wren-core original plan:\n {plan}");
@@ -263,6 +278,29 @@ pub async fn transform_sql_with_ctx(
             Ok(replaced)
         }
         Err(e) => Err(e),
+    }
+}
+
+fn register_remote_function(ctx: &SessionContext, remote_function: &RemoteFunction) {
+    match &remote_function.function_type {
+        FunctionType::Scalar => {
+            ctx.register_udf(ScalarUDF::new_from_impl(ByPassScalarUDF::new(
+                &remote_function.name,
+                map_data_type(&remote_function.return_type),
+            )))
+        }
+        FunctionType::Aggregate => {
+            ctx.register_udaf(AggregateUDF::new_from_impl(ByPassAggregateUDF::new(
+                &remote_function.name,
+                map_data_type(&remote_function.return_type),
+            )))
+        }
+        FunctionType::Window => {
+            ctx.register_udwf(WindowUDF::new_from_impl(ByPassWindowFunction::new(
+                &remote_function.name,
+                map_data_type(&remote_function.return_type),
+            )))
+        }
     }
 }
 
@@ -294,29 +332,6 @@ fn non_lowercase(sql: &str) -> bool {
     lowercase != sql
 }
 
-/// Apply Wren Rules to a given session context with a WrenMDL
-///
-/// TODO: There're some issue about apply the rule with the native optimize rules of datafusion
-/// Recommend to use [transform_sql_with_ctx] generated the SQL text instead.
-pub async fn apply_wren_rules(
-    ctx: &SessionContext,
-    analyzed_wren_mdl: Arc<AnalyzedWrenMDL>,
-) -> Result<()> {
-    // expand the view should be the first rule
-    ctx.add_analyzer_rule(Arc::new(ExpandWrenViewRule::new(
-        Arc::clone(&analyzed_wren_mdl),
-        ctx.state_ref(),
-    )));
-    ctx.add_analyzer_rule(Arc::new(ModelAnalyzeRule::new(
-        Arc::clone(&analyzed_wren_mdl),
-        ctx.state_ref(),
-    )));
-    ctx.add_analyzer_rule(Arc::new(ModelGenerationRule::new(Arc::clone(
-        &analyzed_wren_mdl,
-    ))));
-    register_table_with_mdl(ctx, analyzed_wren_mdl.wren_mdl()).await
-}
-
 /// Analyze the decision point. It's same as the /v1/analysis/sql API in wren engine
 pub fn decision_point_analyze(_wren_mdl: Arc<WrenMDL>, _sql: &str) {}
 
@@ -344,8 +359,9 @@ mod test {
     use std::sync::Arc;
 
     use crate::mdl::builder::{ColumnBuilder, ManifestBuilder, ModelBuilder};
+    use crate::mdl::function::RemoteFunction;
     use crate::mdl::manifest::Manifest;
-    use crate::mdl::{self, AnalyzedWrenMDL};
+    use crate::mdl::{self, transform_sql_with_ctx, AnalyzedWrenMDL};
     use datafusion::arrow::array::{ArrayRef, Int64Array, RecordBatch, StringArray};
     use datafusion::common::not_impl_err;
     use datafusion::common::Result;
@@ -366,6 +382,7 @@ mod test {
         let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(mdl)?);
         let _ = mdl::transform_sql(
             Arc::clone(&analyzed_mdl),
+            &vec![],
             "select o_orderkey + o_orderkey from test.test.orders",
         )?;
         Ok(())
@@ -401,6 +418,7 @@ mod test {
             let actual = mdl::transform_sql_with_ctx(
                 &SessionContext::new(),
                 Arc::clone(&analyzed_mdl),
+                &vec![],
                 sql,
             )
             .await?;
@@ -428,6 +446,7 @@ mod test {
         let actual = mdl::transform_sql_with_ctx(
             &SessionContext::new(),
             Arc::clone(&analyzed_mdl),
+            &vec![],
             sql,
         )
         .await?;
@@ -455,6 +474,7 @@ mod test {
         let actual = mdl::transform_sql_with_ctx(
             &SessionContext::new(),
             Arc::clone(&analyzed_mdl),
+            &vec![],
             sql,
         )
         .await?;
@@ -462,6 +482,68 @@ mod test {
             "SELECT \"Customer\".\"Custkey\", \"Customer\".\"Name\" FROM \
             (SELECT datafusion.public.customer.\"Custkey\" AS \"Custkey\", \
             datafusion.public.customer.\"Name\" AS \"Name\" FROM datafusion.public.customer) AS \"Customer\"");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_remote_function() -> Result<()> {
+        env_logger::init();
+        let test_data: PathBuf =
+            [env!("CARGO_MANIFEST_DIR"), "tests", "data", "functions.csv"]
+                .iter()
+                .collect();
+        let ctx = SessionContext::new();
+        let functions = csv::Reader::from_path(test_data)
+            .unwrap()
+            .into_deserialize::<RemoteFunction>()
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+        dbg!(&functions);
+        let manifest = ManifestBuilder::new()
+            .catalog("CTest")
+            .schema("STest")
+            .model(
+                ModelBuilder::new("Customer")
+                    .table_reference("datafusion.public.customer")
+                    .column(ColumnBuilder::new("Custkey", "int").build())
+                    .column(ColumnBuilder::new("Name", "string").build())
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
+        let actual = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &functions,
+            r#"select add_two("Custkey") from "Customer""#,
+        )
+        .await?;
+        assert_eq!(actual, "SELECT add_two(\"Customer\".\"Custkey\") FROM \
+        (SELECT datafusion.public.customer.\"Custkey\" AS \"Custkey\" FROM \
+        (SELECT datafusion.public.customer.\"Custkey\" FROM datafusion.public.customer)) AS \"Customer\"");
+
+        let actual = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &functions,
+            r#"select median("Custkey") from "CTest"."STest"."Customer" group by "Name""#,
+        )
+        .await?;
+        assert_eq!(actual, "SELECT median(\"Customer\".\"Custkey\") FROM \
+        (SELECT datafusion.public.customer.\"Custkey\" AS \"Custkey\", \
+        datafusion.public.customer.\"Name\" AS \"Name\" FROM \
+        (SELECT datafusion.public.customer.\"Custkey\", datafusion.public.customer.\"Name\" \
+        FROM datafusion.public.customer)) AS \"Customer\" GROUP BY \"Customer\".\"Name\"");
+
+        // TODO: support window functions analysis
+        // let actual = transform_sql_with_ctx(
+        //     &ctx,
+        //     Arc::clone(&analyzed_mdl),
+        //     &functions,
+        //     r#"select max_if("Custkey") OVER (PARTITION BY "Name") from "Customer""#,
+        // ).await?;
+        // assert_eq!(actual, "");
+
         Ok(())
     }
 

--- a/wren-modeling-rs/core/tests/data/functions.csv
+++ b/wren-modeling-rs/core/tests/data/functions.csv
@@ -1,0 +1,4 @@
+function_type,name,return_type,description
+scalar,add_two,int,"Adds two numbers together."
+aggregate,median,int,"Returns the median value of a numeric column.".
+window,max_if,int,"If the condition is true, returns the maximum value in the window."

--- a/wren-modeling-rs/wren-example/Cargo.toml
+++ b/wren-modeling-rs/wren-example/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dev-dependencies]
 async-trait = { workspace = true }
-datafusion = { workspace = true, default-features = true }
+datafusion = { workspace = true }
 env_logger = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
-        vec![],
+        &[],
         "select totalprice from wrenai.public.customers",
     )
     .await

--- a/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
@@ -105,7 +105,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
-        &vec![],
+        &[],
         "select customer_state_cf from wrenai.public.order_items",
     )
     .await

--- a/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/calculation-invoke-calculation.rs
@@ -80,6 +80,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
+        vec![],
         "select totalprice from wrenai.public.customers",
     )
     .await
@@ -104,6 +105,7 @@ async fn main() -> Result<()> {
     let transformed = match transform_sql_with_ctx(
         &ctx,
         Arc::clone(&analyzed_mdl),
+        &vec![],
         "select customer_state_cf from wrenai.public.order_items",
     )
     .await

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
     // TODO: there're some issue for optimize rules
     // let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl).await?;
     let sql = "select * from wrenai.public.order_items";
-    let sql = transform_sql_with_ctx(&ctx, analyzed_mdl, sql).await?;
+    let sql = transform_sql_with_ctx(&ctx, analyzed_mdl, &vec![], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     // create a plan to run a SQL query
     let df = match ctx.sql(&sql).await {

--- a/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
+++ b/wren-modeling-rs/wren-example/examples/datafusion-apply.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<()> {
     // TODO: there're some issue for optimize rules
     // let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl).await?;
     let sql = "select * from wrenai.public.order_items";
-    let sql = transform_sql_with_ctx(&ctx, analyzed_mdl, &vec![], sql).await?;
+    let sql = transform_sql_with_ctx(&ctx, analyzed_mdl, &[], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     // create a plan to run a SQL query
     let df = match ctx.sql(&sql).await {

--- a/wren-modeling-rs/wren-example/examples/plan-sql.rs
+++ b/wren-modeling-rs/wren-example/examples/plan-sql.rs
@@ -13,7 +13,8 @@ async fn main() -> datafusion::common::Result<()> {
 
     let sql = "select customer_state from wrenai.public.orders_model";
     println!("Original SQL: \n{}", sql);
-    let sql = transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, sql).await?;
+    let sql =
+        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, vec![], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     Ok(())
 }

--- a/wren-modeling-rs/wren-example/examples/plan-sql.rs
+++ b/wren-modeling-rs/wren-example/examples/plan-sql.rs
@@ -14,7 +14,7 @@ async fn main() -> datafusion::common::Result<()> {
     let sql = "select customer_state from wrenai.public.orders_model";
     println!("Original SQL: \n{}", sql);
     let sql =
-        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, vec![], sql).await?;
+        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, &[], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     Ok(())
 }

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -7,8 +7,9 @@ use datafusion::prelude::{CsvReadOptions, SessionContext};
 use wren_core::mdl::builder::{
     ColumnBuilder, ManifestBuilder, ModelBuilder, RelationshipBuilder,
 };
+use wren_core::mdl::context::create_ctx_with_mdl;
 use wren_core::mdl::manifest::{JoinType, Manifest};
-use wren_core::mdl::{apply_wren_rules, AnalyzedWrenMDL};
+use wren_core::mdl::AnalyzedWrenMDL;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -75,7 +76,7 @@ async fn main() -> Result<()> {
     ]);
     let analyzed_mdl =
         Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
-    apply_wren_rules(&ctx, analyzed_mdl).await?;
+    let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl).await?;
     let df = match ctx
         .sql("select totalprice from wrenai.public.customers")
         .await

--- a/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
+++ b/wren-modeling-rs/wren-example/examples/to-many-calculation.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
     ]);
     let analyzed_mdl =
         Arc::new(AnalyzedWrenMDL::analyze_with_tables(manifest, register)?);
-    let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl).await?;
+    let ctx = create_ctx_with_mdl(&ctx, analyzed_mdl, true).await?;
     let df = match ctx
         .sql("select totalprice from wrenai.public.customers")
         .await

--- a/wren-modeling-rs/wren-example/examples/view.rs
+++ b/wren-modeling-rs/wren-example/examples/view.rs
@@ -15,7 +15,8 @@ async fn main() -> datafusion::common::Result<()> {
 
     let sql = "select * from wrenai.public.customers_view";
     println!("Original SQL: \n{}", sql);
-    let sql = transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, sql).await?;
+    let sql =
+        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, vec![], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     Ok(())
 }

--- a/wren-modeling-rs/wren-example/examples/view.rs
+++ b/wren-modeling-rs/wren-example/examples/view.rs
@@ -16,7 +16,7 @@ async fn main() -> datafusion::common::Result<()> {
     let sql = "select * from wrenai.public.customers_view";
     println!("Original SQL: \n{}", sql);
     let sql =
-        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, vec![], sql).await?;
+        transform_sql_with_ctx(&SessionContext::new(), analyzed_mdl, &[], sql).await?;
     println!("Wren engine generated SQL: \n{}", sql);
     Ok(())
 }


### PR DESCRIPTION
# Description
When planning a SQL, DataFusion planner will strictly check the function usage. The used function should be registered in the SessionContext. In the Wren AI scenario, we always fully push down the SQL to the data source side. We can invoke the `ByPassFunction` (introduced by #802) which only requires the function name and return type to register a logical function for unparsing purposes.

This PR introduces a file-based register to define the required remote function easily.

# Definition File
The definition file is a CSV file that contains 4 columns and with the header:
- `function_type`: The possible value contains `scalar`, `aggregate`, and `window`. All of them are lowercase. 
- `name`: The function name.
- `return_type`: The expected return type.
- `description`: A simple description of this function. Because the description could contain a comma, we should quote the value.

## Sample
```csv
function_type,name,return_type,description
scalar,add_two,int,"Adds two numbers together."
aggregate,median,int,"Returns the median value of a numeric column.".
window,max_if,int,"If the condition is true, returns the maximum value in the window."
```

# Set up the config
On the ibis server side, we add a new environment variable called `REMOTE_FUNCTION_LIST_PATH` which is the path of the definition file. We should set up it before starting the server.

# Known Issue
- The window function is not yet supported