### PR TITLE
fix(ibis): Display Snowflake constraints without memtable

### DIFF
--- a/ibis-server/app/model/metadata/snowflake.py
+++ b/ibis-server/app/model/metadata/snowflake.py
@@ -1,7 +1,5 @@
 from contextlib import closing
 
-import ibis
-
 from app.model import SnowflakeConnectionInfo
 from app.model.data_source import DataSource
 from app.model.metadata.dto import (
@@ -83,12 +81,7 @@ class SnowflakeMetadata(Metadata):
         """
         with closing(self.connection.raw_sql(sql)) as cur:
             fields = [field[0] for field in cur.description]
-            result = [dict(zip(fields, row)) for row in cur.fetchall()]
-            res = (
-                ibis.memtable(result).to_pandas().to_dict(orient="records")
-                if len(result) > 0
-                else []
-            )
+            res = [dict(zip(fields, row)) for row in cur.fetchall()]
             constraints = []
             for row in res:
                 constraints.append(


### PR DESCRIPTION
### Description
This PR resolves the issue where Snowflake foreign key relationships were not displayed during setup phase by removing the `memtable` function.

### Screenshots
- Snowflake tables with foreign keys defined:
   <img width="1000" alt="Screenshot 2024-11-28 at 8 31 13 AM" src="https://github.com/user-attachments/assets/e966d003-6b6a-4664-8aab-93a11ef4112c">

- Snowflake tables without foreign keys:
   <img width="1000" alt="Screenshot 2024-11-28 at 8 35 44 AM" src="https://github.com/user-attachments/assets/177cad0f-cc50-4940-8dd8-24d8640ad9c0">

Fix #940 