### PR TITLE
chore(ibis): move the wren_core into function

### DIFF
--- a/ibis-server/app/mdl/context.py
+++ b/ibis-server/app/mdl/context.py
@@ -1,8 +1,8 @@
 from functools import cache
 
-from wren_core import SessionContext
-
 
 @cache
-def get_session_context(manifest_str: str, function_path: str) -> SessionContext:
+def get_session_context(manifest_str: str, function_path: str):
+    from wren_core import SessionContext
+
     return SessionContext(manifest_str, function_path)

--- a/ibis-server/docs/development.md
+++ b/ibis-server/docs/development.md
@@ -28,6 +28,7 @@ This installs the pre-commit hooks.
 To get the application running:
 1. Execute `just install` to install the dependencies
 2. Create a `.env` file and fill in the required environment variables (see [Environment Variables](#Environment-Variables))
+3. If you want to use `wren_core`, you need to install the core by `just install-core`. After you modify the core, you can update it by `just update-core`.
 
 To start the server:
 - Execute `just run` to start the server


### PR DESCRIPTION
Allow the core to remain uninstalled when not using the v3 API.