### PR TITLE
fix(core): disable CommonSubexprEliminate to avoid generate invalid plan for unparsing

### DIFF
--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -22,7 +22,6 @@ use datafusion::optimizer::analyzer::count_wildcard_rule::CountWildcardRule;
 use datafusion::optimizer::analyzer::expand_wildcard_rule::ExpandWildcardRule;
 use datafusion::optimizer::analyzer::inline_table_scan::InlineTableScan;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
-use datafusion::optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
 use datafusion::optimizer::decorrelate_predicate_subquery::DecorrelatePredicateSubquery;
 use datafusion::optimizer::eliminate_cross_join::EliminateCrossJoin;
 use datafusion::optimizer::eliminate_duplicated_expr::EliminateDuplicatedExpr;
@@ -168,7 +167,8 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         Arc::new(EliminateDuplicatedExpr::new()),
         Arc::new(EliminateFilter::new()),
         Arc::new(EliminateCrossJoin::new()),
-        Arc::new(CommonSubexprEliminate::new()),
+        // Disable CommonSubexprEliminate to avoid generate invalid projection plan
+        // Arc::new(CommonSubexprEliminate::new()),
         Arc::new(EliminateLimit::new()),
         Arc::new(PropagateEmptyRelation::new()),
         // Must be after PropagateEmptyRelation
@@ -184,7 +184,8 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         // Disable SimplifyExpressions to avoid apply some function locally
         // Arc::new(SimplifyExpressions::new()),
         Arc::new(UnwrapCastInComparison::new()),
-        Arc::new(CommonSubexprEliminate::new()),
+        // Disable CommonSubexprEliminate to avoid generate invalid projection plan
+        // Arc::new(CommonSubexprEliminate::new()),
         Arc::new(EliminateGroupByConstant::new()),
         // TODO: This rule would generate a plan that is not supported by the current unparser
         // Arc::new(OptimizeProjections::new()),

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -1174,6 +1174,20 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_disable_common_expression_eliminate() -> Result<()> {
+        let ctx = SessionContext::new();
+        let sql =
+            "SELECT CAST(TIMESTAMP '2021-01-01 00:00:00' as TIMESTAMP WITH TIME ZONE) = \
+        CAST(TIMESTAMP '2021-01-01 00:00:00' as TIMESTAMP WITH TIME ZONE)";
+        let result =
+            transform_sql_with_ctx(&ctx, Arc::new(AnalyzedWrenMDL::default()), &[], sql)
+                .await?;
+        assert_eq!(result, "SELECT CAST(CAST('2021-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP WITH TIME ZONE) = \
+        CAST(CAST('2021-01-01 00:00:00' AS TIMESTAMP) AS TIMESTAMP WITH TIME ZONE)");
+        Ok(())
+    }
+
     /// Return a RecordBatch with made up data about customer
     fn customer() -> RecordBatch {
         let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));


### PR DESCRIPTION
# Description
`CommonSubexprEliminate` is used to clean up the duplicate expressions. However, it could generate a plan like
```
     Projection: c.properties_first AS contact_first_name, c.properties_last AS contact_last_name, c.properties_e AS properties_e_a
      Projection: c.createdAt, c.properties_e, c.properties_first, c.properties_last
        Filter: __common_expr_1 >= CAST(CAST(Utf8("2024-11-01 00:00:00") AS Timestamp(Nanosecond, None)) AS Timestamp(Nanosecond, Some("+00:00"))) AND __common_expr_1 < CAST(CAST(Utf8("2024-11-15 00:00:00") AS Timestamp(Nanosecond, None)) AS Timestamp(Nanosecond, Some("+00:00")))
          Projection: CAST(c.createdAt AS Timestamp(Nanosecond, Some("+00:00"))) AS __common_expr_1, c.createdAt, c.properties_e, c.properties_first, c.properties_last
```
This plan has continued projection plans that cause an anonymous subquery.  There are some issues with the continued projection plans for the unparsing.

This PR disables it to avoid generating this kind of plan.
