### PR TITLE
ci(image): fix missing nightly tag and fix tag when building imagetools

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -56,7 +56,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.ENGINE_IMAGE }}
-          tags: ${{ needs.prepare-tag.outputs.tags }}
+          tags: |
+            ${{ needs.prepare-tag.outputs.tags }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -152,7 +153,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.IBIS_IMAGE }}
-          tags: ${{ needs.prepare-tag.outputs.tags }}
+          tags: |
+            ${{ needs.prepare-tag.outputs.tags }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -162,9 +164,10 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IBIS_IMAGE }}@sha256:%s ' *) \
-            --tag ${{ steps.meta.outputs.tags }}
+            $TAGS
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -201,9 +201,10 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | awk '{printf "--tag %s ", $0}')
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.IBIS_IMAGE }}@sha256:%s ' *) \
-            --tag ${{ steps.meta.outputs.tags }}
+            $TAGS
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
We found the tag `nightly` is missing and the step in stable release will fail because the command format is wrong.