### PR TITLE
revert(docker): not use gha cache

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -57,8 +57,6 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
   build-ibis-image:
     runs-on: ubuntu-latest
     steps:
@@ -91,5 +89,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,8 +69,6 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
   build-ibis-image:
     needs: prepare-tag
     runs-on: ubuntu-latest
@@ -103,5 +101,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -113,8 +113,6 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
   stable-release-ibis:
     needs: prepare-version
     runs-on: ubuntu-latest
@@ -150,5 +148,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
This reverts commit 282c953b103eccad32055612ba526964f62aada5.

We found the docker cache will cause `System.IO.IOException: No space left on device`.
https://github.com/Canner/wren-engine/actions/runs/11574176406

Unexpectedly, we've filled up our entire GitHub cache, reaching the 10GB limit.