### PR TITLE
fix(core): fix the StatementAnalyzer for UNNEST and LATERAL query

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/ExpressionAnalyzer.java
@@ -80,7 +80,7 @@ public class ExpressionAnalyzer
         {
             QualifiedName qualifiedName = getQualifiedName(node);
             if (qualifiedName != null) {
-                scope.getRelationType().resolveAnyField(qualifiedName)
+                scope.resolveAnyField(qualifiedName)
                         .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             }
             else {
@@ -95,7 +95,7 @@ public class ExpressionAnalyzer
         protected Void visitIdentifier(Identifier node, Void context)
         {
             QualifiedName qualifiedName = QualifiedName.of(ImmutableList.of(node));
-            scope.getRelationType().resolveAnyField(qualifiedName)
+            scope.resolveAnyField(qualifiedName)
                     .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             return null;
         }
@@ -104,7 +104,7 @@ public class ExpressionAnalyzer
         protected Void visitSubscriptExpression(SubscriptExpression node, Void context)
         {
             QualifiedName qualifiedName = getQualifiedName(node.getBase());
-            scope.getRelationType().resolveAnyField(qualifiedName)
+            scope.resolveAnyField(qualifiedName)
                     .ifPresent(field -> referenceFields.put(NodeRef.of(node), field));
             return null;
         }

--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/decisionpoint/RelationAnalyzer.java
@@ -260,7 +260,7 @@ public class RelationAnalyzer
         @Override
         protected Void visitIdentifier(Identifier node, Void context)
         {
-            scope.getRelationType().resolveFields(QualifiedName.of(node.getValue()))
+            scope.resolveFields(QualifiedName.of(node.getValue()))
                     .stream().filter(field -> field.getSourceDatasetName().isPresent())
                     .forEach(field -> exprSources.add(new ExprSource(node.getValue(), field.getSourceDatasetName().get(), field.getSourceColumn().map(Column::getName).orElse(null), node.getLocation().orElse(null))));
             return null;
@@ -270,7 +270,7 @@ public class RelationAnalyzer
         protected Void visitDereferenceExpression(DereferenceExpression node, Void context)
         {
             Optional.ofNullable(getQualifiedName(node)).ifPresent(qualifiedName ->
-                    scope.getRelationType().resolveFields(qualifiedName)
+                    scope.resolveFields(qualifiedName)
                             .stream().filter(field -> field.getSourceDatasetName().isPresent())
                             .forEach(field -> exprSources.add(new ExprSource(qualifiedName.toString(), field.getSourceDatasetName().get(), field.getSourceColumn().map(Column::getName).orElse(null), node.getLocation().orElse(null)))));
             return null;

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDBTableFunction.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDBTableFunction.java
@@ -170,12 +170,35 @@ public class TestWrenWithDuckDBTableFunction
         assertThat(testDefault.getData().get(0)[0]).isEqualTo("2");
 
         setDuckDBInitSQL("create table nested_table as select * from (values ([1,2,3])) t(a1)");
+
+        previewDto = new PreviewDto(manifest, "select * from nested_table n, unnest(n.a1)", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("INTEGER[]");
+        assertThat(testDefault.getData().get(0).length).isEqualTo(2);
+        assertThat(testDefault.getData().size()).isEqualTo(3);
+
+        previewDto = new PreviewDto(manifest, "select * from nested_table n, unnest(n.a1) u(a1)", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("INTEGER[]");
+        assertThat(testDefault.getData().get(0).length).isEqualTo(2);
+        assertThat(testDefault.getData().size()).isEqualTo(3);
+
         previewDto = new PreviewDto(manifest, "select u.a1 from nested_table n, unnest(n.a1) u(a1)", null);
         testDefault = preview(previewDto);
         assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("INTEGER");
         assertThat(testDefault.getData().get(0)[0]).isEqualTo(1);
         assertThat(testDefault.getData().get(1)[0]).isEqualTo(2);
         assertThat(testDefault.getData().get(2)[0]).isEqualTo(3);
+
+        previewDto = new PreviewDto(manifest, "select * from nested_table n cross join lateral (select n.a1[1])", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getData().get(0).length).isEqualTo(2);
+        assertThat(testDefault.getData().size()).isEqualTo(1);
+
+        previewDto = new PreviewDto(manifest, "select * from nested_table n cross join lateral (select n.a1[1]) l(a1)", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getData().get(0).length).isEqualTo(2);
+        assertThat(testDefault.getData().size()).isEqualTo(1);
 
         previewDto = new PreviewDto(manifest, "select l.a1 from nested_table n cross join lateral (select n.a1[1]) l(a1)", null);
         testDefault = preview(previewDto);

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDBTableFunction.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDBTableFunction.java
@@ -168,5 +168,18 @@ public class TestWrenWithDuckDBTableFunction
         testDefault = preview(previewDto);
         assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("VARCHAR");
         assertThat(testDefault.getData().get(0)[0]).isEqualTo("2");
+
+        setDuckDBInitSQL("create table nested_table as select * from (values ([1,2,3])) t(a1)");
+        previewDto = new PreviewDto(manifest, "select u.a1 from nested_table n, unnest(n.a1) u(a1)", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("INTEGER");
+        assertThat(testDefault.getData().get(0)[0]).isEqualTo(1);
+        assertThat(testDefault.getData().get(1)[0]).isEqualTo(2);
+        assertThat(testDefault.getData().get(2)[0]).isEqualTo(3);
+
+        previewDto = new PreviewDto(manifest, "select l.a1 from nested_table n cross join lateral (select n.a1[1]) l(a1)", null);
+        testDefault = preview(previewDto);
+        assertThat(testDefault.getColumns().get(0).getType()).isEqualTo("INTEGER");
+        assertThat(testDefault.getData().get(0)[0]).isEqualTo(1);
     }
 }


### PR DESCRIPTION
# Description
We're missing to analyze the expression in the `UNNEST` and `LATERAL`. It may cause the wrong model generation. The following SQL would be failed:
- `select u.a1 from nested_table n, unnest(n.a1) u(a1)`
- `select l.a1 from nested_table n cross join lateral (select n.a1[1]) l(a1)`
