### PR TITLE
ci(labeler): fix rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 ibis:
 - changed-files:
-  - any-glob-to-all-files: ['ibis-server/**']
+  - any-glob-to-any-files: ['ibis-server/**']
 
 dependencies:
 - changed-files:
@@ -8,15 +8,15 @@ dependencies:
 
 python:
 - changed-files:
-  - any-glob-to-all-files: ['ibis-server/**', 'wren-modeling-py/**']
+  - any-glob-to-any-files: ['ibis-server/**', 'wren-modeling-py/**']
 
 rust:
 - changed-files:
-  - any-glob-to-all-files: ['wren-modeling-rs/**']
+  - any-glob-to-any-files: ['wren-modeling-rs/**']
 
 core:
 - changed-files:
-  - any-glob-to-all-files: ['wren-modeling-rs/**']
+  - any-glob-to-any-files: ['wren-modeling-rs/**']
 
 documentation:
 - changed-files:


### PR DESCRIPTION
- `any-glob-to-any-file`: ANY glob must match against ANY changed file
- `any-glob-to-all-files`: ANY glob must match against ALL changed files
- `all-globs-to-any-file`: ALL globs must match against ANY changed file
- `all-globs-to-all-files`: ALL globs must match against ALL changed files

Reference:
https://github.com/actions/labeler?tab=readme-ov-file#match-object