### PR TITLE
ci(labeler): remove unused label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,10 +22,6 @@ documentation:
 - changed-files:
   - any-glob-to-any-file: ['**/*.md']
 
-trino:
-- changed-files:
-  - any-glob-to-any-file: ['**/*trino*']
-
 bigquery:
 - changed-files:
   - any-glob-to-any-file: ['**/*bigquery*']


### PR DESCRIPTION
Before we split the tests of Trino, we need to append the label `trino` to trigger CI.
Now we integrate the tests so we don't need this label.