### PR TITLE
fix(core): disable `CountWildcardRule` for BigQuery source

### DIFF
--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -17,7 +17,6 @@ use datafusion::common::Result;
 use datafusion::datasource::{TableProvider, TableType, ViewTable};
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::Expr;
-use datafusion::optimizer::analyzer::count_wildcard_rule::CountWildcardRule;
 use datafusion::optimizer::analyzer::expand_wildcard_rule::ExpandWildcardRule;
 use datafusion::optimizer::analyzer::inline_table_scan::InlineTableScan;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
@@ -88,7 +87,9 @@ pub async fn create_ctx_with_mdl(
         Arc::new(ExpandWildcardRule::new()),
         // [Expr::Wildcard] should be expanded before [TypeCoercion]
         Arc::new(TypeCoercion::new()),
-        Arc::new(CountWildcardRule::new()),
+        // Disable it to avoid generate the alias name, `count(*)` because BigQuery doesn't allow
+        // the special character `*` in the alias name
+        // Arc::new(CountWildcardRule::new()),
     ]);
 
     let new_state = if is_local_runtime {

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -77,11 +77,12 @@ pub async fn create_ctx_with_mdl(
         ))
         //  The plan will be executed locally, so apply the default optimizer rules
     } else {
-         new_state.with_analyzer_rules(analyze_rule_for_unparsing(
-            Arc::clone(&analyzed_mdl),
-            reset_default_catalog_schema.clone(),
-        ))
-        .with_optimizer_rules(optimize_rule_for_unparsing())
+        new_state
+            .with_analyzer_rules(analyze_rule_for_unparsing(
+                Arc::clone(&analyzed_mdl),
+                reset_default_catalog_schema.clone(),
+            ))
+            .with_optimizer_rules(optimize_rule_for_unparsing())
     };
 
     let new_state = new_state.with_config(config).build();

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -857,6 +857,18 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_disable_count_wildcard_rule() -> Result<()> {
+        let ctx = SessionContext::new();
+
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::default());
+        let sql = "select count(*) from (select 1)";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT count(*) FROM (SELECT 1)");
+        Ok(())
+    }
+
     async fn assert_sql_valid_executable(sql: &str) -> Result<()> {
         let ctx = SessionContext::new();
         // To roundtrip testing, we should register the mock table for the planned sql.


### PR DESCRIPTION
# Description
Close #876 
DataFusion `CountWildcardRule` will try to rewrite `Count(Expr:Wildcard)` to `Count(Expr:Literal)`. It will generate an alias name `count(*)` which isn't allowed by BigQuery. Disable this rule for BigQuery.