### PR TITLE
feat(java): warm up java engine

### DIFF
--- a/wren-main/src/main/java/io/wren/main/web/SystemResource.java
+++ b/wren-main/src/main/java/io/wren/main/web/SystemResource.java
@@ -1,0 +1,33 @@
+package io.wren.main.web;
+
+import com.google.inject.Inject;
+import io.wren.main.PreviewService;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.container.AsyncResponse;
+import jakarta.ws.rs.container.Suspended;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v2")
+public class SystemResource
+{
+    private final PreviewService previewService;
+
+    @Inject
+    public SystemResource(PreviewService previewService)
+    {
+        this.previewService = previewService;
+    }
+
+    @GET
+    @Path("/health")
+    public void health(@Suspended AsyncResponse asyncResponse)
+    {
+        if (previewService.isWarmed()) {
+            asyncResponse.resume(Response.ok().build());
+        }
+        else {
+            asyncResponse.resume(Response.status(Response.Status.SERVICE_UNAVAILABLE).build());
+        }
+    }
+}

--- a/wren-server/src/main/java/io/wren/server/WrenServer.java
+++ b/wren-server/src/main/java/io/wren/server/WrenServer.java
@@ -15,12 +15,14 @@
 package io.wren.server;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.airlift.event.client.EventModule;
 import io.airlift.http.server.HttpServerModule;
 import io.airlift.jaxrs.JaxrsModule;
 import io.airlift.json.JsonModule;
 import io.airlift.node.NodeModule;
+import io.wren.main.PreviewService;
 import io.wren.main.WrenModule;
 import io.wren.main.server.Server;
 import io.wren.server.module.DuckDBConnectorModule;
@@ -48,5 +50,16 @@ public class WrenServer
                 new DuckDBConnectorModule(),
                 new WrenModule(),
                 new WebModule());
+    }
+
+    @Override
+    protected void configure(Injector injector)
+    {
+        warmUp(injector);
+    }
+
+    private void warmUp(Injector injector)
+    {
+        injector.getInstance(PreviewService.class).warmUp();
     }
 }

--- a/wren-server/src/main/java/io/wren/server/module/WebModule.java
+++ b/wren-server/src/main/java/io/wren/server/module/WebModule.java
@@ -25,6 +25,7 @@ import io.wren.main.web.ConfigResource;
 import io.wren.main.web.DuckDBResource;
 import io.wren.main.web.MDLResource;
 import io.wren.main.web.MDLResourceV2;
+import io.wren.main.web.SystemResource;
 import io.wren.main.web.WrenExceptionMapper;
 
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
@@ -41,6 +42,7 @@ public class WebModule
         jaxrsBinder(binder).bind(AnalysisResourceV2.class);
         jaxrsBinder(binder).bind(ConfigResource.class);
         jaxrsBinder(binder).bind(DuckDBResource.class);
+        jaxrsBinder(binder).bind(SystemResource.class);
         jaxrsBinder(binder).bindInstance(new WrenExceptionMapper());
         binder.bind(PreviewService.class).in(Scopes.SINGLETON);
         binder.bind(ValidationService.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
We noticed that the first request to the Java engine is often timed out.
The Ibis server calls the Java engine timeout `5s`.
So we warm up the Java engine when it starts.
The warm-up time: ~5s. The warm-up case can not be too simple like `SELECT 1`. It will be ineffective.


### Benchmark
Docker resource limit
```yaml
java-engine:
  deploy:
    resources:
      limits:
        cpus: '0.5'
        memory: 2G
```
API: `POST {{ibis-server}}/v2/connector/dry-plan`
- Before: timeout(over 5s)
- After: 1.52s, 1.65s, 1.79s, 1.92s

### Additional information
[Java warm up](https://www.baeldung.com/java-jvm-warmup)
[python httpx timeouts](https://www.python-httpx.org/advanced/timeouts)
[docker compose resource](https://docs.docker.com/reference/compose-file/deploy/#resources)