### PR TITLE
ci(maven-test): fix condition

### DIFF
--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   maven-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'v1-engine-changed' }}
+    if: contains(github.event.pull_request.labels.*.name, 'v1-engine-changed')
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21


### PR DESCRIPTION
If the PR already has other tags, the condition `github.event.label.name == 'v1-engine-changed'` is false.
We need to use `contains` instead of it.