### PR TITLE
ci(ibis): append Trino test to standard tests

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run tests
         env:
           WREN_ENGINE_ENDPOINT: http://localhost:8080
-        run: poetry run pytest -m "not bigquery and not snowflake and not trino and not canner"
+        run: poetry run pytest -m "not bigquery and not snowflake and not canner"
       - name: Test bigquery if need
         if: contains(github.event.pull_request.labels.*.name, 'bigquery')
         env:
@@ -84,8 +84,3 @@ jobs:
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
         run: just test snowflake
-      - name: Test trino if need
-        if: contains(github.event.pull_request.labels.*.name, 'trino')
-        env:
-          WREN_ENGINE_ENDPOINT: http://localhost:8080
-        run: just test trino


### PR DESCRIPTION
By introducing a delay after the Trino container startup, we resolved the issue https://github.com/Canner/wren-engine/issues/671.
So we can reintegrate Trino tests into the standard tests.