### PR TITLE
ci(ibis): update core to avoid caching

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -65,6 +65,7 @@ jobs:
         run: |
           just install
           just install-core
+          just update-core
       - name: Run tests
         env:
           WREN_ENGINE_ENDPOINT: http://localhost:8080


### PR DESCRIPTION
Sometimes, we update the Rust code, but other existing PRs do not update the Rust core. This may be because of the cache.