### PR TITLE
chore(core): remove unused `properties` field

### DIFF
--- a/wren-base/src/main/java/io/wren/base/WrenMDL.java
+++ b/wren-base/src/main/java/io/wren/base/WrenMDL.java
@@ -98,8 +98,7 @@ public class WrenMDL
                     processed,
                     model.getPrimaryKey(),
                     model.isCached(),
-                    model.getRefreshTime(),
-                    model.getProperties());
+                    model.getRefreshTime());
         }).collect(toList());
 
         List<Metric> renderedMetrics = original.getMetrics().stream().map(metric ->
@@ -109,8 +108,7 @@ public class WrenMDL
                         metric.getMeasure().stream().map(column -> renderExpression(column, macroTags, original)).collect(toList()),
                         metric.getTimeGrain(),
                         metric.isCached(),
-                        metric.getRefreshTime(),
-                        metric.getProperties())
+                        metric.getRefreshTime())
         ).collect(toList());
 
         return Manifest.builder(original)
@@ -132,8 +130,7 @@ public class WrenMDL
                 original.getRelationship().orElse(null),
                 original.isCalculated(),
                 original.isNotNull(),
-                expression,
-                original.getProperties());
+                expression);
     }
 
     public String getCatalog()

--- a/wren-base/src/main/java/io/wren/base/dto/Column.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Column.java
@@ -16,9 +16,7 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,26 +32,25 @@ public class Column
     private final String relationship;
     private final String expression;
     private final boolean isCalculated;
-    private final Map<String, String> properties;
 
     public static Column column(String name, String type, String relationship, boolean notNull)
     {
-        return new Column(name, type, relationship, false, notNull, null, null);
+        return new Column(name, type, relationship, false, notNull, null);
     }
 
     public static Column column(String name, String type, String relationship, boolean notNull, String expression)
     {
-        return new Column(name, type, relationship, false, notNull, expression, null);
+        return new Column(name, type, relationship, false, notNull, expression);
     }
 
     public static Column relationshipColumn(String name, String type, String relationship)
     {
-        return new Column(name, type, relationship, false, false, null, null);
+        return new Column(name, type, relationship, false, false, null);
     }
 
     public static Column calculatedColumn(String name, String type, String expression)
     {
-        return new Column(name, type, null, true, false, expression, null);
+        return new Column(name, type, null, true, false, expression);
     }
 
     @JsonCreator
@@ -63,8 +60,7 @@ public class Column
             @JsonProperty("relationship") String relationship,
             @JsonProperty("isCalculated") boolean isCalculated,
             @JsonProperty("notNull") boolean notNull,
-            @JsonProperty("expression") String expression,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("expression") String expression)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.type = requireNonNullEmpty(type, "type is null or empty");
@@ -72,7 +68,6 @@ public class Column
         this.isCalculated = isCalculated;
         this.notNull = notNull;
         this.expression = expression == null || expression.isEmpty() ? null : expression;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -111,12 +106,6 @@ public class Column
         return isCalculated;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     public String getSqlExpression()
     {
         return getExpression().orElse(quote(name));
@@ -137,14 +126,13 @@ public class Column
                 Objects.equals(name, that.name) &&
                 Objects.equals(type, that.type) &&
                 Objects.equals(relationship, that.relationship) &&
-                Objects.equals(expression, that.expression) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(expression, that.expression);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, isCalculated, notNull, relationship, expression, properties);
+        return Objects.hash(name, type, isCalculated, notNull, relationship, expression);
     }
 
     @Override
@@ -157,7 +145,6 @@ public class Column
                 .add("isCalculated", isCalculated)
                 .add("relationship", relationship)
                 .add("expression", expression)
-                .add("properties", properties)
                 .toString();
     }
 

--- a/wren-base/src/main/java/io/wren/base/dto/CumulativeMetric.java
+++ b/wren-base/src/main/java/io/wren/base/dto/CumulativeMetric.java
@@ -16,10 +16,8 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -35,7 +33,7 @@ public class CumulativeMetric
             Measure measure,
             Window window)
     {
-        return new CumulativeMetric(name, baseObject, measure, window, false, null, ImmutableMap.of());
+        return new CumulativeMetric(name, baseObject, measure, window, false, null);
     }
 
     private final String name;
@@ -44,7 +42,6 @@ public class CumulativeMetric
     private final Window window;
     private final boolean cached;
     private final Duration refreshTime;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public CumulativeMetric(
@@ -53,8 +50,7 @@ public class CumulativeMetric
             @JsonProperty("measure") Measure measure,
             @JsonProperty("window") Window window,
             @JsonProperty("cached") boolean cached,
-            @JsonProperty("refreshTime") Duration refreshTime,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("refreshTime") Duration refreshTime)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.baseObject = requireNonNullEmpty(baseObject, "baseObject is null or empty");
@@ -62,7 +58,6 @@ public class CumulativeMetric
         this.window = requireNonNull(window, "window is null");
         this.cached = cached;
         this.refreshTime = refreshTime;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -101,16 +96,10 @@ public class CumulativeMetric
         return refreshTime;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, baseObject, measure, window, cached, refreshTime, properties);
+        return Objects.hash(name, baseObject, measure, window, cached, refreshTime);
     }
 
     @Override
@@ -130,8 +119,7 @@ public class CumulativeMetric
                 Objects.equals(baseObject, that.baseObject) &&
                 Objects.equals(measure, that.measure) &&
                 Objects.equals(window, that.window) &&
-                Objects.equals(refreshTime, that.refreshTime) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(refreshTime, that.refreshTime);
     }
 
     @Override
@@ -144,7 +132,6 @@ public class CumulativeMetric
                 .add("window", window)
                 .add("cached", cached)
                 .add("refreshTime", refreshTime)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/DateSpine.java
+++ b/wren-base/src/main/java/io/wren/base/dto/DateSpine.java
@@ -16,9 +16,7 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -27,24 +25,21 @@ import static java.util.Objects.requireNonNull;
 
 public class DateSpine
 {
-    public static final DateSpine DEFAULT = new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31", null);
+    public static final DateSpine DEFAULT = new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31");
 
     private final TimeUnit unit;
     private final String start;
     private final String end;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public DateSpine(
             @JsonProperty("unit") TimeUnit unit,
             @JsonProperty("start") String start,
-            @JsonProperty("end") String end,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("end") String end)
     {
         this.unit = requireNonNull(unit, "unit is null");
         this.start = requireNonNullEmpty(start, "start is null or empty");
         this.end = requireNonNullEmpty(end, "end is null or empty");
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -65,12 +60,6 @@ public class DateSpine
         return end;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public String toString()
     {
@@ -78,7 +67,6 @@ public class DateSpine
                 .add("unit", unit)
                 .add("start", start)
                 .add("end", end)
-                .add("properties", properties)
                 .toString();
     }
 
@@ -94,13 +82,12 @@ public class DateSpine
         DateSpine dateSpine = (DateSpine) o;
         return unit == dateSpine.unit &&
                 Objects.equals(start, dateSpine.start) &&
-                Objects.equals(end, dateSpine.end) &&
-                Objects.equals(properties, dateSpine.properties);
+                Objects.equals(end, dateSpine.end);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(unit, start, end, properties);
+        return Objects.hash(unit, start, end);
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/EnumDefinition.java
+++ b/wren-base/src/main/java/io/wren/base/dto/EnumDefinition.java
@@ -16,10 +16,8 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -31,22 +29,19 @@ public class EnumDefinition
 {
     public static EnumDefinition enumDefinition(String name, List<EnumValue> values)
     {
-        return new EnumDefinition(name, values, ImmutableMap.of());
+        return new EnumDefinition(name, values);
     }
 
     private final String name;
     private final List<EnumValue> values;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public EnumDefinition(
             @JsonProperty("name") String name,
-            @JsonProperty("values") List<EnumValue> values,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("values") List<EnumValue> values)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.values = requireNonNull(values);
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -59,12 +54,6 @@ public class EnumDefinition
     public String getName()
     {
         return name;
-    }
-
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
     }
 
     public Optional<EnumValue> valueOf(String enumValueName)
@@ -85,8 +74,7 @@ public class EnumDefinition
         }
         EnumDefinition that = (EnumDefinition) obj;
         return Objects.equals(name, that.name) &&
-                Objects.equals(values, that.values) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(values, that.values);
     }
 
     @Override
@@ -94,8 +82,7 @@ public class EnumDefinition
     {
         return Objects.hash(
                 name,
-                values,
-                properties);
+                values);
     }
 
     @Override
@@ -104,7 +91,6 @@ public class EnumDefinition
         return toStringHelper(this)
                 .add("name", name)
                 .add("values", values)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/EnumValue.java
+++ b/wren-base/src/main/java/io/wren/base/dto/EnumValue.java
@@ -16,9 +16,7 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,22 +32,19 @@ public class EnumValue
 
     public static EnumValue enumValue(String name, String value)
     {
-        return new EnumValue(name, value, null);
+        return new EnumValue(name, value);
     }
 
     private final String name;
     private final String value;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public EnumValue(
             @JsonProperty("name") String name,
-            @JsonProperty("value") String value,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("value") String value)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.value = value;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -64,12 +59,6 @@ public class EnumValue
         return Optional.ofNullable(value).orElse(name);
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object o)
     {
@@ -81,14 +70,13 @@ public class EnumValue
         }
         EnumValue enumValue = (EnumValue) o;
         return Objects.equals(name, enumValue.name) &&
-                Objects.equals(value, enumValue.value) &&
-                Objects.equals(properties, enumValue.properties);
+                Objects.equals(value, enumValue.value);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, value, properties);
+        return Objects.hash(name, value);
     }
 
     @Override
@@ -97,7 +85,6 @@ public class EnumValue
         return toStringHelper(this)
                 .add("name", name)
                 .add("value", value)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Macro.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Macro.java
@@ -16,12 +16,10 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.wren.base.macro.Parameter;
 import io.wren.base.macro.ParameterListParser;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -33,20 +31,18 @@ public class Macro
 {
     public static Macro macro(String name, String definition)
     {
-        return new Macro(name, definition, ImmutableMap.of());
+        return new Macro(name, definition);
     }
 
     private final String name;
     private final String definition;
     private final List<Parameter> parameters;
     private final String body;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public Macro(
             @JsonProperty("name") String name,
-            @JsonProperty("definition") String definition,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("definition") String definition)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.definition = requireNonNullEmpty(definition, "definition is null or empty");
@@ -56,7 +52,6 @@ public class Macro
         String body = split[1].trim();
         this.parameters = new ParameterListParser().parse(paramString);
         this.body = body;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -81,12 +76,6 @@ public class Macro
         return body;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object o)
     {
@@ -99,14 +88,13 @@ public class Macro
         Macro macro = (Macro) o;
         return Objects.equals(name, macro.name) &&
                 Objects.equals(parameters, macro.parameters) &&
-                Objects.equals(body, macro.body) &&
-                Objects.equals(properties, macro.properties);
+                Objects.equals(body, macro.body);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, parameters, body, properties);
+        return Objects.hash(name, parameters, body);
     }
 
     @Override
@@ -116,7 +104,6 @@ public class Macro
                 .add("name", name)
                 .add("parameters", parameters)
                 .add("body", body)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Measure.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Measure.java
@@ -17,7 +17,6 @@ package io.wren.base.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -27,28 +26,25 @@ public class Measure
 {
     public static Measure measure(String name, String type, String operator, String refColumn)
     {
-        return new Measure(name, type, operator, refColumn, null);
+        return new Measure(name, type, operator, refColumn);
     }
 
     private final String name;
     private final String type;
     private final String operator;
     private final String refColumn;
-    private final Map<String, String> properties;
 
     @JsonCreator
     public Measure(
             @JsonProperty("name") String name,
             @JsonProperty("type") String type,
             @JsonProperty("operator") String operator,
-            @JsonProperty("refColumn") String refColumn,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("refColumn") String refColumn)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.type = requireNonNullEmpty(type, "type is null or empty");
         this.operator = requireNonNullEmpty(operator, "operator is null or empty");
         this.refColumn = requireNonNullEmpty(refColumn, "refColumn is null or empty");
-        this.properties = properties;
     }
 
     @JsonProperty
@@ -75,15 +71,9 @@ public class Measure
         return refColumn;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     public Column toColumn()
     {
-        return new Column(name, type, null, false, false, refColumn, properties);
+        return new Column(name, type, null, false, false, refColumn);
     }
 
     @Override
@@ -99,14 +89,13 @@ public class Measure
         return Objects.equals(name, measure.name) &&
                 Objects.equals(type, measure.type) &&
                 Objects.equals(operator, measure.operator) &&
-                Objects.equals(refColumn, measure.refColumn) &&
-                Objects.equals(properties, measure.properties);
+                Objects.equals(refColumn, measure.refColumn);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, type, operator, refColumn, properties);
+        return Objects.hash(name, type, operator, refColumn);
     }
 
     @Override
@@ -117,7 +106,6 @@ public class Measure
                 .add("type", type)
                 .add("operator", operator)
                 .add("refColumn", refColumn)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Metric.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Metric.java
@@ -17,11 +17,9 @@ package io.wren.base.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,7 +38,6 @@ public class Metric
     private final List<TimeGrain> timeGrain;
     private final boolean cached;
     private final Duration refreshTime;
-    private final Map<String, String> properties;
 
     public static Metric metric(String name, String baseObject, List<Column> dimension, List<Column> measure)
     {
@@ -54,7 +51,7 @@ public class Metric
 
     public static Metric metric(String name, String baseObject, List<Column> dimension, List<Column> measure, List<TimeGrain> timeGrain, boolean cached)
     {
-        return new Metric(name, baseObject, dimension, measure, timeGrain, cached, null, ImmutableMap.of());
+        return new Metric(name, baseObject, dimension, measure, timeGrain, cached, null);
     }
 
     @JsonCreator
@@ -65,8 +62,7 @@ public class Metric
             @JsonProperty("measure") List<Column> measure,
             @JsonProperty("timeGrain") List<TimeGrain> timeGrain,
             @JsonProperty("cached") boolean cached,
-            @JsonProperty("refreshTime") Duration refreshTime,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("refreshTime") Duration refreshTime)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.baseObject = requireNonNullEmpty(baseObject, "baseObject is null or empty");
@@ -76,7 +72,6 @@ public class Metric
         checkArgument(!measure.isEmpty(), "the number of measures should be one at least");
         this.timeGrain = timeGrain == null ? ImmutableList.of() : timeGrain;
         this.refreshTime = refreshTime == null ? defaultRefreshTime : refreshTime;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @Override
@@ -138,12 +133,6 @@ public class Metric
         return refreshTime;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object obj)
     {
@@ -160,8 +149,7 @@ public class Metric
                 Objects.equals(dimension, that.dimension) &&
                 Objects.equals(measure, that.measure) &&
                 Objects.equals(timeGrain, that.timeGrain) &&
-                Objects.equals(refreshTime, that.refreshTime) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(refreshTime, that.refreshTime);
     }
 
     @Override
@@ -174,8 +162,7 @@ public class Metric
                 measure,
                 timeGrain,
                 cached,
-                refreshTime,
-                properties);
+                refreshTime);
     }
 
     @Override
@@ -189,7 +176,6 @@ public class Metric
                 .add("timeGrain", timeGrain)
                 .add("cached", cached)
                 .add("refreshTime", refreshTime)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Model.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Model.java
@@ -16,11 +16,9 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -39,7 +37,6 @@ public class Model
     private final String primaryKey;
     private final boolean cached;
     private final Duration refreshTime;
-    private final Map<String, String> properties;
 
     public static Model model(String name, String refSql, List<Column> columns)
     {
@@ -48,22 +45,22 @@ public class Model
 
     public static Model model(String name, String refSql, List<Column> columns, boolean cached)
     {
-        return new Model(name, refSql, null, null, columns, null, cached, null, ImmutableMap.of());
+        return new Model(name, refSql, null, null, columns, null, cached, null);
     }
 
     public static Model model(String name, String refSql, List<Column> columns, String primaryKey)
     {
-        return new Model(name, refSql, null, null, columns, primaryKey, false, null, ImmutableMap.of());
+        return new Model(name, refSql, null, null, columns, primaryKey, false, null);
     }
 
     public static Model onBaseObject(String name, String baseObject, List<Column> columns, String primaryKey)
     {
-        return new Model(name, null, baseObject, null, columns, primaryKey, false, null, ImmutableMap.of());
+        return new Model(name, null, baseObject, null, columns, primaryKey, false, null);
     }
 
     public static Model onTableReference(String name, TableReference tableReference, List<Column> columns, String primaryKey)
     {
-        return new Model(name, null, null, tableReference, columns, primaryKey, false, null, ImmutableMap.of());
+        return new Model(name, null, null, tableReference, columns, primaryKey, false, null);
     }
 
     @JsonCreator
@@ -75,8 +72,7 @@ public class Model
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("primaryKey") String primaryKey,
             @JsonProperty("cached") boolean cached,
-            @JsonProperty("refreshTime") Duration refreshTime,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("refreshTime") Duration refreshTime)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         checkArgument(Stream.of(refSql, baseObject, tableReference).filter(Model::isNonNullOrNonEmpty).count() == 1,
@@ -88,7 +84,6 @@ public class Model
         this.primaryKey = primaryKey;
         this.cached = cached;
         this.refreshTime = refreshTime == null ? defaultRefreshTime : refreshTime;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     private static boolean isNonNullOrNonEmpty(Object value)
@@ -154,12 +149,6 @@ public class Model
         return refreshTime;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object obj)
     {
@@ -177,14 +166,13 @@ public class Model
                 Objects.equals(tableReference, that.tableReference) &&
                 Objects.equals(columns, that.columns) &&
                 Objects.equals(primaryKey, that.primaryKey) &&
-                Objects.equals(refreshTime, that.refreshTime) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(refreshTime, that.refreshTime);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, refSql, baseObject, tableReference, columns, primaryKey, properties);
+        return Objects.hash(name, refSql, baseObject, tableReference, columns, primaryKey);
     }
 
     @Override
@@ -198,7 +186,6 @@ public class Model
                 .add("columns", columns)
                 .add("cached", cached)
                 .add("refreshTime", refreshTime)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Relationship.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Relationship.java
@@ -16,7 +16,6 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
@@ -26,7 +25,6 @@ import io.trino.sql.tree.Identifier;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -46,7 +44,6 @@ public class Relationship
     // for debugging internally
     private final boolean isReverse;
     private final List<SortKey> manySideSortKeys;
-    private final Map<String, String> properties;
 
     public static Relationship relationship(String name, List<String> models, JoinType joinType, String condition)
     {
@@ -55,7 +52,7 @@ public class Relationship
 
     public static Relationship relationship(String name, List<String> models, JoinType joinType, String condition, List<SortKey> manySideSortKeys)
     {
-        return new Relationship(name, models, joinType, condition, manySideSortKeys, ImmutableMap.of());
+        return new Relationship(name, models, joinType, condition, manySideSortKeys);
     }
 
     public static Relationship reverse(Relationship relationship)
@@ -66,8 +63,7 @@ public class Relationship
                 JoinType.reverse(relationship.joinType),
                 relationship.getCondition(),
                 true,
-                relationship.getManySideSortKeys(),
-                ImmutableMap.of());
+                relationship.getManySideSortKeys());
     }
 
     @JsonCreator
@@ -76,10 +72,9 @@ public class Relationship
             @JsonProperty("models") List<String> models,
             @JsonProperty("joinType") JoinType joinType,
             @JsonProperty("condition") String condition,
-            @JsonProperty("manySideSortKeys") List<SortKey> manySideSortKeys,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("manySideSortKeys") List<SortKey> manySideSortKeys)
     {
-        this(name, models, joinType, condition, false, manySideSortKeys, properties);
+        this(name, models, joinType, condition, false, manySideSortKeys);
     }
 
     public Relationship(
@@ -88,8 +83,7 @@ public class Relationship
             JoinType joinType,
             String condition,
             boolean isReverse,
-            List<SortKey> manySideSortKeys,
-            Map<String, String> properties)
+            List<SortKey> manySideSortKeys)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         checkArgument(models != null && models.size() >= 2, "relationship should contain at least 2 models");
@@ -99,7 +93,6 @@ public class Relationship
         this.qualifiedCondition = qualifiedCondition(condition);
         this.isReverse = isReverse;
         this.manySideSortKeys = manySideSortKeys == null ? List.of() : manySideSortKeys;
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     private Expression qualifiedCondition(String condition)
@@ -170,12 +163,6 @@ public class Relationship
         return isReverse;
     }
 
-    @JsonProperty("properties")
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object obj)
     {
@@ -191,14 +178,13 @@ public class Relationship
                 joinType == that.joinType &&
                 Objects.equals(condition, that.condition) &&
                 isReverse == that.isReverse &&
-                Objects.equals(manySideSortKeys, that.manySideSortKeys) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(manySideSortKeys, that.manySideSortKeys);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, models, joinType, condition, isReverse, manySideSortKeys, properties);
+        return Objects.hash(name, models, joinType, condition, isReverse, manySideSortKeys);
     }
 
     @Override
@@ -211,7 +197,6 @@ public class Relationship
                 .add("condition", condition)
                 .add("isReverse", isReverse)
                 .add("manySideSortKeys", manySideSortKeys)
-                .add("properties", properties)
                 .toString();
     }
 

--- a/wren-base/src/main/java/io/wren/base/dto/View.java
+++ b/wren-base/src/main/java/io/wren/base/dto/View.java
@@ -16,7 +16,6 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.Objects;
@@ -28,7 +27,6 @@ public class View
 {
     private final String name;
     private final String statement;
-    private final Map<String, String> properties;
 
     public static View view(String name, String statement)
     {
@@ -43,7 +41,6 @@ public class View
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.statement = requireNonNullEmpty(statement, "statement is null or empty");
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -58,12 +55,6 @@ public class View
         return statement;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public boolean equals(Object o)
     {
@@ -75,8 +66,7 @@ public class View
         }
         View view = (View) o;
         return Objects.equals(name, view.name) &&
-                Objects.equals(statement, view.statement) &&
-                Objects.equals(properties, view.properties);
+                Objects.equals(statement, view.statement);
     }
 
     @Override
@@ -84,8 +74,7 @@ public class View
     {
         return Objects.hash(
                 name,
-                statement,
-                properties);
+                statement);
     }
 
     @Override
@@ -94,7 +83,6 @@ public class View
         return toStringHelper(this)
                 .add("name", name)
                 .add("statement", statement)
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/wren-base/src/main/java/io/wren/base/dto/Window.java
+++ b/wren-base/src/main/java/io/wren/base/dto/Window.java
@@ -16,10 +16,8 @@ package io.wren.base.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableMap;
 import io.wren.base.WrenTypes;
 
-import java.util.Map;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -36,11 +34,10 @@ public class Window
 
     private final String start;
     private final String end;
-    private final Map<String, String> properties;
 
     public static Window window(String name, String refColumn, TimeUnit timeUnit, String start, String end)
     {
-        return new Window(name, refColumn, timeUnit, start, end, null);
+        return new Window(name, refColumn, timeUnit, start, end);
     }
 
     @JsonCreator
@@ -49,15 +46,13 @@ public class Window
             @JsonProperty("refColumn") String refColumn,
             @JsonProperty("timeUnit") TimeUnit timeUnit,
             @JsonProperty("start") String start,
-            @JsonProperty("end") String end,
-            @JsonProperty("properties") Map<String, String> properties)
+            @JsonProperty("end") String end)
     {
         this.name = requireNonNullEmpty(name, "name is null or empty");
         this.refColumn = requireNonNullEmpty(refColumn, "refColumn is null or empty");
         this.timeUnit = requireNonNull(timeUnit, "timeUnit is null or empty");
         this.start = requireNonNullEmpty(start, "start is null or empty");
         this.end = requireNonNullEmpty(end, "end is null or empty");
-        this.properties = properties == null ? ImmutableMap.of() : properties;
     }
 
     @JsonProperty
@@ -90,15 +85,9 @@ public class Window
         return end;
     }
 
-    @JsonProperty
-    public Map<String, String> getProperties()
-    {
-        return properties;
-    }
-
     public Column toColumn()
     {
-        return new Column(name, WrenTypes.TIMESTAMP, null, false, false, refColumn, properties);
+        return new Column(name, WrenTypes.TIMESTAMP, null, false, false, refColumn);
     }
 
     @Override
@@ -110,7 +99,6 @@ public class Window
                 .add("timeUnit", timeUnit)
                 .add("start", start)
                 .add("end", end)
-                .add("properties", properties)
                 .toString();
     }
 
@@ -129,13 +117,12 @@ public class Window
                 Objects.equals(refColumn, window.refColumn) &&
                 timeUnit == window.timeUnit &&
                 Objects.equals(start, window.start) &&
-                Objects.equals(end, window.end) &&
-                Objects.equals(properties, window.properties);
+                Objects.equals(end, window.end);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, refColumn, timeUnit, start, end, properties);
+        return Objects.hash(name, refColumn, timeUnit, start, end);
     }
 }

--- a/wren-base/src/test/java/io/wren/base/dto/TestManifestSerDe.java
+++ b/wren-base/src/test/java/io/wren/base/dto/TestManifestSerDe.java
@@ -49,76 +49,69 @@ public class TestManifestSerDe
                                 null,
                                 null,
                                 List.of(
-                                        new Column("orderkey", "integer", null, false, true, null,
-                                                ImmutableMap.of("description", "the key of each order")),
-                                        new Column("custkey", "integer", null, false, true, null, null),
-                                        new Column("orderstatus", "string", null, false, true, null, null),
-                                        new Column("totalprice", "double", null, false, true, null, null),
-                                        new Column("orderdate", "date", null, false, true, null, null),
-                                        new Column("orderpriority", "string", null, false, true, null, null),
-                                        new Column("clerk", "string", null, false, true, null, null),
-                                        new Column("shippriority", "integer", null, false, true, null, null),
-                                        new Column("comment", "string", null, false, true, null, null),
-                                        new Column("customer", "CustomerModel", "OrdersCustomer", false, true, null, null)),
+                                        new Column("orderkey", "integer", null, false, true, null),
+                                        new Column("custkey", "integer", null, false, true, null),
+                                        new Column("orderstatus", "string", null, false, true, null),
+                                        new Column("totalprice", "double", null, false, true, null),
+                                        new Column("orderdate", "date", null, false, true, null),
+                                        new Column("orderpriority", "string", null, false, true, null),
+                                        new Column("clerk", "string", null, false, true, null),
+                                        new Column("shippriority", "integer", null, false, true, null),
+                                        new Column("comment", "string", null, false, true, null),
+                                        new Column("customer", "CustomerModel", "OrdersCustomer", false, true, null)),
                                 "orderkey",
                                 false,
-                                null,
-                                ImmutableMap.of("description", "tpch tiny orders table")),
+                                null),
                         new Model("LineitemModel",
                                 "select * from lineitem",
                                 null,
                                 null,
                                 List.of(
-                                        new Column("orderkey", "integer", null, false, true, null, null),
-                                        new Column("linenumber", "integer", null, false, true, null, null),
-                                        new Column("extendedprice", "integer", null, false, true, null, null)),
+                                        new Column("orderkey", "integer", null, false, true, null),
+                                        new Column("linenumber", "integer", null, false, true, null),
+                                        new Column("extendedprice", "integer", null, false, true, null)),
                                 null,
                                 false,
-                                null,
                                 null),
                         new Model("CustomerModel",
                                 null,
                                 null,
                                 new TableReference("test-catalog", "test-schema", "customer"),
                                 List.of(
-                                        new Column("custkey", "integer", null, false, true, null, null),
-                                        new Column("name", "string", null, false, true, null, null),
-                                        new Column("address", "string", null, false, true, null, null),
-                                        new Column("nationkey", "integer", null, false, true, null, null),
-                                        new Column("phone", "string", null, false, true, null, null),
-                                        new Column("acctbal", "double", null, false, true, null, null),
-                                        new Column("mktsegment", "string", null, false, true, null, null),
-                                        new Column("comment", "string", null, false, true, null, null),
-                                        new Column("orders", "OrdersModel", "OrdersCustomer", false, true, null, null),
+                                        new Column("custkey", "integer", null, false, true, null),
+                                        new Column("name", "string", null, false, true, null),
+                                        new Column("address", "string", null, false, true, null),
+                                        new Column("nationkey", "integer", null, false, true, null),
+                                        new Column("phone", "string", null, false, true, null),
+                                        new Column("acctbal", "double", null, false, true, null),
+                                        new Column("mktsegment", "string", null, false, true, null),
+                                        new Column("comment", "string", null, false, true, null),
+                                        new Column("orders", "OrdersModel", "OrdersCustomer", false, true, null),
                                         // calculated field
-                                        new Column("orders_totalprice", WrenTypes.VARCHAR, null, true, false, "SUM(orders.totalprice)", null)),
+                                        new Column("orders_totalprice", WrenTypes.VARCHAR, null, true, false, "SUM(orders.totalprice)")),
                                 "custkey",
                                 false,
-                                null,
                                 null)))
                 .setRelationships(List.of(
                         new Relationship("OrdersCustomer",
                                 List.of("OrdersModel", "CustomerModel"),
                                 JoinType.MANY_TO_ONE,
                                 "OrdersModel.custkey = CustomerModel.custkey",
-                                List.of(new Relationship.SortKey("orderkey", Relationship.SortKey.Ordering.ASC)),
-                                ImmutableMap.of("description", "the relationship between orders and customers"))))
+                                List.of(new Relationship.SortKey("orderkey", Relationship.SortKey.Ordering.ASC)))))
                 .setEnumDefinitions(List.of(
                         new EnumDefinition("OrderStatus", List.of(
-                                new EnumValue("PENDING", "pending", ImmutableMap.of("description", "pending")),
-                                new EnumValue("PROCESSING", "processing", null),
-                                new EnumValue("SHIPPED", "shipped", null),
-                                new EnumValue("COMPLETE", "complete", null)),
-                                ImmutableMap.of("description", "the status of an order"))))
+                                new EnumValue("PENDING", "pending"),
+                                new EnumValue("PROCESSING", "processing"),
+                                new EnumValue("SHIPPED", "shipped"),
+                                new EnumValue("COMPLETE", "complete")))))
                 .setMetrics(List.of(
                         new Metric("Revenue",
                                 "OrdersModel",
-                                List.of(new Column("orderkey", "string", null, false, true, null, null)),
-                                List.of(new Column("total", "integer", null, false, true, null, null)),
+                                List.of(new Column("orderkey", "string", null, false, true, null)),
+                                List.of(new Column("total", "integer", null, false, true, null)),
                                 List.of(new TimeGrain("orderdate", "orderdate", List.of(TimeUnit.DAY, TimeUnit.MONTH))),
                                 true,
-                                null,
-                                ImmutableMap.of("description", "the revenue of an order"))))
+                                null)))
                 .setViews(List.of(
                         new View("useMetric",
                                 "select * from Revenue",
@@ -126,20 +119,18 @@ public class TestManifestSerDe
                 .setCumulativeMetrics(List.of(
                         new CumulativeMetric("DailyRevenue",
                                 "Orders",
-                                new Measure("totalprice", WrenTypes.INTEGER, "sum", "totalprice", ImmutableMap.of("description", "totalprice")),
-                                new Window("orderdate", "orderdate", TimeUnit.DAY, "1994-01-01", "1994-12-31", ImmutableMap.of("description", "orderdate")),
+                                new Measure("totalprice", WrenTypes.INTEGER, "sum", "totalprice"),
+                                new Window("orderdate", "orderdate", TimeUnit.DAY, "1994-01-01", "1994-12-31"),
                                 false,
-                                null,
-                                ImmutableMap.of("description", "daily revenue")),
+                                null),
                         new CumulativeMetric("WeeklyRevenue",
                                 "Orders",
-                                new Measure("totalprice", WrenTypes.INTEGER, "sum", "totalprice", null),
-                                new Window("orderdate", "orderdate", TimeUnit.WEEK, "1994-01-01", "1994-12-31", null),
+                                new Measure("totalprice", WrenTypes.INTEGER, "sum", "totalprice"),
+                                new Window("orderdate", "orderdate", TimeUnit.WEEK, "1994-01-01", "1994-12-31"),
                                 false,
-                                null,
                                 null)))
-                .setDateSpine(new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31", ImmutableMap.of("description", "a date spine")))
-                .setMacros(List.of(new Macro("test", "(a: Expression) => a + 1", ImmutableMap.of("description", "a macro"))))
+                .setDateSpine(new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31"))
+                .setMacros(List.of(new Macro("test", "(a: Expression) => a + 1")))
                 .build();
     }
 

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestFramework.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestFramework.java
@@ -60,8 +60,7 @@ public abstract class AbstractTestFramework
                         .build(),
                 model.getPrimaryKey(),
                 model.isCached(),
-                model.getRefreshTime(),
-                model.getProperties());
+                model.getRefreshTime());
     }
 
     @BeforeClass

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestModel.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/AbstractTestModel.java
@@ -383,7 +383,7 @@ public abstract class AbstractTestModel
 
     private void buildFailedModel(String refSql, String baseObject, TableReference tableReference)
     {
-        new Model("failed", refSql, baseObject, tableReference, null, null, false, null, null);
+        new Model("failed", refSql, baseObject, tableReference, null, null, false, null);
     }
 
     private void assertQuery(WrenMDL mdl, @Language("SQL") String wrenSql, @Language("SQL") String duckDBSql)

--- a/wren-base/src/test/java/io/wren/base/sqlrewrite/TestCumulativeMetric.java
+++ b/wren-base/src/test/java/io/wren/base/sqlrewrite/TestCumulativeMetric.java
@@ -75,7 +75,7 @@ public class TestCumulativeMetric
                         CumulativeMetric.cumulativeMetric("YearlyRevenue",
                                 "Orders", Measure.measure("totalprice", WrenTypes.INTEGER, "sum", "totalprice"),
                                 Window.window("orderdate", "orderdate", TimeUnit.YEAR, "1994-01-01", "1998-12-31"))))
-                .setDateSpine(new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31", null))
+                .setDateSpine(new DateSpine(TimeUnit.DAY, "1970-01-01", "2077-12-31"))
                 .build();
         wrenMDL = WrenMDL.fromManifest(manifest);
     }

--- a/wren-tests/src/test/resources/duckdb/mdl.json
+++ b/wren-tests/src/test/resources/duckdb/mdl.json
@@ -9,7 +9,14 @@
         {
           "name": "orderkey",
           "expression": "o_orderkey",
-          "type": "int4"
+          "type": "int4",
+          "properties": {
+            "field": "test1",
+            "nested": {
+              "n1": "test1",
+              "n2": "test2"
+            }
+          }
         },
         {
           "name": "custkey",

--- a/wren-tests/src/test/resources/tpch_mdl.json
+++ b/wren-tests/src/test/resources/tpch_mdl.json
@@ -9,7 +9,14 @@
         {
           "name": "orderkey",
           "expression": "o_orderkey",
-          "type": "int4"
+          "type": "int4",
+          "properties": {
+            "field": "test1",
+            "nested": {
+              "n1": "test1",
+              "n2": "test2"
+            }
+          }
         },
         {
           "name": "custkey",


### PR DESCRIPTION
# Description
Remove the unused `properties` field from the MDL, Then, the user can apply the structure they want.
```json
"properties": {
  "field": "test1",
  "nested": {
    "n1": "test1",
    "n2": "test2"
  }
}
```