### PR TITLE
ci(image): fix missing sha tag

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "type=sha" > tags.txt
-            echo "type=raw,value=nightly" > tags.txt
+            echo "type=raw,value=nightly" >> tags.txt
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -n "${{ github.event.inputs.docker_image_tag_name }}" ]; then

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "type=sha" > tags.txt
-            echo "type=raw,value=nightly" >> tags.txt
+            echo "type=schedule" >> tags.txt
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -n "${{ github.event.inputs.docker_image_tag_name }}" ]; then


### PR DESCRIPTION
We found the sha tag missing. Because we cover the text by `>` when writing to the `tags.txt`, it should be `>>` to append it.

I also found an entry `type=schedule` that can delegate `nightly`. 
https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule