### PR TITLE
feat(core): support to define param_names and param_types in the list file

### DIFF
--- a/wren-core-py/tests/functions.csv
+++ b/wren-core-py/tests/functions.csv
@@ -1,3 +1,3 @@
-function_type,name,return_type,description
-scalar,add_two,int,"Adds two numbers together."
-window,max_if,int,"If the condition is true, returns the maximum value in the window."
+function_type,name,return_type,param_names,param_types,description
+scalar,add_two,int,"f1,f2","int,int","Adds two numbers together."
+window,max_if,int,,,"If the condition is true, returns the maximum value in the window."

--- a/wren-core-py/tests/test_modeling_core.py
+++ b/wren-core-py/tests/test_modeling_core.py
@@ -63,3 +63,13 @@ def test_get_available_functions():
     assert add_two["name"] == "add_two"
     assert add_two["function_type"] == "scalar"
     assert add_two["description"] == "Adds two numbers together."
+    assert add_two["return_type"] == "int"
+    assert add_two["param_names"] == "f1,f2"
+    assert add_two["param_types"] == "int,int"
+
+    max_if = next(filter(lambda x: x["name"] == "max_if", map(lambda x: x.to_dict(), functions)))
+    assert max_if["name"] == "max_if"
+    assert max_if["function_type"] == "window"
+    assert max_if["param_names"] is None
+    assert max_if["param_types"] is None
+


### PR DESCRIPTION
# Description
Because the CSV doesn't support the native array format, use a comma-separated string to present the list.
## Sample
```
function_type,name,return_type,param_names,param_types,description
scalar,add_two,int,"f1,f2","int,int","Adds two numbers together."
```