### PR TITLE
fix(ibis): remove redundant comma of the function list

### DIFF
--- a/ibis-server/resources/function_list/bigquery.csv
+++ b/ibis-server/resources/function_list/bigquery.csv
@@ -82,9 +82,9 @@ scalar,timestamp_add,TIMESTAMP,"Adds a specified interval to a timestamp."
 scalar,timestamp_sub,TIMESTAMP,"Subtracts a specified interval from a timestamp."
 scalar,timestamp_diff,INT64,"Returns the difference between two timestamps."
 scalar,timestamp_trunc,TIMESTAMP,"Truncates a timestamp to a specified granularity."
-scalar,timestamp_micros,TIMESTAMP,"Converts the number of microseconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP.",
-scalar,timestamp_millis,TIMESTAMP,"Converts the number of milliseconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP.",
-scalar,timestamp_seconds,TIMESTAMP,"Converts the number of seconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP.",
+scalar,timestamp_micros,TIMESTAMP,"Converts the number of microseconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP."
+scalar,timestamp_millis,TIMESTAMP,"Converts the number of milliseconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP."
+scalar,timestamp_seconds,TIMESTAMP,"Converts the number of seconds since 1970-01-01 00:00:00 UTC to a TIMESTAMP."
 scalar,format_date,STRING,"Formats a date according to the specified format string."
 scalar,format_timestamp,STRING,"Formats a timestamp according to the specified format string."
 scalar,parse_date,DATE,"Parses a date from a string."

--- a/ibis-server/tests/routers/v3/connector/bigquery/conftest.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/conftest.py
@@ -3,9 +3,13 @@ import pathlib
 
 import pytest
 
+from app.config import get_config
+from tests.conftest import file_path
+
 pytestmark = pytest.mark.bigquery
 
 base_url = "/v3/connector/bigquery"
+function_list_path = file_path("../resources/function_list")
 
 
 def pytest_collection_modifyitems(items):
@@ -22,3 +26,11 @@ def connection_info():
         "dataset_id": "tpch_tiny",
         "credentials": os.getenv("TEST_BIG_QUERY_CREDENTIALS_BASE64_JSON"),
     }
+
+
+@pytest.fixture(autouse=True)
+def set_remote_function_list_path():
+    config = get_config()
+    config.set_remote_function_list_path(function_list_path)
+    yield
+    config.set_remote_function_list_path(None)

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -47,7 +47,7 @@ with TestClient(app) as client:
         response = client.get(url=f"{base_url}/functions")
         assert response.status_code == 200
         result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 30
+        assert len(result) == DATAFUSION_FUNCTION_COUNT + 33
         the_func = next(filter(lambda x: x["name"] == "abs", result))
         assert the_func == {
             "name": "abs",

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -6,8 +6,7 @@ from fastapi.testclient import TestClient
 
 from app.config import get_config
 from app.main import app
-from tests.conftest import file_path
-from tests.routers.v3.connector.bigquery.conftest import base_url
+from tests.routers.v3.connector.bigquery.conftest import base_url, function_list_path
 
 manifest = {
     "catalog": "my_catalog",
@@ -26,20 +25,10 @@ manifest = {
     ],
 }
 
-function_list_path = file_path("../resources/function_list")
-
 
 @pytest.fixture
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
-
-
-@pytest.fixture(autouse=True)
-def set_remote_function_list_path():
-    config = get_config()
-    config.set_remote_function_list_path(function_list_path)
-    yield
-    config.set_remote_function_list_path(None)
 
 
 with TestClient(app) as client:
@@ -57,10 +46,10 @@ with TestClient(app) as client:
         response = client.get(url=f"{base_url}/functions")
         assert response.status_code == 200
         result = response.json()
-        assert len(result) == 299
-        the_func = next(filter(lambda x: x["name"] == "abs", result))
+        assert len(result) == 368
+        the_func = next(filter(lambda x: x["name"] == "ABS", result))
         assert the_func == {
-            "name": "abs",
+            "name": "ABS",
             "description": "Returns the absolute value of a number.",
             "function_type": "scalar",
             "param_names": None,

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -46,10 +46,10 @@ with TestClient(app) as client:
         response = client.get(url=f"{base_url}/functions")
         assert response.status_code == 200
         result = response.json()
-        assert len(result) == 368
-        the_func = next(filter(lambda x: x["name"] == "ABS", result))
+        assert len(result) == 302
+        the_func = next(filter(lambda x: x["name"] == "abs", result))
         assert the_func == {
-            "name": "ABS",
+            "name": "abs",
             "description": "Returns the absolute value of a number.",
             "function_type": "scalar",
             "param_names": None,

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -211,3 +211,29 @@ with TestClient(app) as client:
         )
         assert response.status_code == 422
         assert response.text is not None
+
+    def test_timestamp_func(manifest_str, connection_info):
+        response = client.post(
+            url=f"{base_url}/query",
+            json={
+                "connectionInfo": connection_info,
+                "manifestStr": manifest_str,
+                "sql": "SELECT timestamp_millis(1000000) as millis, \
+                    timestamp_micros(1000000) as micros, \
+                    timestamp_seconds(1000000) as seconds",
+            },
+        )
+        assert response.status_code == 200
+        result = response.json()
+        assert len(result["columns"]) == 3
+        assert len(result["data"]) == 1
+        assert result["data"][0] == [
+            "1970-01-01 00:16:40.000000 UTC",
+            "1970-01-01 00:00:01.000000 UTC",
+            "1970-01-12 13:46:40.000000 UTC",
+        ]
+        assert result["dtypes"] == {
+            "millis": "object",
+            "micros": "object",
+            "seconds": "object",
+        }


### PR DESCRIPTION
# Description
The redundant comma causes the function can't be registered. I also added tests to assert if it's available.