### PR TITLE
feat(core): introduce Timestamp Simplify rule to handle timezone

### DIFF
--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from tests.routers.v3.connector.postgres.conftest import base_url
+from tests.routers.v3.connector.bigquery.conftest import base_url
 
 manifest = {
     "catalog": "wren",
@@ -14,7 +14,7 @@ manifest = {
         {
             "name": "orders",
             "tableReference": {
-                "schema": "public",
+                "schema": "tpch_tiny",
                 "table": "orders",
             },
             "columns": [
@@ -86,18 +86,18 @@ with TestClient(app) as client:
             "2024-01-01 23:59:59.000000",
             "2024-01-16 04:00:00.000000",  # utc-5
             "2024-07-16 03:00:00.000000",  # utc-4
-            "1_370",
-            370,
-            "1996-01-02",
-            1,
-            "O",
-            "172799.49",
+            "36485_1202",
+            1202,
+            "1992-06-06",
+            36485,
+            "F",
+            356711.63,
         ]
         assert result["dtypes"] == {
-            "o_orderkey": "int32",
-            "o_custkey": "int32",
+            "o_orderkey": "int64",
+            "o_custkey": "int64",
             "o_orderstatus": "object",
-            "o_totalprice": "object",
+            "o_totalprice": "float64",
             "o_orderdate": "object",
             "order_cust_key": "object",
             "timestamp": "object",
@@ -105,22 +105,6 @@ with TestClient(app) as client:
             "dst_utc_minus_5": "object",
             "dst_utc_minus_4": "object",
         }
-
-    def test_query_with_connection_url(manifest_str, connection_url):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == "2024-01-01 23:59:59.000000"
-        assert result["dtypes"] is not None
 
     def test_query_with_limit(manifest_str, connection_info):
         response = client.post(

--- a/wren-core/core/src/logical_plan/mod.rs
+++ b/wren-core/core/src/logical_plan/mod.rs
@@ -1,3 +1,4 @@
 pub mod analyze;
 pub mod context_provider;
+pub mod optimize;
 pub mod utils;

--- a/wren-core/core/src/logical_plan/optimize/mod.rs
+++ b/wren-core/core/src/logical_plan/optimize/mod.rs
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+pub mod simplify_timestamp;

--- a/wren-core/core/src/logical_plan/optimize/simplify_timestamp.rs
+++ b/wren-core/core/src/logical_plan/optimize/simplify_timestamp.rs
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
+use datafusion::common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
+use datafusion::common::ScalarValue::{
+    TimestampMicrosecond, TimestampMillisecond, TimestampSecond,
+};
+use datafusion::common::{DFSchema, DFSchemaRef, Result, ScalarValue};
+use datafusion::execution::context::ExecutionProps;
+use datafusion::logical_expr::expr_rewriter::NamePreserver;
+use datafusion::logical_expr::simplify::SimplifyContext;
+use datafusion::logical_expr::utils::merge_schema;
+use datafusion::logical_expr::{cast, Cast, LogicalPlan, TryCast};
+use datafusion::optimizer::optimizer::ApplyOrder;
+use datafusion::optimizer::simplify_expressions::ExprSimplifier;
+use datafusion::optimizer::{OptimizerConfig, OptimizerRule};
+use datafusion::prelude::Expr;
+use datafusion::scalar::ScalarValue::TimestampNanosecond;
+use std::sync::Arc;
+
+/// Simplify the casting to [DataType::Timestamp] expression in the logical plan.
+/// It's modified from [datafusion::optimizer::simplify_expressions::SimplifyExpressions].
+/// Only the `Expr::Cast` with [DataType::Timestamp] is handled here.
+#[derive(Debug, Default)]
+pub struct TimestampSimplify {}
+
+impl TimestampSimplify {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for TimestampSimplify {
+    fn name(&self) -> &str {
+        "simplify_cast_expressions"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn supports_rewrite(&self) -> bool {
+        true
+    }
+
+    /// if supports_owned returns true, the Optimizer calls
+    /// [`Self::rewrite`] instead of [`Self::try_optimize`]
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        let mut execution_props = ExecutionProps::new();
+        execution_props.query_execution_start_time = config.query_execution_start_time();
+        Self::optimize_internal(plan, &execution_props)
+    }
+}
+
+impl TimestampSimplify {
+    fn optimize_internal(
+        plan: LogicalPlan,
+        execution_props: &ExecutionProps,
+    ) -> Result<Transformed<LogicalPlan>> {
+        let schema = if !plan.inputs().is_empty() {
+            DFSchemaRef::new(merge_schema(&plan.inputs()))
+        } else if let LogicalPlan::TableScan(scan) = &plan {
+            // When predicates are pushed into a table scan, there is no input
+            // schema to resolve predicates against, so it must be handled specially
+            //
+            // Note that this is not `plan.schema()` which is the *output*
+            // schema, and reflects any pushed down projection. The output schema
+            // will not contain columns that *only* appear in pushed down predicates
+            // (and no where else) in the plan.
+            //
+            // Thus, use the full schema of the inner provider without any
+            // projection applied for simplification
+            Arc::new(DFSchema::try_from_qualified_schema(
+                scan.table_name.clone(),
+                &scan.source.schema(),
+            )?)
+        } else {
+            Arc::new(DFSchema::empty())
+        };
+
+        let info = SimplifyContext::new(execution_props).with_schema(schema);
+
+        // Inputs have already been rewritten (due to bottom-up traversal handled by Optimizer)
+        // Just need to rewrite our own expressions
+
+        let simplifier = ExprSimplifier::new(info);
+
+        // The left and right expressions in a Join on clause are not
+        // commutative, for reasons that are not entirely clear. Thus, do not
+        // reorder expressions in Join while simplifying.
+        //
+        // This is likely related to the fact that order of the columns must
+        // match the order of the children. see
+        // https://github.com/apache/datafusion/pull/8780 for more details
+        let simplifier = if let LogicalPlan::Join(_) = plan {
+            simplifier.with_canonicalize(false)
+        } else {
+            simplifier
+        };
+
+        // Preserve expression names to avoid changing the schema of the plan.
+        let name_preserver = NamePreserver::new(&plan);
+        let mut rewriter = ExprRewriter {
+            simplifier: &simplifier,
+            name_preserver,
+        };
+        plan.map_expressions(|e| e.rewrite(&mut rewriter))
+    }
+}
+
+/// Rewriter for simplifying expressions in the logical plan.
+/// Try to evaluate the expression and replace it with a constant if possible.
+struct ExprRewriter<'a> {
+    simplifier: &'a ExprSimplifier<SimplifyContext<'a>>,
+    name_preserver: NamePreserver,
+}
+
+impl TreeNodeRewriter for ExprRewriter<'_> {
+    type Node = Expr;
+
+    fn f_down(&mut self, expr: Expr) -> Result<Transformed<Self::Node>> {
+        match &expr {
+            Expr::Cast(Cast { data_type, .. })
+            | Expr::TryCast(TryCast { data_type, .. })
+                if is_timestamp(data_type) =>
+            {
+                let original_name = self.name_preserver.save(&expr);
+                let new_e = self
+                    .simplifier
+                    .simplify(expr)
+                    .map(|expr| original_name.restore(expr))?;
+                // TODO it would be nice to have a way to know if the expression was simplified
+                // or not. For now conservatively return Transformed::yes
+                Ok(Transformed::yes(new_e))
+            }
+            Expr::Literal(value) => {
+                if let Some(cast_type) = cast_to_utc(value) {
+                    let cast_to_utc_expr = cast(expr.clone(), cast_type);
+                    let new_e = self.simplifier.simplify(cast_to_utc_expr)?;
+                    Ok(Transformed::yes(new_e))
+                } else {
+                    Ok(Transformed::no(expr))
+                }
+            }
+            _ => Ok(Transformed::no(expr)),
+        }
+    }
+}
+
+fn is_timestamp(data_type: &DataType) -> bool {
+    matches!(data_type, DataType::Timestamp(_, _))
+}
+
+fn cast_to_utc(value: &ScalarValue) -> Option<DataType> {
+    match value {
+        TimestampSecond(..) => Some(DataType::Timestamp(TimeUnit::Second, None)),
+        TimestampMillisecond(..) => {
+            Some(DataType::Timestamp(TimeUnit::Millisecond, None))
+        }
+        TimestampMicrosecond(..) => {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, None))
+        }
+        TimestampNanosecond(..) => Some(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        _ => None,
+    }
+}

--- a/wren-core/core/src/logical_plan/optimize/simplify_timestamp.rs
+++ b/wren-core/core/src/logical_plan/optimize/simplify_timestamp.rs
@@ -140,9 +140,16 @@ impl TreeNodeRewriter for ExprRewriter<'_> {
 
     fn f_down(&mut self, expr: Expr) -> Result<Transformed<Self::Node>> {
         match &expr {
-            Expr::Cast(Cast { data_type, .. })
-            | Expr::TryCast(TryCast { data_type, .. })
-                if is_timestamp(data_type) =>
+            // we only simplify the cast expression for the literal value
+            Expr::Cast(Cast {
+                data_type,
+                expr: sub_expr,
+            })
+            | Expr::TryCast(TryCast {
+                data_type,
+                expr: sub_expr,
+            }) if is_timestamp(data_type)
+                && matches!(sub_expr.as_ref(), Expr::Literal(_)) =>
             {
                 let original_name = self.name_preserver.save(&expr);
                 let new_e = self

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::logical_plan::analyze::expand_view::ExpandWrenViewRule;
 use crate::logical_plan::analyze::model_anlayze::ModelAnalyzeRule;
 use crate::logical_plan::analyze::model_generation::ModelGenerationRule;
+use crate::logical_plan::optimize::simplify_timestamp::TimestampSimplify;
 use crate::logical_plan::utils::create_schema;
 use crate::mdl::manifest::Model;
 use crate::mdl::{AnalyzedWrenMDL, SessionStateRef, WrenMDL};
@@ -179,6 +180,7 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         Arc::new(SingleDistinctToGroupBy::new()),
         // Disable SimplifyExpressions to avoid apply some function locally
         // Arc::new(SimplifyExpressions::new()),
+        Arc::new(TimestampSimplify::new()),
         Arc::new(UnwrapCastInComparison::new()),
         Arc::new(CommonSubexprEliminate::new()),
         Arc::new(EliminateGroupByConstant::new()),


### PR DESCRIPTION
# Description
We will simplify the timestamp literal when planning SQL to support the complex timezone issues in the different data sources. Something like
- MSSQL only accepts the time zone offset.
- Clikchouse only accepts the name of the time zone.
- BigQuery has timestamp (impacted by timezone) and Datetime (non-impacted by timezone).

To handle them, Wren Core will convert all of the time zone literals to UTC, which is how other databases process the timestamp with the time zone literal.

Powered by DataFusion, both the offset and the timezone name are allowed. It can also handle the DST issue.

## How the SQL transformed
When you input a SQL like
```
select timestamp '2011-01-01 18:00:00 Asia/Taipei'
```

The planned SQL will be
```
SELECT CAST('2011-01-01 10:00:00' AS TIMESTAMP)
```

Then, the dialect will be if the dialect is BigQuery.
```
SELECT CAST('2011-01-01 10:00:00' AS DATETIME)
```