### PR TITLE
ci: use macos-arm64 runner

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -90,7 +90,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
   build-ibis-arm64-image:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Docker meta

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -103,7 +103,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
   build-ibis-arm64-image:
     needs: prepare-tag
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Docker meta

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -150,7 +150,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
   stable-release-ibis-arm64:
     needs: prepare-version
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - name: Docker meta


### PR DESCRIPTION
We found that building a Docker image is slow on the Arm64 platform. May use an Arm64 OS image to build the image will be faster.

GitHub runner image list
https://github.com/actions/runner-images?tab=readme-ov-file#available-images