### PR TITLE
feat(core): support to Array and Struct type

### DIFF
--- a/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -227,7 +227,7 @@ impl ModelPlanNodeBuilder {
                 Some(TableReference::bare(quoted(model.name()))),
                 Arc::new(Field::new(
                     column.name(),
-                    map_data_type(&column.r#type),
+                    map_data_type(&column.r#type)?,
                     column.not_null,
                 )),
             ));
@@ -735,7 +735,7 @@ impl ModelSourceNode {
                         Some(TableReference::bare(quoted(model.name()))),
                         Arc::new(Field::new(
                             column.name(),
-                            map_data_type(&column.r#type),
+                            map_data_type(&column.r#type)?,
                             column.not_null,
                         )),
                     ));
@@ -775,7 +775,7 @@ impl ModelSourceNode {
                     Some(TableReference::bare(quoted(model.name()))),
                     Arc::new(Field::new(
                         column.name(),
-                        map_data_type(&column.r#type),
+                        map_data_type(&column.r#type)?,
                         column.not_null,
                     )),
                 ));
@@ -869,12 +869,12 @@ impl CalculationPlanNode {
         let output_field = vec![
             Arc::new(Field::new(
                 calculation.column.name(),
-                map_data_type(&calculation.column.r#type),
+                map_data_type(&calculation.column.r#type)?,
                 calculation.column.not_null,
             )),
             Arc::new(Field::new(
                 pk_column.name(),
-                map_data_type(&pk_column.r#type),
+                map_data_type(&pk_column.r#type)?,
                 pk_column.not_null,
             )),
         ]

--- a/wren-core/core/src/logical_plan/utils.rs
+++ b/wren-core/core/src/logical_plan/utils.rs
@@ -25,6 +25,10 @@ use std::collections::HashSet;
 use std::{collections::HashMap, sync::Arc};
 
 fn create_list_type(array_type: &str) -> Result<DataType> {
+    // Workaround for the array type without an element type
+    if array_type.len() == "array".len() {
+        return create_list_type("array<varchar>");
+    }
     if let ast::DataType::Array(value) = parse_type(array_type)? {
         let data_type = match value {
             ArrayElemTypeDef::None => {
@@ -361,6 +365,7 @@ mod test {
             ("null", DataType::Null),
             ("geography", DataType::Utf8),
             ("range", DataType::Utf8),
+            ("array", create_list_type("array<varchar>")?),
             ("array<int64>", create_list_type("array<int64>")?),
             (
                 "struct<name string, age int>",

--- a/wren-core/core/src/mdl/dialect.rs
+++ b/wren-core/core/src/mdl/dialect.rs
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+use datafusion::common::{internal_err, plan_err, Result, ScalarValue};
+use datafusion::logical_expr::sqlparser::ast::{Ident, Subscript};
+use datafusion::logical_expr::sqlparser::keywords::ALL_KEYWORDS;
+use datafusion::logical_expr::Expr;
+use datafusion::sql::sqlparser::ast;
+use datafusion::sql::sqlparser::ast::{Array, Value};
+use datafusion::sql::unparser::dialect::{Dialect, IntervalStyle};
+use datafusion::sql::unparser::Unparser;
+use regex::Regex;
+
+/// WrenDialect is a dialect for Wren engine. Handle the identifier quote style based on the
+/// original Datafusion Dialect implementation but with more strict rules.
+/// If the identifier isn't lowercase, it will be quoted.
+pub struct WrenDialect {}
+
+impl Dialect for WrenDialect {
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
+        if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
+            || !identifier_regex.is_match(identifier)
+            || non_lowercase(identifier)
+        {
+            Some('"')
+        } else {
+            None
+        }
+    }
+
+    fn interval_style(&self) -> IntervalStyle {
+        IntervalStyle::SQLStandard
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser<'_>,
+        func_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        match func_name {
+            "make_array" => {
+                let sql = self.make_array_to_sql(args, unparser)?;
+                Ok(Some(sql))
+            }
+            "array_element" => {
+                let sql = self.array_element_to_sql(args, unparser)?;
+                Ok(Some(sql))
+            }
+            "get_field" => self.get_fields_to_sql(args, unparser),
+            "named_struct" => {
+                let sql = self.named_struct_to_sql(args, unparser)?;
+                Ok(Some(sql))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+impl WrenDialect {
+    fn make_array_to_sql(&self, args: &[Expr], unparser: &Unparser) -> Result<ast::Expr> {
+        let args = args
+            .iter()
+            .map(|e| unparser.expr_to_sql(e))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ast::Expr::Array(Array {
+            elem: args,
+            named: false,
+        }))
+    }
+
+    fn array_element_to_sql(
+        &self,
+        args: &[Expr],
+        unparser: &Unparser,
+    ) -> Result<ast::Expr> {
+        if args.len() != 2 {
+            return internal_err!("array_element must have exactly 2 arguments");
+        }
+        let array = unparser.expr_to_sql(&args[0])?;
+        let index = unparser.expr_to_sql(&args[1])?;
+        Ok(ast::Expr::Subscript {
+            expr: Box::new(array),
+            subscript: Box::new(Subscript::Index { index }),
+        })
+    }
+
+    fn named_struct_to_sql(
+        &self,
+        args: &[Expr],
+        unparser: &Unparser,
+    ) -> Result<ast::Expr> {
+        if args.is_empty() {
+            return plan_err!("struct must have at least one field");
+        }
+        if args.len() % 2 != 0 {
+            return internal_err!(
+                "named_struct must have an even number of arguments or more than 0"
+            );
+        }
+        let fields = args
+            .chunks(2)
+            .map(|pair| {
+                let name = match &pair[0] {
+                    Expr::Literal(ScalarValue::Utf8(Some(s))) => s,
+                    _ => {
+                        return internal_err!("named_struct field name must be a string")
+                    }
+                };
+                let value = unparser.expr_to_sql(&pair[1])?;
+                Ok(ast::DictionaryField {
+                    key: self.new_ident_quoted_if_needs(name.to_string()),
+                    value: Box::new(value),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(ast::Expr::Dictionary(fields))
+    }
+
+    fn get_fields_to_sql(
+        &self,
+        args: &[Expr],
+        unparser: &Unparser,
+    ) -> Result<Option<ast::Expr>> {
+        if args.len() != 2 {
+            return internal_err!("get_fields must have exactly 2 argument");
+        }
+
+        let mut exprs = match unparser.expr_to_sql(&args[0])? {
+            ast::Expr::CompoundIdentifier(exprs) => exprs,
+            ast::Expr::Identifier(ident) => vec![ident],
+            // If the first argument is not identifiers, unparse it as ScalarFunction
+            _ => return Ok(None),
+        };
+
+        if let ast::Expr::Value(Value::SingleQuotedString(field_name)) =
+            unparser.expr_to_sql(&args[1])?
+        {
+            exprs.extend(vec![self.new_ident_quoted_if_needs(field_name)]);
+            return Ok(Some(ast::Expr::CompoundIdentifier(exprs)));
+        }
+
+        Ok(None)
+    }
+
+    fn new_ident_quoted_if_needs(&self, ident: String) -> Ident {
+        let quote_style = self.identifier_quote_style(&ident);
+        Ident {
+            value: ident,
+            quote_style,
+        }
+    }
+}
+
+fn non_lowercase(sql: &str) -> bool {
+    let lowercase = sql.to_lowercase();
+    lowercase != sql
+}

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -1,36 +1,36 @@
 use crate::logical_plan::utils::{from_qualified_name_str, map_data_type};
 use crate::mdl::builder::ManifestBuilder;
 use crate::mdl::context::{create_ctx_with_mdl, WrenDataSource};
+use crate::mdl::dialect::WrenDialect;
 use crate::mdl::function::{
     ByPassAggregateUDF, ByPassScalarUDF, ByPassWindowFunction, FunctionType,
     RemoteFunction,
 };
 use crate::mdl::manifest::{Column, Manifest, Model, View};
+use crate::DataFusionError;
 use datafusion::arrow::datatypes::Field;
 use datafusion::common::internal_datafusion_err;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionState;
-use datafusion::logical_expr::sqlparser::keywords::ALL_KEYWORDS;
 use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use datafusion::prelude::SessionContext;
 use datafusion::sql::parser::DFParser;
 use datafusion::sql::sqlparser::ast::{Expr, Ident};
 use datafusion::sql::sqlparser::dialect::dialect_from_str;
-use datafusion::sql::unparser::dialect::{Dialect, IntervalStyle};
 use datafusion::sql::unparser::Unparser;
 use datafusion::sql::TableReference;
 pub use dataset::Dataset;
 use log::{debug, info};
 use manifest::Relationship;
 use parking_lot::RwLock;
-use regex::Regex;
 use std::hash::Hash;
 use std::{collections::HashMap, sync::Arc};
 
 pub mod builder;
 pub mod context;
 pub(crate) mod dataset;
+mod dialect;
 pub mod function;
 pub mod lineage;
 pub mod manifest;
@@ -63,7 +63,7 @@ impl Default for AnalyzedWrenMDL {
 
 impl AnalyzedWrenMDL {
     pub fn analyze(manifest: Manifest) -> Result<Self> {
-        let wren_mdl = Arc::new(WrenMDL::infer_and_register_remote_table(manifest));
+        let wren_mdl = Arc::new(WrenMDL::infer_and_register_remote_table(manifest)?);
         let lineage = Arc::new(lineage::Lineage::new(&wren_mdl)?);
         Ok(AnalyzedWrenMDL { wren_mdl, lineage })
     }
@@ -171,7 +171,7 @@ impl WrenMDL {
 
     /// Create a WrenMDL from a manifest and register the table reference of the model as a remote table.
     /// All the column without expression will be considered a column
-    pub fn infer_and_register_remote_table(manifest: Manifest) -> Self {
+    pub fn infer_and_register_remote_table(manifest: Manifest) -> Result<Self> {
         let mut mdl = WrenMDL::new(manifest);
         let sources: Vec<_> = mdl
             .models()
@@ -181,7 +181,7 @@ impl WrenMDL {
                 let fields: Vec<_> = model
                     .columns
                     .iter()
-                    .filter_map(|column| Self::infer_source_column(column))
+                    .filter_map(|column| Self::infer_source_column(column).ok().flatten())
                     .collect();
                 let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(fields));
                 let datasource = WrenDataSource::new_with_schema(schema);
@@ -191,7 +191,7 @@ impl WrenMDL {
         sources
             .into_iter()
             .for_each(|(name, ds_ref)| mdl.register_table(name, ds_ref));
-        mdl
+        Ok(mdl)
     }
 
     /// Infer the source column from the column expression.
@@ -202,23 +202,25 @@ impl WrenMDL {
     /// If the expression is a simple column reference, it's the source column name.
     /// If the expression is a complex expression, it can't be inferred.
     ///
-    fn infer_source_column(column: &Column) -> Option<Field> {
+    fn infer_source_column(column: &Column) -> Result<Option<Field>> {
         if column.is_calculated || column.relationship.is_some() {
-            return None;
+            return Ok(None);
         }
 
         if let Some(expression) = column.expression() {
-            let expr = WrenMDL::sql_to_expr(expression).ok()?;
+            let expr = WrenMDL::sql_to_expr(expression)?;
             // if the column is a simple column reference, we can infer the column name
-            Self::collect_one_column(&expr).map(|name| {
-                Field::new(
+            if let Some(name) = Self::collect_one_column(&expr) {
+                Ok(Some(Field::new(
                     name.value.clone(),
-                    map_data_type(&column.r#type),
+                    map_data_type(&column.r#type)?,
                     column.not_null,
-                )
-            })
+                )))
+            } else {
+                Ok(None)
+            }
         } else {
-            Some(column.to_field())
+            Ok(Some(column.to_field()?))
         }
     }
 
@@ -328,10 +330,11 @@ pub async fn transform_sql_with_ctx(
     sql: &str,
 ) -> Result<String> {
     info!("wren-core received SQL: {}", sql);
-    remote_functions.iter().for_each(|remote_function| {
+    remote_functions.iter().try_for_each(|remote_function| {
         debug!("Registering remote function: {:?}", remote_function);
-        register_remote_function(ctx, remote_function);
-    });
+        register_remote_function(ctx, remote_function)?;
+        Ok::<_, DataFusionError>(())
+    })?;
     let ctx = create_ctx_with_mdl(ctx, Arc::clone(&analyzed_mdl), false).await?;
     let plan = ctx.state().create_logical_plan(sql).await?;
     debug!("wren-core original plan:\n {plan}");
@@ -353,55 +356,31 @@ pub async fn transform_sql_with_ctx(
     }
 }
 
-fn register_remote_function(ctx: &SessionContext, remote_function: &RemoteFunction) {
+fn register_remote_function(
+    ctx: &SessionContext,
+    remote_function: &RemoteFunction,
+) -> Result<()> {
     match &remote_function.function_type {
         FunctionType::Scalar => {
             ctx.register_udf(ScalarUDF::new_from_impl(ByPassScalarUDF::new(
                 &remote_function.name,
-                map_data_type(&remote_function.return_type),
+                map_data_type(&remote_function.return_type)?,
             )))
         }
         FunctionType::Aggregate => {
             ctx.register_udaf(AggregateUDF::new_from_impl(ByPassAggregateUDF::new(
                 &remote_function.name,
-                map_data_type(&remote_function.return_type),
+                map_data_type(&remote_function.return_type)?,
             )))
         }
         FunctionType::Window => {
             ctx.register_udwf(WindowUDF::new_from_impl(ByPassWindowFunction::new(
                 &remote_function.name,
-                map_data_type(&remote_function.return_type),
+                map_data_type(&remote_function.return_type)?,
             )))
         }
-    }
-}
-
-/// WrenDialect is a dialect for Wren engine. Handle the identifier quote style based on the
-/// original Datafusion Dialect implementation but with more strict rules.
-/// If the identifier isn't lowercase, it will be quoted.
-pub struct WrenDialect {}
-
-impl Dialect for WrenDialect {
-    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
-        let identifier_regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
-        if ALL_KEYWORDS.contains(&identifier.to_uppercase().as_str())
-            || !identifier_regex.is_match(identifier)
-            || non_lowercase(identifier)
-        {
-            Some('"')
-        } else {
-            None
-        }
-    }
-
-    fn interval_style(&self) -> IntervalStyle {
-        IntervalStyle::SQLStandard
-    }
-}
-
-fn non_lowercase(sql: &str) -> bool {
-    let lowercase = sql.to_lowercase();
-    lowercase != sql
+    };
+    Ok(())
 }
 
 /// Analyze the decision point. It's same as the /v1/analysis/sql API in wren engine
@@ -437,8 +416,10 @@ mod test {
     use crate::mdl::manifest::Manifest;
     use crate::mdl::{self, transform_sql_with_ctx, AnalyzedWrenMDL};
     use datafusion::arrow::array::{
-        ArrayRef, Int64Array, RecordBatch, StringArray, TimestampNanosecondArray,
+        ArrayRef, Float64Array, Int64Array, ListArray, RecordBatch, StringArray,
+        StructArray, TimestampNanosecondArray,
     };
+    use datafusion::arrow::datatypes::{DataType, Field, Fields, Int32Type, TimeUnit};
     use datafusion::assert_batches_eq;
     use datafusion::common::not_impl_err;
     use datafusion::common::Result;
@@ -1117,6 +1098,84 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_list() -> Result<()> {
+        let ctx = SessionContext::new();
+        ctx.register_batch("list_table", list_table()?)?;
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("list_table")
+                    .table_reference("list_table")
+                    .column(ColumnBuilder::new("list_col", "array<int>").build())
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
+        let sql = "select list_col[1] from wren.test.list_table";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT list_table.list_col[1] FROM (SELECT list_table.list_col FROM \
+        (SELECT list_table.list_col AS list_col FROM list_table) AS list_table) AS list_table");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_struct() -> Result<()> {
+        let ctx = SessionContext::new();
+        ctx.register_batch("struct_table", struct_table()?)?;
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("struct_table")
+                    .table_reference("struct_table")
+                    .column(
+                        ColumnBuilder::new(
+                            "struct_col",
+                            "struct<float_field float,time_field timestamp>",
+                        )
+                        .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
+        let sql = "select struct_col.float_field from wren.test.struct_table";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT struct_table.struct_col.float_field FROM \
+        (SELECT struct_table.struct_col FROM (SELECT struct_table.struct_col AS struct_col \
+        FROM struct_table) AS struct_table) AS struct_table");
+
+        let sql =
+            "select {float_field: 1.0, time_field: timestamp '2021-01-01 00:00:00'}";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT {float_field: 1.0, time_field: CAST('2021-01-01 00:00:00' AS TIMESTAMP)}");
+
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("struct_table")
+                    .table_reference("struct_table")
+                    .column(ColumnBuilder::new("struct_col", "struct<>").build())
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(manifest)?);
+        let sql = "select struct_col.float_field from wren.test.struct_table";
+        transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await.map_err(|e| {
+            assert_eq!(
+                e.to_string(),
+                "Error during planning: struct must have at least one field"
+            )
+        }).unwrap();
+        Ok(())
+    }
+
     /// Return a RecordBatch with made up data about customer
     fn customer() -> RecordBatch {
         let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));
@@ -1179,5 +1238,36 @@ mod test {
             ("timestamptz_col", timestamptz),
         ])
         .unwrap()
+    }
+
+    fn list_table() -> Result<RecordBatch> {
+        let data = vec![
+            Some(vec![Some(0), Some(1), Some(2)]),
+            None,
+            Some(vec![Some(3), None, Some(5)]),
+            Some(vec![Some(6), Some(7)]),
+        ];
+        let list_array: ArrayRef =
+            Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(data));
+        Ok(RecordBatch::try_from_iter(vec![("list_col", list_array)]).unwrap())
+    }
+
+    fn struct_table() -> Result<RecordBatch> {
+        let field: Fields = vec![
+            Field::new("float_field", DataType::Float64, true),
+            Field::new(
+                "time_field",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+        ]
+        .into();
+        let f64arr: ArrayRef = Arc::new(Float64Array::from(vec![1.0])) as ArrayRef;
+        let timearr: ArrayRef =
+            Arc::new(TimestampNanosecondArray::from(vec![1])) as ArrayRef;
+
+        let struct_arr: ArrayRef =
+            Arc::new(StructArray::try_new(field, vec![f64arr, timearr], None)?);
+        Ok(RecordBatch::try_from_iter(vec![("struct_col", struct_arr)]).unwrap())
     }
 }


### PR DESCRIPTION
# Description
- close #906 
- Support to define array and struct type in the MDL.
    - Array: `array<int>`
    - Struct: `struct<number int, name varchar>`
- Support to unparse array and struct to the SQL

# Known Issue
The array of struct isn't supported now. 
- `array<struct<number int>`