### PR TITLE
feat(core): introduce the hidden column

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -52,7 +52,6 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            wren-core-py/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('wren-core-py/Cargo.lock') }}
       - name: Install FreeTDS to be a ODBC driver
         run: |

--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -52,6 +52,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            wren-core-py/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('wren-core-py/Cargo.lock') }}
       - name: Install FreeTDS to be a ODBC driver
         run: |

--- a/wren-core/core/src/mdl/builder.rs
+++ b/wren-core/core/src/mdl/builder.rs
@@ -177,13 +177,6 @@ impl ColumnBuilder {
         self
     }
 
-    pub fn property(mut self, key: &str, value: &str) -> Self {
-        self.column
-            .properties
-            .insert(key.to_string(), value.to_string());
-        self
-    }
-
     pub fn build(self) -> Arc<Column> {
         Arc::new(self.column)
     }

--- a/wren-core/core/src/mdl/builder.rs
+++ b/wren-core/core/src/mdl/builder.rs
@@ -146,6 +146,7 @@ impl ColumnBuilder {
                 r#type: r#type.to_string(),
                 relationship: None,
                 is_calculated: false,
+                is_hidden: false,
                 not_null: false,
                 expression: None,
                 properties: BTreeMap::default(),
@@ -178,6 +179,11 @@ impl ColumnBuilder {
 
     pub fn expression(mut self, expression: &str) -> Self {
         self.column.expression = Some(expression.to_string());
+        self
+    }
+
+    pub fn hidden(mut self, is_hidden: bool) -> Self {
+        self.column.is_hidden = is_hidden;
         self
     }
 
@@ -373,6 +379,7 @@ mod test {
             .relationship("test")
             .calculated(true)
             .not_null(true)
+            .hidden(true)
             .expression("test")
             .property("key", "value")
             .build();

--- a/wren-core/core/src/mdl/lineage.rs
+++ b/wren-core/core/src/mdl/lineage.rs
@@ -40,7 +40,7 @@ impl Lineage {
         let mut source_columns_map = HashMap::new();
 
         for model in mdl.manifest.models.iter() {
-            for column in model.columns.iter() {
+            for column in model.get_visible_columns() {
                 if column.is_calculated {
                     let expr: &String = match column.expression {
                         Some(ref exp) => exp,
@@ -79,13 +79,13 @@ impl Lineage {
     }
     fn collect_required_fields(
         mdl: &WrenMDL,
-        source_colums_map: &HashMap<Column, HashSet<Column>>,
+        source_columns_map: &HashMap<Column, HashSet<Column>>,
     ) -> Result<RequiredInfo> {
         let mut required_fields_map: HashMap<Column, HashSet<Column>> = HashMap::new();
         let mut required_dataset_topo: HashMap<Column, Graph<Dataset, DatasetLink>> =
             HashMap::new();
         let mut pending_fields = Vec::new();
-        for (column, source_columns) in source_colums_map.iter() {
+        for (column, source_columns) in source_columns_map.iter() {
             let Some(relation) = column.clone().relation else {
                 return internal_err!("relation not found: {}", column);
             };

--- a/wren-core/core/src/mdl/manifest.rs
+++ b/wren-core/core/src/mdl/manifest.rs
@@ -170,6 +170,8 @@ pub struct Column {
     #[serde_as(as = "NoneAsEmptyString")]
     #[serde(default)]
     pub expression: Option<String>,
+    #[serde(default, with = "bool_from_int")]
+    pub is_hidden: bool,
     #[serde(default)]
     pub properties: BTreeMap<String, String>,
 }


### PR DESCRIPTION
# Description
This PR introduces a new column property, `is_hidden`. A hidden column means this column is defined in the MDL but it can't be used in the query.
The main purpose of a hidden column is to infer the remote source column. Sometimes, we want to apply something on a remote column like, casting, lowercase, or trim. we may write the MDL like
```json
{
    "name": "date_in_int_col",
    "type": "date",
    "expression": "cast(date_in_int_col as date)"
}
```
However, according to the rule of https://github.com/Canner/wren-engine/pull/844, we can get a remote column from a casting expression. So `date_in_int_col` won't be registered as a source column, the column expression isn't valid.

In this case, we should add another column for the column inferring but we don't want to expose this column. So we can invoke the `is_hidden` property
```json
{
    "name": "date_in_int_col",
    "type": "int",
    "is_hidden": true
},
{
    "name": "date_in_int_col_date",
    "type": "date",
    "expression": "cast(date_in_int_col as date)"
}
```

Now, we can infer the remote column is an int column called `date_in_int_col`. We can use it in the expression of another column.