### PR TITLE
chore(metadata): avoid using schema as a field name

### DIFF
--- a/ibis-server/app/model/metadata/dto.py
+++ b/ibis-server/app/model/metadata/dto.py
@@ -75,7 +75,8 @@ class Column(BaseModel):
 
 
 class TableProperties(BaseModel):
-    schema: str | None
+    # To prevent schema shadowing in Pydantic, avoid using schema as a field name
+    schema_: str | None = Field(alias="schema", default=None)
     catalog: str | None
     table: str | None  # only table name without schema or catalog
 


### PR DESCRIPTION
Pydantic performs a check on all subclasses of BaseModel to identify any overlapping field names with the base BaseModel class. It then generates a warning to discourage the use of identical field names to mitigate shadowing issues.
```
.venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:172
 .../wren-engine/ibis-server/.venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:172: UserWarning: Field name "schema" in "TableProperties" shadows an attribute in parent "BaseModel"
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```