### PR TITLE
feat(metadata): provide db version

### DIFF
--- a/ibis-server/app/model/metadata/bigquery.py
+++ b/ibis-server/app/model/metadata/bigquery.py
@@ -136,3 +136,6 @@ class BigQueryMetadata(Metadata):
                 )
             )
         return constraints
+
+    def get_version(self) -> str:
+        return "Follow BigQuery release version"

--- a/ibis-server/app/model/metadata/canner.py
+++ b/ibis-server/app/model/metadata/canner.py
@@ -33,6 +33,16 @@ class CannerMetadata(Metadata):
     def get_constraints(self) -> list[Constraint]:
         return []
 
+    def get_version(self) -> str:
+        query = gql("""
+            query SystemInfo {
+                systemInfo {
+                  version
+                }
+            }
+        """)
+        return self.client.execute(query)["systemInfo"]["version"]
+
     def _get_workspace_sql_name(self) -> str:
         if hasattr(self.connection_info, "connection_url"):
             return urlparse(

--- a/ibis-server/app/model/metadata/clickhouse.py
+++ b/ibis-server/app/model/metadata/clickhouse.py
@@ -70,6 +70,9 @@ class ClickHouseMetadata(Metadata):
     def get_constraints(self) -> list[Constraint]:
         return []
 
+    def get_version(self) -> str:
+        return self.connection.sql("SELECT version()").to_pandas().iloc[0, 0]
+
     def _format_compact_table_name(self, schema: str, table: str):
         return f"{schema}.{table}"
 

--- a/ibis-server/app/model/metadata/metadata.py
+++ b/ibis-server/app/model/metadata/metadata.py
@@ -15,3 +15,7 @@ class Metadata(ABC):
     @abstractmethod
     def get_constraints(self) -> list[Constraint]:
         pass
+
+    @abstractmethod
+    def get_version(self) -> str:
+        pass

--- a/ibis-server/app/model/metadata/mssql.py
+++ b/ibis-server/app/model/metadata/mssql.py
@@ -161,6 +161,9 @@ class MSSQLMetadata(Metadata):
             )
         return constraints
 
+    def get_version(self) -> str:
+        return self.connection.sql("SELECT @@VERSION").to_pandas().iloc[0, 0]
+
     def _format_compact_table_name(self, schema: str, table: str):
         return f"{schema}.{table}"
 

--- a/ibis-server/app/model/metadata/mysql.py
+++ b/ibis-server/app/model/metadata/mysql.py
@@ -117,6 +117,9 @@ class MySQLMetadata(Metadata):
             )
         return constraints
 
+    def get_version(self) -> str:
+        return self.connection.sql("SELECT version()").to_pandas().iloc[0, 0]
+
     def _format_compact_table_name(self, schema: str, table: str):
         return f"{schema}.{table}"
 

--- a/ibis-server/app/model/metadata/postgres.py
+++ b/ibis-server/app/model/metadata/postgres.py
@@ -123,6 +123,9 @@ class PostgresMetadata(Metadata):
             )
         return constraints
 
+    def get_version(self) -> str:
+        return self.connection.sql("SELECT version()").to_pandas().iloc[0, 0]
+
     def _format_postgres_compact_table_name(self, schema: str, table: str):
         return f"{schema}.{table}"
 

--- a/ibis-server/app/model/metadata/trino.py
+++ b/ibis-server/app/model/metadata/trino.py
@@ -79,6 +79,9 @@ class TrinoMetadata(Metadata):
     def get_constraints(self) -> list[Constraint]:
         return []
 
+    def get_version(self) -> str:
+        return self.connection.sql("SELECT version()").to_pandas().iloc[0, 0]
+
     def _format_trino_compact_table_name(
         self, catalog: str, schema: str, table: str
     ) -> str:

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -59,6 +59,11 @@ def get_constraints(data_source: DataSource, dto: MetadataDTO) -> list[Constrain
     ).get_constraints()
 
 
+@router.post("/{data_source}/metadata/version")
+def get_db_version(data_source: DataSource, dto: MetadataDTO) -> str:
+    return MetadataFactory.get_metadata(data_source, dto.connection_info).get_version()
+
+
 @router.post("/dry-plan")
 def dry_plan(dto: DryPlanDTO) -> str:
     return Rewriter(dto.manifest_str).rewrite(dto.sql)

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -319,3 +319,11 @@ with TestClient(app) as client:
             json={"connectionInfo": connection_info},
         )
         assert response.status_code == 200
+
+    def test_metadata_db_version():
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert response.text == '"Follow BigQuery release version"'

--- a/ibis-server/tests/routers/v2/connector/test_canner.py
+++ b/ibis-server/tests/routers/v2/connector/test_canner.py
@@ -346,6 +346,14 @@ with TestClient(app) as client:
         assert response.status_code == 200
         assert response.json() == []
 
+    def test_metadata_db_version():
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert response.text is not None
+
     def _to_connection_url():
         info = connection_info
         return f"postgres://{info['user']}:{info['pat']}@{info['host']}:{info['port']}/{info['workspace']}"

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -529,6 +529,15 @@ with TestClient(app) as client:
         result = response.json()
         assert len(result) == 0
 
+    def test_metadata_db_version(clickhouse: ClickHouseContainer):
+        connection_info = _to_connection_info(clickhouse)
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert response.text is not None
+
     def _to_connection_info(db: ClickHouseContainer):
         return {
             "host": db.get_container_host_ip(),

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -366,6 +366,15 @@ with TestClient(app) as client:
         )
         assert response.status_code == 200
 
+    def test_metadata_db_version(mssql: SqlServerContainer):
+        connection_info = _to_connection_info(mssql)
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert "Microsoft SQL Server 2019" in response.text
+
     def _to_connection_info(mssql: SqlServerContainer):
         return {
             "host": mssql.get_container_host_ip(),

--- a/ibis-server/tests/routers/v2/connector/test_mysql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mysql.py
@@ -85,7 +85,7 @@ def manifest_str():
 
 @pytest.fixture(scope="module")
 def mysql(request) -> MySqlContainer:
-    mysql = MySqlContainer("mysql:8.0").start()
+    mysql = MySqlContainer("mysql:8.0.40").start()
     connection_url = mysql.get_connection_url()
     engine = sqlalchemy.create_engine(connection_url)
     pd.read_parquet(file_path("resource/tpch/data/orders.parquet")).to_sql(
@@ -380,6 +380,15 @@ with TestClient(app) as client:
         assert result["constraintColumn"] is not None
         assert result["constraintedTable"] is not None
         assert result["constraintedColumn"] is not None
+
+    def test_metadata_db_version(mysql: MySqlContainer):
+        connection_info = _to_connection_info(mysql)
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert response.text == '"8.0.40"'
 
     def _to_connection_info(mysql: MySqlContainer):
         return {

--- a/ibis-server/tests/routers/v2/connector/test_snowflake.py
+++ b/ibis-server/tests/routers/v2/connector/test_snowflake.py
@@ -268,3 +268,7 @@ with TestClient(app) as client:
     @pytest.mark.skip(reason="Not implemented")
     def test_metadata_list_constraints():
         pass
+
+    @pytest.mark.skip(reason="Not implemented")
+    def test_metadata_get_version():
+        pass

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -402,6 +402,15 @@ with TestClient(app) as client:
         result = response.json()
         assert len(result) == 0
 
+    def test_metadata_db_version(trino: TrinoContainer):
+        connection_info = _to_connection_info(trino)
+        response = client.post(
+            url=f"{base_url}/metadata/version",
+            json={"connectionInfo": connection_info},
+        )
+        assert response.status_code == 200
+        assert response.text is not None
+
     def _to_connection_info(trino: TrinoContainer):
         return {
             "host": trino.get_container_host_ip(),


### PR DESCRIPTION
Add new API `/v2/connector/{data_source}/metadata/version` to provide the DB version.
The request body follows other metadata APIs.