### PR TITLE
feat(core): use MySQL interval style for output format

### DIFF
--- a/wren-core/core/src/mdl/dialect.rs
+++ b/wren-core/core/src/mdl/dialect.rs
@@ -45,7 +45,7 @@ impl Dialect for WrenDialect {
     }
 
     fn interval_style(&self) -> IntervalStyle {
-        IntervalStyle::SQLStandard
+        IntervalStyle::MySQL
     }
 
     fn scalar_function_to_sql_overrides(

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -877,6 +877,30 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_mysql_style_interval() -> Result<()> {
+        let ctx = SessionContext::new();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::default());
+        let sql = "select interval 1 day";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT INTERVAL 1 DAY");
+
+        let sql = "SELECT INTERVAL '1 YEAR 1 MONTH'";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(actual, "SELECT INTERVAL 13 MONTH");
+
+        let sql = "SELECT INTERVAL '1' YEAR + INTERVAL '2' MONTH + INTERVAL '3' DAY";
+        let actual =
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], sql).await?;
+        assert_eq!(
+            actual,
+            "SELECT INTERVAL 12 MONTH + INTERVAL 2 MONTH + INTERVAL 3 DAY"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_simplify_timestamp() -> Result<()> {
         let ctx = SessionContext::new();
         let analyzed_mdl = Arc::new(AnalyzedWrenMDL::default());


### PR DESCRIPTION
# Description
Part of #930 
Refer to [the interval style of DataFusion](https://github.com/apache/datafusion/blob/172e5573270ae4a3d152d5bf15c5c0008595090e/datafusion/sql/src/unparser/dialect.rs#L171), `MySQL` style is more common for various data sources. 