### PR TITLE
ci(docker): use gha cache

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -57,6 +57,8 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-ibis-image:
     runs-on: ubuntu-latest
     steps:
@@ -89,3 +91,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,6 +69,8 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   build-ibis-image:
     needs: prepare-tag
     runs-on: ubuntu-latest
@@ -101,3 +103,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -113,6 +113,8 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   stable-release-ibis:
     needs: prepare-version
     runs-on: ubuntu-latest
@@ -148,3 +150,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Use the gha cache to reduce building time. I wish it worked.

Reference:
https://docs.docker.com/build/cache/backends/gha/