### PR TITLE
ci(image): split ibis building to two jobs

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -57,7 +57,8 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-  build-ibis-image:
+  build-ibis-amd64-image:
+    needs: prepare-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +87,39 @@ jobs:
           build-contexts: |
             wren-core-py=./wren-core-py
             wren-core=./wren-core
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+  build-ibis-arm64-image:
+    needs: prepare-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/canner/wren-engine-ibis
+          tags: |
+            type=sha
+            type=raw,value=nightly
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ibis-server
+          build-contexts: |
+            wren-core-py=./wren-core-py
+            wren-core=./wren-core
+          platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,7 +69,7 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-  build-ibis-image:
+  build-ibis-amd64-image:
     needs: prepare-tag
     runs-on: ubuntu-latest
     steps:
@@ -98,6 +98,38 @@ jobs:
           build-contexts: |
             wren-core-py=./wren-core-py
             wren-core=./wren-core
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+  build-ibis-arm64-image:
+    needs: prepare-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/canner/wren-engine-ibis
+          tags: |
+            type=raw,value=${{ needs.prepare-tag.outputs.tag_name }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ibis-server
+          build-contexts: |
+            wren-core-py=./wren-core-py
+            wren-core=./wren-core
+          platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -113,7 +113,7 @@ jobs:
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
           push: true
-  stable-release-ibis:
+  stable-release-ibis-amd64:
     needs: prepare-version
     runs-on: ubuntu-latest
     steps:
@@ -145,6 +145,41 @@ jobs:
           build-contexts: |
             wren-core-py=./wren-core-py
             wren-core=./wren-core
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+  stable-release-ibis-arm64:
+    needs: prepare-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/canner/wren-engine-ibis
+          tags: |
+            type=raw,value=${{ needs.prepare-version.outputs.next_version }}
+            type=raw,value=latest
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ibis-server
+          build-args: |
+            RUST_PROFILE=--release
+          build-contexts: |
+            wren-core-py=./wren-core-py
+            wren-core=./wren-core
+          platforms: linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -45,7 +45,7 @@ jobs:
           git push
           echo "value=$version" >> $GITHUB_OUTPUT
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
We found if the job only builds one platform, it takes 16 minutes. So we can split the two platforms building into two jobs and let them be parallel to reduce the building time.

And also upgrade the `setup-java` action version to avoid warnings.
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/