### PR TITLE
fix(core): disable pushdown filter to keep the casting for timestamp column

### DIFF
--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -36,7 +36,6 @@ use datafusion::optimizer::eliminate_outer_join::EliminateOuterJoin;
 use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
 use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
 use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
-use datafusion::optimizer::push_down_filter::PushDownFilter;
 use datafusion::optimizer::replace_distinct_aggregate::ReplaceDistinctWithAggregate;
 use datafusion::optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion::optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -176,7 +176,8 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         // Filters can't be pushed down past Limits, we should do PushDownFilter after PushDownLimit
         // TODO: Sort with pushdown-limit doesn't support to be unparse
         // Arc::new(PushDownLimit::new()),
-        Arc::new(PushDownFilter::new()),
+        // Disable PushDownFilter to avoid the casting for bigquery (datetime/timestamp) column be removed
+        // Arc::new(PushDownFilter::new()),
         Arc::new(SingleDistinctToGroupBy::new()),
         // Disable SimplifyExpressions to avoid apply some function locally
         // Arc::new(SimplifyExpressions::new()),


### PR DESCRIPTION
# Description
Sometimes, we will cast a timestamp column to a timestamp type because we must handle the `DATETIME` and `TIMESTAMP` for the BigQuery. However, `push_down_filter` will remove the casting because it can't differentiate `DATETIME` and `TIMESTAMP` in the DataFusion layer.

see the unit test for the details.
If applying `push_down_filter`, the result will be as below. However, it will fail if `出道時間` is `DATETIME` in BigQuery
```sql
SELECT 
  count(*) 
FROM 
  (
    SELECT 
      artist.cast_timestamp 
    FROM 
      (
        SELECT 
          CAST(
            artist."出道時間" AS TIMESTAMP WITH TIME ZONE
          ) AS cast_timestamp 
        FROM 
          artist 
        WHERE 
          artist."出道時間" > CAST(
            '2011-01-01 21:00:00' AS TIMESTAMP
          )
      ) AS artist
  ) AS artist
```