### PR TITLE
feat(ibis): use `httpx.AsyncClient` instead of httpx.request

### DIFF
--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -9,7 +9,7 @@ from loguru import logger
 from starlette.responses import PlainTextResponse
 
 from app.config import get_config
-from app.mdl.http import get_http_client, try_connect
+from app.mdl.http import get_http_client, warmup_http_client
 from app.middleware import ProcessTimeMiddleware, RequestLogMiddleware
 from app.model import ConfigModel, CustomHttpError
 from app.routers import v2, v3
@@ -19,7 +19,7 @@ get_config().init_logger()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    asyncio.create_task(try_connect())  # noqa: RUF006
+    asyncio.create_task(warmup_http_client())  # noqa: RUF006
 
     yield
 

--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -19,9 +19,9 @@ get_config().init_logger()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    task = asyncio.create_task(try_connect())
+    asyncio.create_task(try_connect())  # noqa: RUF006
+
     yield
-    task.cancel()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -9,7 +9,7 @@ from loguru import logger
 from starlette.responses import PlainTextResponse
 
 from app.config import get_config
-from app.mdl.http import try_connect
+from app.mdl.http import get_http_client, try_connect
 from app.middleware import ProcessTimeMiddleware, RequestLogMiddleware
 from app.model import ConfigModel, CustomHttpError
 from app.routers import v2, v3
@@ -22,6 +22,8 @@ async def lifespan(app: FastAPI):
     asyncio.create_task(try_connect())  # noqa: RUF006
 
     yield
+
+    await get_http_client().aclose()
 
 
 app = FastAPI(lifespan=lifespan)

--- a/ibis-server/app/mdl/http.py
+++ b/ibis-server/app/mdl/http.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import httpcore
+import httpx
+
+from app.config import get_config
+
+wren_engine_endpoint = get_config().wren_engine_endpoint
+
+
+client = httpx.AsyncClient(
+    base_url=wren_engine_endpoint,
+    headers={
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    },
+)
+
+
+async def try_connect():
+    wait_time = 30
+    while wait_time > 0:
+        try:
+            response = await client.get("/v2/health")
+            if response.status_code == 200:
+                return
+        except (
+            httpx.ConnectError,
+            httpx.HTTPStatusError,
+            httpx.TimeoutException,
+            httpcore.ReadTimeout,
+        ):
+            await asyncio.sleep(1)
+            wait_time -= 1
+
+
+try:
+    asyncio.get_running_loop().create_task(try_connect())
+except RuntimeError:
+    loop = asyncio.new_event_loop()
+    loop.create_task(try_connect())  # noqa: RUF006
+    asyncio.set_event_loop(loop)
+
+
+def get_http_client():
+    return client

--- a/ibis-server/app/mdl/http.py
+++ b/ibis-server/app/mdl/http.py
@@ -1,5 +1,4 @@
-import asyncio
-
+import anyio
 import httpcore
 import httpx
 
@@ -17,9 +16,8 @@ client = httpx.AsyncClient(
 )
 
 
-async def try_connect():
-    wait_time = 30
-    while wait_time > 0:
+async def warmup_http_client(timeout=30):
+    for _ in range(timeout):
         try:
             response = await client.get("/v2/health")
             if response.status_code == 200:
@@ -30,8 +28,7 @@ async def try_connect():
             httpx.TimeoutException,
             httpcore.ReadTimeout,
         ):
-            await asyncio.sleep(1)
-            wait_time -= 1
+            await anyio.sleep(1)
 
 
 def get_http_client() -> httpx.AsyncClient:

--- a/ibis-server/app/mdl/http.py
+++ b/ibis-server/app/mdl/http.py
@@ -34,5 +34,5 @@ async def try_connect():
             wait_time -= 1
 
 
-def get_http_client():
+def get_http_client() -> httpx.AsyncClient:
     return client

--- a/ibis-server/app/mdl/http.py
+++ b/ibis-server/app/mdl/http.py
@@ -34,13 +34,5 @@ async def try_connect():
             wait_time -= 1
 
 
-try:
-    asyncio.get_running_loop().create_task(try_connect())
-except RuntimeError:
-    loop = asyncio.new_event_loop()
-    loop.create_task(try_connect())  # noqa: RUF006
-    asyncio.set_event_loop(loop)
-
-
 def get_http_client():
     return client

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 
 import httpx
@@ -94,14 +95,14 @@ class EmbeddedEngineRewriter:
         self.manifest_str = manifest_str
         self.function_path = function_path
 
-    def rewrite(self, sql: str) -> str:
+    async def rewrite(self, sql: str) -> str:
         try:
             extractor = get_manifest_extractor(self.manifest_str)
             tables = extractor.resolve_used_table_names(sql)
             manifest = extractor.extract_by(tables)
             manifest_str = to_json_base64(manifest)
             session_context = get_session_context(manifest_str, self.function_path)
-            return session_context.transform_sql(sql)
+            return await asyncio.to_thread(session_context.transform_sql, sql)
         except Exception as e:
             raise RewriteError(str(e))
 

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -11,6 +11,7 @@ from app.mdl.core import (
     get_session_context,
     to_json_base64,
 )
+from app.mdl.http import get_http_client
 from app.model import InternalServerError, UnprocessableEntityError
 from app.model.data_source import DataSource
 
@@ -21,6 +22,8 @@ importlib.import_module("ibis.backends.sql.dialects")
 
 # Register custom dialects
 importlib.import_module("app.custom_sqlglot.dialects")
+
+client = get_http_client()
 
 
 class Rewriter:
@@ -40,8 +43,8 @@ class Rewriter:
         else:
             self._rewriter = ExternalEngineRewriter(manifest_str)
 
-    def rewrite(self, sql: str) -> str:
-        planned_sql = self._rewriter.rewrite(sql)
+    async def rewrite(self, sql: str) -> str:
+        planned_sql = await self._rewriter.rewrite(sql)
         logger.debug("Planned SQL: {}", planned_sql)
         dialect_sql = self._transpile(planned_sql) if self.data_source else planned_sql
         logger.debug("Dialect SQL: {}", dialect_sql)
@@ -66,19 +69,15 @@ class ExternalEngineRewriter:
     def __init__(self, manifest_str: str):
         self.manifest_str = manifest_str
 
-    def rewrite(self, sql: str) -> str:
+    async def rewrite(self, sql: str) -> str:
         try:
             extractor = get_manifest_extractor(self.manifest_str)
             tables = extractor.resolve_used_table_names(sql)
             manifest = extractor.extract_by(tables)
             manifest_str = to_json_base64(manifest)
-            r = httpx.request(
+            r = await client.request(
                 method="GET",
                 url=f"{wren_engine_endpoint}/v2/mdl/dry-plan",
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
                 content=orjson.dumps({"manifestStr": manifest_str, "sql": sql}),
             )
             return r.raise_for_status().text.replace("\n", " ")

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -1,9 +1,9 @@
-import asyncio
 import importlib
 
 import httpx
 import orjson
 import sqlglot
+from anyio import to_thread
 from loguru import logger
 
 from app.config import get_config
@@ -102,7 +102,7 @@ class EmbeddedEngineRewriter:
             manifest = extractor.extract_by(tables)
             manifest_str = to_json_base64(manifest)
             session_context = get_session_context(manifest_str, self.function_path)
-            return await asyncio.to_thread(session_context.transform_sql, sql)
+            return await to_thread.run_sync(session_context.transform_sql, sql)
         except Exception as e:
             raise RewriteError(str(e))
 

--- a/ibis-server/app/model/validator.py
+++ b/ibis-server/app/model/validator.py
@@ -42,7 +42,7 @@ class Validator:
         except Exception as e:
             raise ValidationError(f"Exception: {type(e)}, message: {e!s}")
 
-    def _validate_relationship_is_valid(
+    async def _validate_relationship_is_valid(
         self, parameters: dict[str, str], manifest_str: str
     ):
         relationship_name = parameters.get("relationshipName")
@@ -136,7 +136,7 @@ class Validator:
             right_column,
         )
         try:
-            rewritten_sql = self.rewriter.rewrite(sql)
+            rewritten_sql = await self.rewriter.rewrite(sql)
             result = self.connector.query(rewritten_sql, limit=1)
             if not result.get("result").get(0):
                 raise ValidationError(

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -50,12 +50,14 @@ async def dry_plan_for_data_source(data_source: DataSource, dto: DryPlanDTO) -> 
 
 
 @router.post("/{data_source}/validate/{rule_name}")
-def validate(data_source: DataSource, rule_name: str, dto: ValidateDTO) -> Response:
+async def validate(
+    data_source: DataSource, rule_name: str, dto: ValidateDTO
+) -> Response:
     validator = Validator(
         Connector(data_source, dto.connection_info),
         Rewriter(dto.manifest_str, data_source=data_source, experiment=True),
     )
-    validator.validate(rule_name, dto.parameters, dto.manifest_str)
+    await validator.validate(rule_name, dto.parameters, dto.manifest_str)
     return Response(status_code=204)
 
 

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -21,13 +21,13 @@ router = APIRouter(prefix="/connector")
 
 
 @router.post("/{data_source}/query", dependencies=[Depends(verify_query_dto)])
-def query(
+async def query(
     data_source: DataSource,
     dto: QueryDTO,
     dry_run: Annotated[bool, Query(alias="dryRun")] = False,
     limit: int | None = None,
 ) -> Response:
-    rewritten_sql = Rewriter(
+    rewritten_sql = await Rewriter(
         dto.manifest_str, data_source=data_source, experiment=True
     ).rewrite(dto.sql)
     connector = Connector(data_source, dto.connection_info)
@@ -38,15 +38,15 @@ def query(
 
 
 @router.post("/dry-plan")
-def dry_plan(dto: DryPlanDTO) -> str:
-    return Rewriter(dto.manifest_str, experiment=True).rewrite(dto.sql)
+async def dry_plan(dto: DryPlanDTO) -> str:
+    return await Rewriter(dto.manifest_str, experiment=True).rewrite(dto.sql)
 
 
 @router.post("/{data_source}/dry-plan")
-def dry_plan_for_data_source(data_source: DataSource, dto: DryPlanDTO) -> str:
-    return Rewriter(dto.manifest_str, data_source=data_source, experiment=True).rewrite(
-        dto.sql
-    )
+async def dry_plan_for_data_source(data_source: DataSource, dto: DryPlanDTO) -> str:
+    return await Rewriter(
+        dto.manifest_str, data_source=data_source, experiment=True
+    ).rewrite(dto.sql)
 
 
 @router.post("/{data_source}/validate/{rule_name}")

--- a/ibis-server/poetry.lock
+++ b/ibis-server/poetry.lock
@@ -149,22 +149,23 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.6.2.post1"
+version = "4.7.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
-    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+    {file = "anyio-4.7.0-py3-none-any.whl", hash = "sha256:ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352"},
+    {file = "anyio-4.7.0.tar.gz", hash = "sha256:2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48"},
 ]
 
 [package.dependencies]
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
@@ -4145,4 +4146,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "43c5b5c0db80b5119a37aabc589258f12500ee3a8e30ae0ea7009ec1ba9ceb76"
+content-hash = "bd95c7c9979bfc9bd6c1082faa3f631177abf03324256374be6906ba435cb661"

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -28,6 +28,7 @@ sqlglot = ">=23.4,<25.21"
 loguru = "0.7.2"
 asgi-correlation-id = "4.3.4"
 gql = { extras = ["aiohttp"], version = "3.5.0" }
+anyio = "4.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.3.4"

--- a/ibis-server/tests/conftest.py
+++ b/ibis-server/tests/conftest.py
@@ -1,8 +1,21 @@
 import os
 
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
 
 def file_path(path: str) -> str:
     return os.path.join(os.path.dirname(__file__), path)
 
 
 DATAFUSION_FUNCTION_COUNT = 270
+
+
+@pytest.fixture(scope="module")
+async def client() -> AsyncClient:
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://test"
+    ) as client:
+        yield client

--- a/ibis-server/tests/conftest.py
+++ b/ibis-server/tests/conftest.py
@@ -13,7 +13,7 @@ def file_path(path: str) -> str:
 DATAFUSION_FUNCTION_COUNT = 270
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 async def client() -> AsyncClient:
     async with AsyncClient(
         transport=ASGITransport(app), base_url="http://test"

--- a/ibis-server/tests/routers/conftest.py
+++ b/ibis-server/tests/routers/conftest.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+def pytest_collection_modifyitems(items):
+    current_file_dir = pathlib.Path(__file__).resolve().parent
+    for item in items:
+        if pathlib.Path(item.fspath).is_relative_to(current_file_dir):
+            item.add_marker(pytestmark)
+            item.fixturenames.append("anyio_backend")
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():
+    return "asyncio"

--- a/ibis-server/tests/routers/test_ibis.py
+++ b/ibis-server/tests/routers/test_ibis.py
@@ -2,9 +2,6 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
-
-from app.main import app
 
 manifest = {
     "catalog": "my_catalog",
@@ -21,20 +18,18 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
-
-    def test_dry_plan(manifest_str):
-        response = client.post(
-            url="/v2/connector/dry-plan",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT orderkey FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+async def test_dry_plan(client, manifest_str):
+    response = await client.post(
+        url="/v2/connector/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT orderkey FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    assert response.text is not None

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -3,9 +3,7 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from app.model.validator import rules
 
 pytestmark = pytest.mark.bigquery
@@ -70,260 +68,277 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        172799.49,
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+        "616263",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "float64",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+        "bytea_column": "object",
+    }
 
-    def test_query(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            172799.49,
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            None,
-            "616263",
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int64",
-            "custkey": "int64",
-            "orderstatus": "object",
-            "totalprice": "float64",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-            "bytea_column": "object",
-        }
 
-    def test_query_without_manifest():
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_manifest(client):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_sql(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_sql(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_values(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM (VALUES (1, 2), (3, 4))",
-            },
-        )
 
-        assert response.status_code == 204
+async def test_query_with_dry_run(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-    def test_interval(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT INTERVAL '1' YEAR + INTERVAL '100' MONTH + INTERVAL '100' DAY + INTERVAL '1' HOUR AS col",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result["data"][0] == ["112 months 100 days 3600000000 microseconds"]
-        assert result["dtypes"] == {"col": "object"}
 
-    def test_avg_interval(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT AVG(DATE '2024-01-01' - orderdate) AS col from \"Orders\"",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result["data"][0] == ["10484 days 32054400000 microseconds"]
-        assert result["dtypes"] == {"col": "object"}
+async def test_query_with_dry_run_and_invalid_sql(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-    def test_validate_with_unknown_rule(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
 
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
+async def test_query_values(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM (VALUES (1, 2), (3, 4))",
+        },
+    )
 
-    def test_validate_rule_column_is_valid(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
+async def test_interval(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT INTERVAL '1' YEAR + INTERVAL '100' MONTH + INTERVAL '100' DAY + INTERVAL '1' HOUR AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["data"][0] == ["112 months 100 days 3600000000 microseconds"]
+    assert result["dtypes"] == {"col": "object"}
 
-    def test_validate_rule_column_is_valid_without_parameters(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_rule_column_is_valid_without_one_parameter(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
+async def test_avg_interval(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT AVG(DATE '2024-01-01' - orderdate) AS col from \"Orders\"",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["data"][0] == ["10484 days 32054400000 microseconds"]
+    assert result["dtypes"] == {"col": "object"}
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
 
-    def test_metadata_list_tables():
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
+async def test_validate_with_unknown_rule(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
 
-    def test_metadata_list_constraints():
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-    def test_metadata_db_version():
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert response.text == '"Follow BigQuery release version"'
+
+async def test_validate_rule_column_is_valid(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
+
+
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_validate_rule_column_is_valid_without_parameters(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+
+async def test_metadata_list_constraints(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+
+async def test_metadata_db_version(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert response.text == '"Follow BigQuery release version"'

--- a/ibis-server/tests/routers/v2/connector/test_clickhouse.py
+++ b/ibis-server/tests/routers/v2/connector/test_clickhouse.py
@@ -4,7 +4,7 @@ import clickhouse_connect
 import orjson
 import pandas as pd
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from testcontainers.clickhouse import ClickHouseContainer
 
 from app.main import app
@@ -163,390 +163,446 @@ def clickhouse(request) -> ClickHouseContainer:
     return ch
 
 
-with TestClient(app) as client:
+@pytest.fixture(scope="module")
+async def client():
+    async with AsyncClient(
+        transport=ASGITransport(app), base_url="http://test"
+    ) as client:
+        yield client
 
-    def test_query(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
+
+@pytest.mark.anyio
+async def test_query(client, manifest_str, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 10
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+        "abc",  # Clickhouse does not support bytea, so it is returned as string
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int32",
+        "custkey": "int32",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "object",
+        "bytea_column": "object",
+    }
+
+
+@pytest.mark.anyio
+async def test_query_with_connection_url(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_url = _to_connection_url(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 10
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
+
+
+@pytest.mark.anyio
+async def test_query_with_limit(client, manifest_str, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders"',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 10',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+
+
+@pytest.mark.anyio
+async def test_query_join(client, manifest_str, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT name as customer_name FROM "Orders" join "Customer" on "Orders".custkey = "Customer".custkey WHERE custkey = 370 LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["data"][0] == ["Customer#000000370"]
+    assert result["dtypes"] == {
+        "customer_name": "object",
+    }
+
+
+@pytest.mark.anyio
+async def test_query_to_one_relationship(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT customer_name FROM "Orders" where custkey = 370 LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["data"][0] == ["Customer#000000370"]
+    assert result["dtypes"] == {
+        "customer_name": "object",
+    }
+
+
+@pytest.mark.anyio
+async def test_query_to_many_relationship(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT totalprice FROM "Customer" where custkey = 370 LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["data"][0] == ["2860895.79"]
+    assert result["dtypes"] == {
+        "totalprice": "object",
+    }
+
+
+@pytest.mark.anyio
+async def test_query_alias_join(client, manifest_str, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    # ClickHouse does not support alias join
+    with pytest.raises(Exception):
+        await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+                "sql": 'SELECT orderstatus FROM ("Orders" o JOIN "Customer" c ON o.custkey = c.custkey) j1 LIMIT 1',
             },
         )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 10
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            "172799.49",
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            None,
-            "abc",  # Clickhouse does not support bytea, so it is returned as string
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int32",
-            "custkey": "int32",
-            "orderstatus": "object",
-            "totalprice": "object",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "object",
-            "bytea_column": "object",
-        }
 
-    def test_query_with_connection_url(manifest_str, clickhouse: ClickHouseContainer):
-        connection_url = _to_connection_url(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 10
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == 1
-        assert result["dtypes"] is not None
 
-    def test_query_with_limit(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders"',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+@pytest.mark.anyio
+async def test_query_without_manifest(client, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 10',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
 
-    def test_query_join(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT name as customer_name FROM "Orders" join "Customer" on "Orders".custkey = "Customer".custkey WHERE custkey = 370 LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["data"][0] == ["Customer#000000370"]
-        assert result["dtypes"] == {
-            "customer_name": "object",
-        }
+@pytest.mark.anyio
+async def test_query_without_sql(client, manifest_str, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_to_one_relationship(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT customer_name FROM "Orders" where custkey = 370 LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["data"][0] == ["Customer#000000370"]
-        assert result["dtypes"] == {
-            "customer_name": "object",
-        }
 
-    def test_query_to_many_relationship(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT totalprice FROM "Customer" where custkey = 370 LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["data"][0] == ["2860895.79"]
-        assert result["dtypes"] == {
-            "totalprice": "object",
-        }
+@pytest.mark.anyio
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_alias_join(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        # ClickHouse does not support alias join
-        with pytest.raises(Exception):
-            client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": 'SELECT orderstatus FROM ("Orders" o JOIN "Customer" c ON o.custkey = c.custkey) j1 LIMIT 1',
-                },
-            )
 
-    def test_query_without_manifest(clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
+@pytest.mark.anyio
+async def test_query_with_dry_run(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-    def test_query_without_sql(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
+@pytest.mark.anyio
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-    def test_query_with_dry_run(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
 
-    def test_query_with_dry_run_and_invalid_sql(
-        manifest_str, clickhouse: ClickHouseContainer
-    ):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
+@pytest.mark.anyio
+async def test_validate_with_unknown_rule(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-    def test_validate_with_unknown_rule(manifest_str, clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
 
-    def test_validate_rule_column_is_valid(
-        manifest_str, clickhouse: ClickHouseContainer
-    ):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
+@pytest.mark.anyio
+async def test_validate_rule_column_is_valid(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, clickhouse: ClickHouseContainer
-    ):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
+@pytest.mark.anyio
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, clickhouse: ClickHouseContainer
-    ):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, clickhouse: ClickHouseContainer
-    ):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
+@pytest.mark.anyio
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_metadata_list_tables(clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={
-                "connectionInfo": connection_info,
-            },
-        )
-        assert response.status_code == 200
 
-        result = response.json()[1]
-        assert result["name"] == "test.orders"
-        assert result["primaryKey"] is not None
-        assert result["description"] == "This is a table comment"
-        assert result["properties"] == {
-            "catalog": None,
-            "schema": "test",
-            "table": "orders",
-        }
-        assert len(result["columns"]) == 9
-        assert result["columns"][8] == {
-            "name": "o_comment",
-            "nestedColumns": None,
-            "type": "VARCHAR",
-            "notNull": False,
-            "description": "This is a comment",
-            "properties": None,
-        }
+@pytest.mark.anyio
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, clickhouse: ClickHouseContainer
+):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
 
-    def test_metadata_list_constraints(clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={
-                "connectionInfo": connection_info,
-            },
-        )
-        assert response.status_code == 200
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
 
-        result = response.json()
-        assert len(result) == 0
 
-    def test_metadata_db_version(clickhouse: ClickHouseContainer):
-        connection_info = _to_connection_info(clickhouse)
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+@pytest.mark.anyio
+async def test_metadata_list_tables(client, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
 
-    def _to_connection_info(db: ClickHouseContainer):
-        return {
-            "host": db.get_container_host_ip(),
-            "port": db.get_exposed_port(db.port),
-            "user": db.username,
-            "password": db.password,
-            "database": db.dbname,
-        }
+    result = response.json()[1]
+    assert result["name"] == "test.orders"
+    assert result["primaryKey"] is not None
+    assert result["description"] == "This is a table comment"
+    assert result["properties"] == {
+        "catalog": None,
+        "schema": "test",
+        "table": "orders",
+    }
+    assert len(result["columns"]) == 9
+    assert result["columns"][8] == {
+        "name": "o_comment",
+        "nestedColumns": None,
+        "type": "VARCHAR",
+        "notNull": False,
+        "description": "This is a comment",
+        "properties": None,
+    }
 
-    def _to_connection_url(ch: ClickHouseContainer):
-        info = _to_connection_info(ch)
-        return f"clickhouse://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"
+
+@pytest.mark.anyio
+async def test_metadata_list_constraints(client, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+
+    result = response.json()
+    assert len(result) == 0
+
+
+@pytest.mark.anyio
+async def test_metadata_db_version(client, clickhouse: ClickHouseContainer):
+    connection_info = _to_connection_info(clickhouse)
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert response.text is not None
+
+
+def _to_connection_info(db: ClickHouseContainer):
+    return {
+        "host": db.get_container_host_ip(),
+        "port": db.get_exposed_port(db.port),
+        "user": db.username,
+        "password": db.password,
+        "database": db.dbname,
+    }
+
+
+def _to_connection_url(ch: ClickHouseContainer):
+    info = _to_connection_info(ch)
+    return f"clickhouse://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"

--- a/ibis-server/tests/routers/v2/connector/test_mssql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mssql.py
@@ -4,11 +4,9 @@ import orjson
 import pandas as pd
 import pytest
 import sqlalchemy
-from fastapi.testclient import TestClient
 from sqlalchemy import text
 from testcontainers.mssql import SqlServerContainer
 
-from app.main import app
 from app.model.validator import rules
 from tests.conftest import file_path
 
@@ -69,7 +67,7 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -108,317 +106,338 @@ def mssql(request) -> SqlServerContainer:
     return mssql
 
 
-with TestClient(app) as client:
-
-    def test_query(manifest_str, mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            "172799.49",
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            None,
-            "616263",
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int32",
-            "custkey": "int32",
-            "orderstatus": "object",
-            "totalprice": "object",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-            "bytea_column": "object",
-        }
-
-    def test_query_with_connection_url(manifest_str, mssql: SqlServerContainer):
-        connection_url = _to_connection_url(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == 1
-        assert result["dtypes"] is not None
-
-    def test_query_without_manifest(mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
-
-    def test_query_without_sql(manifest_str, mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
-
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
-
-    def test_query_with_dry_run(manifest_str, mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
-
-    def test_query_with_dry_run_and_invalid_sql(
-        manifest_str, mssql: SqlServerContainer
-    ):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert "Invalid object name 'X'" in response.text
-
-    @pytest.mark.skip(
-        reason="Ibis use non-nvarchar sql to get schema, it will get question mark. Wait https://github.com/ibis-project/ibis/pull/10490"
+async def test_query(client, manifest_str, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
     )
-    def test_query_non_ascii_column(manifest_str, mssql: SqlServerContainer):
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+        "616263",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int32",
+        "custkey": "int32",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+        "bytea_column": "object",
+    }
+
+
+async def test_query_with_connection_url(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_url = _to_connection_url(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
+
+
+async def test_query_without_manifest(client, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_query_without_sql(client, manifest_str, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_query_with_dry_run(client, manifest_str, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
+
+
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert "Invalid object name 'X'" in response.text
+
+
+@pytest.mark.skip(
+    reason="Ibis use non-nvarchar sql to get schema, it will get question mark. Wait https://github.com/ibis-project/ibis/pull/10490"
+)
+async def test_query_non_ascii_column(client, manifest_str, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT 1 AS "калона"',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["columns"] == ["калона"]
+
+
+async def test_validate_with_unknown_rule(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
+
+
+async def test_validate_rule_column_is_valid(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
+
+
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, mssql: SqlServerContainer
+):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = next(filter(lambda x: x["name"] == "dbo.orders", response.json()))
+    assert result["name"] == "dbo.orders"
+    assert result["primaryKey"] is not None
+    assert result["description"] == "This is a table comment"
+    assert result["properties"] == {
+        "catalog": "tempdb",
+        "schema": "dbo",
+        "table": "orders",
+    }
+    assert len(result["columns"]) == 9
+    assert result["columns"][8] == {
+        "name": "o_comment",
+        "nestedColumns": None,
+        "type": "VARCHAR",
+        "notNull": False,
+        "description": "This is a comment",
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+
+async def test_metadata_db_version(client, mssql: SqlServerContainer):
+    connection_info = _to_connection_info(mssql)
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert "Microsoft SQL Server 2019" in response.text
+
+
+async def test_password_with_special_characters(client):
+    pwd = "{R;3G1/8Al2AniRye"
+    with SqlServerContainer(
+        mssql_image,
+        dialect="mssql+pyodbc",
+        password=pwd,
+    ) as mssql:
         connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT 1 AS "калона"',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result["columns"] == ["калона"]
-
-    def test_validate_with_unknown_rule(manifest_str, mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
-
-    def test_validate_rule_column_is_valid(manifest_str, mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
-
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, mssql: SqlServerContainer
-    ):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
-
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, mssql: SqlServerContainer
-    ):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
-
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, mssql: SqlServerContainer
-    ):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
-
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
-
-    def test_metadata_list_tables(mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-
-        result = next(filter(lambda x: x["name"] == "dbo.orders", response.json()))
-        assert result["name"] == "dbo.orders"
-        assert result["primaryKey"] is not None
-        assert result["description"] == "This is a table comment"
-        assert result["properties"] == {
-            "catalog": "tempdb",
-            "schema": "dbo",
-            "table": "orders",
-        }
-        assert len(result["columns"]) == 9
-        assert result["columns"][8] == {
-            "name": "o_comment",
-            "nestedColumns": None,
-            "type": "VARCHAR",
-            "notNull": False,
-            "description": "This is a comment",
-            "properties": None,
-        }
-
-    def test_metadata_list_constraints(mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-
-    def test_metadata_db_version(mssql: SqlServerContainer):
-        connection_info = _to_connection_info(mssql)
-        response = client.post(
+        response = await client.post(
             url=f"{base_url}/metadata/version",
             json={"connectionInfo": connection_info},
         )
         assert response.status_code == 200
         assert "Microsoft SQL Server 2019" in response.text
 
-    def test_password_with_special_characters():
-        pwd = "{R;3G1/8Al2AniRye"
-        with SqlServerContainer(
-            mssql_image,
-            dialect="mssql+pyodbc",
-            password=pwd,
-        ) as mssql:
-            connection_info = _to_connection_info(mssql)
-            response = client.post(
-                url=f"{base_url}/metadata/version",
-                json={"connectionInfo": connection_info},
-            )
-            assert response.status_code == 200
-            assert "Microsoft SQL Server 2019" in response.text
 
-    def _to_connection_info(mssql: SqlServerContainer):
-        return {
-            "host": mssql.get_container_host_ip(),
-            "port": mssql.get_exposed_port(mssql.port),
-            "user": mssql.username,
-            "password": mssql.password,
-            "database": mssql.dbname,
-            "kwargs": {"TrustServerCertificate": "YES"},
-        }
+def _to_connection_info(mssql: SqlServerContainer):
+    return {
+        "host": mssql.get_container_host_ip(),
+        "port": mssql.get_exposed_port(mssql.port),
+        "user": mssql.username,
+        "password": mssql.password,
+        "database": mssql.dbname,
+        "kwargs": {"TrustServerCertificate": "YES"},
+    }
 
-    def _to_connection_url(mssql: SqlServerContainer):
-        info = _to_connection_info(mssql)
-        return f"mssql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=YES"
+
+def _to_connection_url(mssql: SqlServerContainer):
+    info = _to_connection_info(mssql)
+    return f"mssql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=YES"

--- a/ibis-server/tests/routers/v2/connector/test_mysql.py
+++ b/ibis-server/tests/routers/v2/connector/test_mysql.py
@@ -4,11 +4,9 @@ import orjson
 import pandas as pd
 import pytest
 import sqlalchemy
-from fastapi.testclient import TestClient
 from sqlalchemy import text
 from testcontainers.mysql import MySqlContainer
 
-from app.main import app
 from app.model.validator import rules
 from tests.conftest import file_path
 
@@ -78,7 +76,7 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -113,292 +111,309 @@ def mysql(request) -> MySqlContainer:
     return mysql
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000",
+        None,
+        "616263",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int32",
+        "custkey": "int32",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+        "bytea_column": "object",
+    }
 
-    def test_query(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            "172799.49",
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000",
-            None,
-            "616263",
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int32",
-            "custkey": "int32",
-            "orderstatus": "object",
-            "totalprice": "object",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-            "bytea_column": "object",
-        }
 
-    def test_query_with_connection_url(manifest_str, mysql: MySqlContainer):
-        connection_url = _to_connection_url(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == 1
-        assert result["dtypes"] is not None
+async def test_query_with_connection_url(client, manifest_str, mysql: MySqlContainer):
+    connection_url = _to_connection_url(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
 
-    def test_query_without_manifest(mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_sql(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_manifest(client, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
+async def test_query_without_sql(client, manifest_str, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
 
-    def test_validate_with_unknown_rule(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_rule_column_is_valid(manifest_str, mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, mysql: MySqlContainer
-    ):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
+async def test_query_with_dry_run(client, manifest_str, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, mysql: MySqlContainer
-    ):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, mysql: MySqlContainer
+):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, mysql: MySqlContainer
-    ):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
+async def test_validate_with_unknown_rule(client, manifest_str, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-    def test_metadata_list_tables(mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
 
-        result = next(filter(lambda x: x["name"] == "test.orders", response.json()))
-        assert result["name"] == "test.orders"
-        assert result["primaryKey"] is not None
-        assert result["description"] == "This is a table comment"
-        assert result["properties"] == {
-            "catalog": "",
-            "schema": "test",
-            "table": "orders",
-        }
-        assert len(result["columns"]) == 9
-        o_comment_column = next(
-            filter(lambda x: x["name"] == "o_comment", result["columns"])
-        )
-        assert o_comment_column == {
-            "name": "o_comment",
-            "nestedColumns": None,
-            "type": "VARCHAR",
-            "notNull": False,
-            "description": "This is a comment",
-            "properties": None,
-        }
+async def test_validate_rule_column_is_valid(
+    client, manifest_str, mysql: MySqlContainer
+):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-    def test_metadata_list_constraints(mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
 
-        result = response.json()[0]
-        assert result["constraintName"] is not None
-        assert result["constraintType"] is not None
-        assert result["constraintTable"] is not None
-        assert result["constraintColumn"] is not None
-        assert result["constraintedTable"] is not None
-        assert result["constraintedColumn"] is not None
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, mysql: MySqlContainer
+):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_metadata_db_version(mysql: MySqlContainer):
-        connection_info = _to_connection_info(mysql)
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert response.text == '"8.0.40"'
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
 
-    def _to_connection_info(mysql: MySqlContainer):
-        return {
-            "host": mysql.get_container_host_ip(),
-            "port": mysql.get_exposed_port(mysql.port),
-            "user": mysql.username,
-            "password": mysql.password,
-            "database": mysql.dbname,
-        }
 
-    def _to_connection_url(mysql: MySqlContainer):
-        info = _to_connection_info(mysql)
-        return f"mysql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, mysql: MySqlContainer
+):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, mysql: MySqlContainer
+):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = next(filter(lambda x: x["name"] == "test.orders", response.json()))
+    assert result["name"] == "test.orders"
+    assert result["primaryKey"] is not None
+    assert result["description"] == "This is a table comment"
+    assert result["properties"] == {
+        "catalog": "",
+        "schema": "test",
+        "table": "orders",
+    }
+    assert len(result["columns"]) == 9
+    o_comment_column = next(
+        filter(lambda x: x["name"] == "o_comment", result["columns"])
+    )
+    assert o_comment_column == {
+        "name": "o_comment",
+        "nestedColumns": None,
+        "type": "VARCHAR",
+        "notNull": False,
+        "description": "This is a comment",
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = response.json()[0]
+    assert result["constraintName"] is not None
+    assert result["constraintType"] is not None
+    assert result["constraintTable"] is not None
+    assert result["constraintColumn"] is not None
+    assert result["constraintedTable"] is not None
+    assert result["constraintedColumn"] is not None
+
+
+async def test_metadata_db_version(client, mysql: MySqlContainer):
+    connection_info = _to_connection_info(mysql)
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert response.text == '"8.0.40"'
+
+
+def _to_connection_info(mysql: MySqlContainer):
+    return {
+        "host": mysql.get_container_host_ip(),
+        "port": mysql.get_exposed_port(mysql.port),
+        "user": mysql.username,
+        "password": mysql.password,
+        "database": mysql.dbname,
+    }
+
+
+def _to_connection_url(mysql: MySqlContainer):
+    info = _to_connection_info(mysql)
+    return f"mysql://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -106,7 +106,7 @@ def manifest_str():
 
 @pytest.fixture(scope="module")
 def postgres(request) -> PostgresContainer:
-    pg = PostgresContainer("postgres:16.4-alpine").start()
+    pg = PostgresContainer("postgres:16-alpine").start()
     engine = sqlalchemy.create_engine(pg.get_connection_url())
     pd.read_parquet(file_path("resource/tpch/data/orders.parquet")).to_sql(
         "orders", engine, index=False

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -482,7 +482,7 @@ async def test_metadata_db_version(client, postgres: PostgresContainer):
         json={"connectionInfo": connection_info},
     )
     assert response.status_code == 200
-    assert "PostgreSQL 16.4" in response.text
+    assert "PostgreSQL 16" in response.text
 
 
 async def test_dry_plan(client, manifest_str):

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -6,11 +6,9 @@ import pandas as pd
 import psycopg2
 import pytest
 import sqlalchemy
-from fastapi.testclient import TestClient
 from sqlalchemy import text
 from testcontainers.postgres import PostgresContainer
 
-from app.main import app
 from app.model.validator import rules
 from tests.conftest import file_path
 
@@ -101,7 +99,7 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -123,369 +121,392 @@ def postgres(request) -> PostgresContainer:
     return pg
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+        "616263",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int32",
+        "custkey": "int32",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+        "bytea_column": "object",
+    }
 
-    def test_query(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
+
+async def test_query_with_connection_url(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_url = _to_connection_url(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
+
+
+async def test_query_with_dot_all(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    test_sqls = [
+        'SELECT "Customer".* FROM "Customer"',
+        'SELECT c.* FROM "Customer" AS c',
+        'SELECT c.* FROM "Customer" AS c JOIN "Orders" AS o ON c.custkey = o.custkey',
+    ]
+    for sql in test_sqls:
+        response = await client.post(
             url=f"{base_url}/query",
+            params={"limit": 1},
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
+                "sql": sql,
             },
         )
         assert response.status_code == 200
         result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+        assert len(result["columns"]) == 1  # Not include calculated column
         assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            "172799.49",
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            None,
-            "616263",
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int32",
-            "custkey": "int32",
-            "orderstatus": "object",
-            "totalprice": "object",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-            "bytea_column": "object",
-        }
+        assert result["dtypes"] is not None
 
-    def test_query_with_connection_url(manifest_str, postgres: PostgresContainer):
-        connection_url = _to_connection_url(postgres)
-        response = client.post(
+
+async def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_value_error(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_url = _to_connection_url(postgres)
+    part = urlparse(connection_url)
+    password_with_bracket = quote_plus(f"{part.password}[")
+    connection_url = part._replace(
+        netloc=f"{part.username}:{password_with_bracket}@{part.hostname}:{part.port}"
+    ).geturl()
+
+    with pytest.raises(
+        psycopg2.OperationalError,
+        match='FATAL:  password authentication failed for user "test"',
+    ):
+        await client.post(
             url=f"{base_url}/query",
+            params={"dryRun": True},
             json={
                 "connectionInfo": {"connectionUrl": connection_url},
                 "manifestStr": manifest_str,
                 "sql": 'SELECT * FROM "Orders" LIMIT 1',
             },
         )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == 1
-        assert result["dtypes"] is not None
 
-    def test_query_with_dot_all(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        test_sqls = [
-            'SELECT "Customer".* FROM "Customer"',
-            'SELECT c.* FROM "Customer" AS c',
-            'SELECT c.* FROM "Customer" AS c JOIN "Orders" AS o ON c.custkey = o.custkey',
-        ]
-        for sql in test_sqls:
-            response = client.post(
-                url=f"{base_url}/query",
-                params={"limit": 1},
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200
-            result = response.json()
-            assert len(result["columns"]) == 1  # Not include calculated column
-            assert len(result["data"]) == 1
-            assert result["dtypes"] is not None
 
-    def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_value_error(
-        manifest_str, postgres: PostgresContainer
-    ):
-        connection_url = _to_connection_url(postgres)
-        part = urlparse(connection_url)
-        password_with_bracket = quote_plus(f"{part.password}[")
-        connection_url = part._replace(
-            netloc=f"{part.username}:{password_with_bracket}@{part.hostname}:{part.port}"
-        ).geturl()
+async def test_query_with_limit(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders"',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-        with pytest.raises(
-            psycopg2.OperationalError,
-            match='FATAL:  password authentication failed for user "test"',
-        ):
-            client.post(
-                url=f"{base_url}/query",
-                params={"dryRun": True},
-                json={
-                    "connectionInfo": {"connectionUrl": connection_url},
-                    "manifestStr": manifest_str,
-                    "sql": 'SELECT * FROM "Orders" LIMIT 1',
-                },
-            )
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 10',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_with_limit(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders"',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
 
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 10',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+async def test_query_without_manifest(client, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_manifest(postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_sql(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_sql(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run_and_invalid_sql(
-        manifest_str, postgres: PostgresContainer
-    ):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
 
-    def test_validate_with_unknown_rule(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
+async def test_query_with_dry_run(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid(manifest_str, postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, postgres: PostgresContainer
-    ):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, postgres: PostgresContainer
-    ):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_validate_with_unknown_rule(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, postgres: PostgresContainer
-    ):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
+async def test_validate_rule_column_is_valid(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-    def test_metadata_list_tables(postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
 
-        result = next(filter(lambda x: x["name"] == "public.orders", response.json()))
-        assert result["name"] == "public.orders"
-        assert result["primaryKey"] is not None
-        assert result["description"] == "This is a table comment"
-        assert result["properties"] == {
-            "catalog": "test",
-            "schema": "public",
-            "table": "orders",
-        }
-        assert len(result["columns"]) == 9
-        assert result["columns"][8] == {
-            "name": "o_comment",
-            "nestedColumns": None,
-            "type": "TEXT",
-            "notNull": False,
-            "description": "This is a comment",
-            "properties": None,
-        }
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_metadata_list_constraints(postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_metadata_db_version(postgres: PostgresContainer):
-        connection_info = _to_connection_info(postgres)
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert "PostgreSQL 16.4" in response.text
 
-    def test_dry_plan(manifest_str):
-        response = client.post(
-            url=f"{base_url}/dry-plan",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT orderkey, order_cust_key FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def _to_connection_info(pg: PostgresContainer):
-        return {
-            "host": pg.get_container_host_ip(),
-            "port": pg.get_exposed_port(pg.port),
-            "user": pg.username,
-            "password": pg.password,
-            "database": pg.dbname,
-        }
 
-    def _to_connection_url(pg: PostgresContainer):
-        info = _to_connection_info(pg)
-        return f"postgres://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, postgres: PostgresContainer
+):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = next(filter(lambda x: x["name"] == "public.orders", response.json()))
+    assert result["name"] == "public.orders"
+    assert result["primaryKey"] is not None
+    assert result["description"] == "This is a table comment"
+    assert result["properties"] == {
+        "catalog": "test",
+        "schema": "public",
+        "table": "orders",
+    }
+    assert len(result["columns"]) == 9
+    assert result["columns"][8] == {
+        "name": "o_comment",
+        "nestedColumns": None,
+        "type": "TEXT",
+        "notNull": False,
+        "description": "This is a comment",
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+
+async def test_metadata_db_version(client, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert "PostgreSQL 16.4" in response.text
+
+
+async def test_dry_plan(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT orderkey, order_cust_key FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    assert response.text is not None
+
+
+def _to_connection_info(pg: PostgresContainer):
+    return {
+        "host": pg.get_container_host_ip(),
+        "port": pg.get_exposed_port(pg.port),
+        "user": pg.username,
+        "password": pg.password,
+        "database": pg.dbname,
+    }
+
+
+def _to_connection_url(pg: PostgresContainer):
+    info = _to_connection_info(pg)
+    return f"postgres://{info['user']}:{info['password']}@{info['host']}:{info['port']}/{info['database']}"

--- a/ibis-server/tests/routers/v2/connector/test_snowflake.py
+++ b/ibis-server/tests/routers/v2/connector/test_snowflake.py
@@ -3,9 +3,7 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from app.model.validator import rules
 
 pytestmark = pytest.mark.snowflake
@@ -69,240 +67,254 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY "orderkey" LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        36901,
+        "O",
+        "173665.47",
+        "1996-01-02",
+        "1_36901",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+    }
 
-    def test_query(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" ORDER BY "orderkey" LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            36901,
-            "O",
-            "173665.47",
-            "1996-01-02",
-            "1_36901",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            None,
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int64",
-            "custkey": "int64",
-            "orderstatus": "object",
-            "totalprice": "object",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-        }
 
-    def test_query_without_manifest():
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_manifest(client):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_sql(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_sql(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_with_unknown_rule(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
 
-    def test_validate_rule_column_is_valid(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
+async def test_query_with_dry_run(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
+async def test_query_with_dry_run_and_invalid_sql(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-    def test_validate_rule_column_is_valid_without_parameters(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_rule_column_is_valid_without_one_parameter(manifest_str):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
+async def test_validate_with_unknown_rule(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
 
-    def test_metadata_list_tables():
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        tables = response.json()
-        assert len(tables) == 8
-        table = next(filter(lambda t: t["name"] == "TPCH_SF1.ORDERS", tables))
-        assert table["name"] == "TPCH_SF1.ORDERS"
-        assert table["primaryKey"] is not None
-        assert table["description"] == "Orders data as defined by TPC-H"
-        assert table["properties"] == {
-            "catalog": "SNOWFLAKE_SAMPLE_DATA",
-            "schema": "TPCH_SF1",
-            "table": "ORDERS",
-        }
-        assert len(table["columns"]) == 9
-        column = next(filter(lambda c: c["name"] == "O_COMMENT", table["columns"]))
-        assert column == {
-            "name": "O_COMMENT",
-            "nestedColumns": None,
-            "type": "TEXT",
-            "notNull": True,
-            "description": None,
-            "properties": None,
-        }
+async def test_validate_rule_column_is_valid(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-    def test_metadata_list_constraints():
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
 
-        result = response.json()
-        assert len(result) == 0
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_metadata_get_version():
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
+
+
+async def test_validate_rule_column_is_valid_without_parameters(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) == 8
+    table = next(filter(lambda t: t["name"] == "TPCH_SF1.ORDERS", tables))
+    assert table["name"] == "TPCH_SF1.ORDERS"
+    assert table["primaryKey"] is not None
+    assert table["description"] == "Orders data as defined by TPC-H"
+    assert table["properties"] == {
+        "catalog": "SNOWFLAKE_SAMPLE_DATA",
+        "schema": "TPCH_SF1",
+        "table": "ORDERS",
+    }
+    assert len(table["columns"]) == 9
+    column = next(filter(lambda c: c["name"] == "O_COMMENT", table["columns"]))
+    assert column == {
+        "name": "O_COMMENT",
+        "nestedColumns": None,
+        "type": "TEXT",
+        "notNull": True,
+        "description": None,
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = response.json()
+    assert len(result) == 0
+
+
+async def test_metadata_get_version(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert response.text is not None

--- a/ibis-server/tests/routers/v2/connector/test_trino.py
+++ b/ibis-server/tests/routers/v2/connector/test_trino.py
@@ -3,11 +3,9 @@ import time
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 from testcontainers.trino import TrinoContainer
 from trino.dbapi import connect
 
-from app.main import app
 from app.model.validator import rules
 
 pytestmark = pytest.mark.trino
@@ -90,336 +88,354 @@ def trino(request) -> TrinoContainer:
     return db
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        172799.49,
+        "1996-01-02",
+        "1_370",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000",
+        None,
+        "616263",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "float64",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "datetime64[ns]",
+        "bytea_column": "object",
+    }
 
-    def test_query(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            1,
-            370,
-            "O",
-            172799.49,
-            "1996-01-02",
-            "1_370",
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000",
-            None,
-            "616263",
-        ]
-        assert result["dtypes"] == {
-            "orderkey": "int64",
-            "custkey": "int64",
-            "orderstatus": "object",
-            "totalprice": "float64",
-            "orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "test_null_time": "datetime64[ns]",
-            "bytea_column": "object",
-        }
 
-    def test_query_with_connection_url(manifest_str, trino: TrinoContainer):
-        connection_url = _to_connection_url(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == 1
-        assert result["dtypes"] is not None
+async def test_query_with_connection_url(client, manifest_str, trino: TrinoContainer):
+    connection_url = _to_connection_url(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None
 
-    def test_query_with_limit(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders"',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
 
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 10',
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+async def test_query_with_limit(client, manifest_str, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders"',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_without_manifest(trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 10',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_without_sql(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_manifest(client, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": 'SELECT * FROM "Orders" LIMIT 1',
-            },
-        )
-        assert response.status_code == 204
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
+async def test_query_without_sql(client, manifest_str, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_with_unknown_rule(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
 
-    def test_validate_rule_column_is_valid(manifest_str, trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 204
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, trino: TrinoContainer
-    ):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
+async def test_query_with_dry_run(client, manifest_str, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, trino: TrinoContainer
-    ):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, trino: TrinoContainer
-    ):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "Orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, trino: TrinoContainer
+):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
 
-    def test_metadata_list_tables(trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        tables = response.json()
-        assert len(tables) == 8
-        table = next(filter(lambda t: t["name"] == "tpch.tiny.customer", tables))
-        assert len(table["columns"]) == 8
+async def test_validate_with_unknown_rule(client, manifest_str, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-        connection_info = {
-            "host": trino.get_container_host_ip(),
-            "port": trino.get_exposed_port(trino.port),
-            "catalog": "memory",
-            "schema": "default",
-            "user": "test",
-        }
-        response = client.post(
-            url=f"{base_url}/metadata/tables",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        tables = response.json()
-        assert len(tables) == 1
-        table = next(filter(lambda t: t["name"] == "memory.default.orders", tables))
-        assert table["name"] == "memory.default.orders"
-        assert table["primaryKey"] is not None
-        assert table["description"] == "This is a table comment"
-        assert table["properties"] == {
-            "catalog": "memory",
-            "schema": "default",
-            "table": "orders",
-        }
-        assert len(table["columns"]) == 9
-        column = next(filter(lambda c: c["name"] == "comment", table["columns"]))
-        assert column == {
-            "name": "comment",
-            "nestedColumns": None,
-            "type": "VARCHAR",
-            "notNull": False,
-            "description": "This is a comment",
-            "properties": None,
-        }
 
-    def test_metadata_list_constraints(trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/metadata/constraints",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
+async def test_validate_rule_column_is_valid(
+    client, manifest_str, trino: TrinoContainer
+):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-        result = response.json()
-        assert len(result) == 0
 
-    def test_metadata_db_version(trino: TrinoContainer):
-        connection_info = _to_connection_info(trino)
-        response = client.post(
-            url=f"{base_url}/metadata/version",
-            json={"connectionInfo": connection_info},
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, trino: TrinoContainer
+):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def _to_connection_info(trino: TrinoContainer):
-        return {
-            "host": trino.get_container_host_ip(),
-            "port": trino.get_exposed_port(trino.port),
-            "catalog": "tpch",
-            "schema": "tiny",
-            "user": "test",
-        }
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
 
-    def _to_connection_url(trino: TrinoContainer):
-        info = _to_connection_info(trino)
-        return f"trino://{info['user']}@{info['host']}:{info['port']}/{info['catalog']}/{info['schema']}"
+
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, trino: TrinoContainer
+):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, trino: TrinoContainer
+):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "Orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"
+
+
+async def test_metadata_list_tables(client, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) == 8
+    table = next(filter(lambda t: t["name"] == "tpch.tiny.customer", tables))
+    assert len(table["columns"]) == 8
+
+    connection_info = {
+        "host": trino.get_container_host_ip(),
+        "port": trino.get_exposed_port(trino.port),
+        "catalog": "memory",
+        "schema": "default",
+        "user": "test",
+    }
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    tables = response.json()
+    assert len(tables) == 1
+    table = next(filter(lambda t: t["name"] == "memory.default.orders", tables))
+    assert table["name"] == "memory.default.orders"
+    assert table["primaryKey"] is not None
+    assert table["description"] == "This is a table comment"
+    assert table["properties"] == {
+        "catalog": "memory",
+        "schema": "default",
+        "table": "orders",
+    }
+    assert len(table["columns"]) == 9
+    column = next(filter(lambda c: c["name"] == "comment", table["columns"]))
+    assert column == {
+        "name": "comment",
+        "nestedColumns": None,
+        "type": "VARCHAR",
+        "notNull": False,
+        "description": "This is a comment",
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+
+    result = response.json()
+    assert len(result) == 0
+
+
+async def test_metadata_db_version(client, trino: TrinoContainer):
+    connection_info = _to_connection_info(trino)
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={"connectionInfo": connection_info},
+    )
+    assert response.status_code == 200
+    assert response.text is not None
+
+
+def _to_connection_info(trino: TrinoContainer):
+    return {
+        "host": trino.get_container_host_ip(),
+        "port": trino.get_exposed_port(trino.port),
+        "catalog": "tpch",
+        "schema": "tiny",
+        "user": "test",
+    }
+
+
+def _to_connection_url(trino: TrinoContainer):
+    info = _to_connection_info(trino)
+    return f"trino://{info['user']}@{info['host']}:{info['port']}/{info['catalog']}/{info['schema']}"

--- a/ibis-server/tests/routers/v2/test_relationship_valid.py
+++ b/ibis-server/tests/routers/v2/test_relationship_valid.py
@@ -62,6 +62,13 @@ def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
+@pytest.fixture(scope="module")
+def postgres(request) -> PostgresContainer:
+    pg = PostgresContainer("postgres:16-alpine").start()
+    request.addfinalizer(pg.stop)
+    return pg
+
+
 async def test_validation_relationship(
     client, manifest_str, postgres: PostgresContainer
 ):

--- a/ibis-server/tests/routers/v3/connector/bigquery/conftest.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/conftest.py
@@ -9,6 +9,7 @@ from tests.conftest import file_path
 pytestmark = pytest.mark.bigquery
 
 base_url = "/v3/connector/bigquery"
+
 function_list_path = file_path("../resources/function_list")
 
 

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT
 from tests.routers.v3.connector.bigquery.conftest import base_url, function_list_path
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -31,119 +29,120 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 35
+    the_func = next(filter(lambda x: x["name"] == "string_agg", result))
+    assert the_func == {
+        "name": "string_agg",
+        "description": "Aggregates string values with a delimiter.",
+        "function_type": "aggregate",
+        "param_names": None,
+        "param_types": "text,text",
+        "return_type": "text",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 35
-        the_func = next(filter(lambda x: x["name"] == "string_agg", result))
-        assert the_func == {
-            "name": "string_agg",
-            "description": "Aggregates string values with a delimiter.",
-            "function_type": "aggregate",
-            "param_names": None,
-            "param_types": "text,text",
-            "return_type": "text",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT date_add(CAST('2024-01-01' AS DATE), 1) as col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [["2024-01-02"]],
+        "dtypes": {"col": "object"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_parser = FunctionCsvParser(os.path.join(function_list_path, "bigquery.csv"))
+    sql_generator = SqlTestGenerator("bigquery")
+    for function in csv_parser.parse():
+        # Skip window functions util https://github.com/Canner/wren-engine/issues/924 is resolved
+        if function.function_type == "window":
+            continue
+        # Skip functions with interval util https://github.com/Canner/wren-engine/issues/930 is resolved
+        if function.name in (
+            "date_add",
+            "date_sub",
+            "date_diff",
+            "date_trunc",
+            "timestamp_add",
+            "timestamp_sub",
+            "timestamp_diff",
+            "timestamp_trunc",
+        ):
+            continue
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT date_add(CAST('2024-01-01' AS DATE), 1) as col",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [["2024-01-02"]],
-            "dtypes": {"col": "object"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_parser = FunctionCsvParser(os.path.join(function_list_path, "bigquery.csv"))
-        sql_generator = SqlTestGenerator("bigquery")
-        for function in csv_parser.parse():
-            # Skip window functions util https://github.com/Canner/wren-engine/issues/924 is resolved
-            if function.function_type == "window":
-                continue
-            # Skip functions with interval util https://github.com/Canner/wren-engine/issues/930 is resolved
-            if function.name in (
-                "date_add",
-                "date_sub",
-                "date_diff",
-                "date_trunc",
-                "timestamp_add",
-                "timestamp_sub",
-                "timestamp_diff",
-                "timestamp_trunc",
-            ):
-                continue
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -2,9 +2,7 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from tests.routers.v3.connector.bigquery.conftest import base_url
 
 manifest = {
@@ -61,198 +59,206 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        "2024-01-16 04:00:00.000000 UTC",  # utc-5
+        "2024-07-16 03:00:00.000000 UTC",  # utc-4
+        "36485_1202",
+        1202,
+        "1992-06-06",
+        36485,
+        "F",
+        356711.63,
+    ]
+    assert result["dtypes"] == {
+        "o_orderkey": "int64",
+        "o_custkey": "int64",
+        "o_orderstatus": "object",
+        "o_totalprice": "float64",
+        "o_orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "dst_utc_minus_5": "object",
+        "dst_utc_minus_4": "object",
+    }
 
-    def test_query(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == len(manifest["models"][0]["columns"])
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            "2024-01-16 04:00:00.000000 UTC",  # utc-5
-            "2024-07-16 03:00:00.000000 UTC",  # utc-4
-            "36485_1202",
-            1202,
-            "1992-06-06",
-            36485,
-            "F",
-            356711.63,
-        ]
-        assert result["dtypes"] == {
-            "o_orderkey": "int64",
-            "o_custkey": "int64",
-            "o_orderstatus": "object",
-            "o_totalprice": "float64",
-            "o_orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "dst_utc_minus_5": "object",
-            "dst_utc_minus_4": "object",
-        }
 
-    def test_query_with_limit(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+async def test_query_with_limit(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 10",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 10",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_with_invalid_manifest_str(connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": "xxx",
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Base64 decode error: Invalid padding"
 
-    def test_query_without_manifest(connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_with_invalid_manifest_str(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": "xxx",
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Base64 decode error: Invalid padding"
 
-    def test_query_without_sql(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_without_manifest(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 204
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
+async def test_query_without_sql(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_timestamp_func(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT timestamp_millis(1000000) as millis, \
-                    timestamp_micros(1000000) as micros, \
-                    timestamp_seconds(1000000) as seconds",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 3
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            "1970-01-01 00:16:40.000000 UTC",
-            "1970-01-01 00:00:01.000000 UTC",
-            "1970-01-12 13:46:40.000000 UTC",
-        ]
-        assert result["dtypes"] == {
-            "millis": "object",
-            "micros": "object",
-            "seconds": "object",
-        }
 
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT timestamp with time zone '2000-01-01 10:00:00' < current_datetime() as compare",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            True,
-        ]
-        assert result["dtypes"] == {
-            "compare": "bool",
-        }
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_query_with_dry_run(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 204
+
+
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, connection_info
+):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
+
+
+async def test_timestamp_func(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT timestamp_millis(1000000) as millis, \
+                timestamp_micros(1000000) as micros, \
+                timestamp_seconds(1000000) as seconds",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 3
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        "1970-01-01 00:16:40.000000 UTC",
+        "1970-01-01 00:00:01.000000 UTC",
+        "1970-01-12 13:46:40.000000 UTC",
+    ]
+    assert result["dtypes"] == {
+        "millis": "object",
+        "micros": "object",
+        "seconds": "object",
+    }
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT timestamp with time zone '2000-01-01 10:00:00' < current_datetime() as compare",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        True,
+    ]
+    assert result["dtypes"] == {
+        "compare": "bool",
+    }

--- a/ibis-server/tests/routers/v3/connector/canner/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/canner/test_functions.py
@@ -2,10 +2,8 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.canner.conftest import base_url
 
@@ -29,7 +27,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -42,68 +40,68 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 30
+    the_func = next(filter(lambda x: x["name"] == "abs", result))
+    assert the_func == {
+        "name": "abs",
+        "description": "Returns absolute value of the argument",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": None,
+        "return_type": "double",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 30
-        the_func = next(filter(lambda x: x["name"] == "abs", result))
-        assert the_func == {
-            "name": "abs",
-            "description": "Returns absolute value of the argument",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": None,
-            "return_type": "double",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int32"},
-        }
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int32"},
+    }
 
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }

--- a/ibis-server/tests/routers/v3/connector/clickhouse/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/clickhouse/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.clickhouse.conftest import base_url
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -31,7 +29,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -44,84 +42,85 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 5
+    the_func = next(filter(lambda x: x["name"] == "abs", result))
+    assert the_func == {
+        "name": "abs",
+        "description": "Returns absolute value.",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": "Numeric",
+        "return_type": "Numeric",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 5
-        the_func = next(filter(lambda x: x["name"] == "abs", result))
-        assert the_func == {
-            "name": "abs",
-            "description": "Returns absolute value.",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": "Numeric",
-            "return_type": "Numeric",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "uint8"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "uint64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_path = os.path.join(function_list_path, "clickhouse.csv")
+    csv_parser = FunctionCsvParser(csv_path)
+    sql_generator = SqlTestGenerator("clickhouse")
+    for function in csv_parser.parse():
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "uint8"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "uint64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_path = os.path.join(function_list_path, "clickhouse.csv")
-        csv_parser = FunctionCsvParser(csv_path)
-        sql_generator = SqlTestGenerator("clickhouse")
-        for function in csv_parser.parse():
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/mssql/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/mssql/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.mssql.conftest import base_url
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -31,7 +29,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -44,83 +42,84 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 6
+    the_func = next(filter(lambda x: x["name"] == "floor", result))
+    assert the_func == {
+        "name": "floor",
+        "description": "Returns largest integer less than number.",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": "decimal",
+        "return_type": "Numeric",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 6
-        the_func = next(filter(lambda x: x["name"] == "floor", result))
-        assert the_func == {
-            "name": "floor",
-            "description": "Returns largest integer less than number.",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": "decimal",
-            "return_type": "Numeric",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int32"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_parser = FunctionCsvParser(os.path.join(function_list_path, "mssql.csv"))
+    sql_generator = SqlTestGenerator("mssql")
+    for function in csv_parser.parse():
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int32"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_parser = FunctionCsvParser(os.path.join(function_list_path, "mssql.csv"))
-        sql_generator = SqlTestGenerator("mssql")
-        for function in csv_parser.parse():
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/mysql/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/mysql/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.mysql.conftest import base_url
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -31,7 +29,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -44,83 +42,84 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 25
+    the_func = next(filter(lambda x: x["name"] == "abs", result))
+    assert the_func == {
+        "name": "abs",
+        "description": "Returns the absolute value of a number",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": "int",
+        "return_type": "int",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 25
-        the_func = next(filter(lambda x: x["name"] == "abs", result))
-        assert the_func == {
-            "name": "abs",
-            "description": "Returns the absolute value of a number",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": "int",
-            "return_type": "int",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int32"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_parser = FunctionCsvParser(os.path.join(function_list_path, "mysql.csv"))
+    sql_generator = SqlTestGenerator("mysql")
+    for function in csv_parser.parse():
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int32"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_parser = FunctionCsvParser(os.path.join(function_list_path, "mysql.csv"))
-        sql_generator = SqlTestGenerator("mysql")
-        for function in csv_parser.parse():
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
@@ -2,9 +2,7 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from tests.routers.v3.connector.postgres.conftest import base_url
 
 manifest = {
@@ -31,20 +29,18 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
-
-    def test_dry_plan(manifest_str):
-        response = client.post(
-            url=f"{base_url}/dry-plan",
-            json={
-                "manifestStr": manifest_str,
-                "sql": "SELECT o_orderkey, order_cust_key FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 200
-        assert response.text is not None
+async def test_dry_plan(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT o_orderkey, order_cust_key FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 200
+    assert response.text is not None

--- a/ibis-server/tests/routers/v3/connector/postgres/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.postgres.conftest import base_url
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -33,7 +31,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -46,83 +44,84 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 35
+    the_func = next(filter(lambda x: x["name"] == "extract", result))
+    assert the_func == {
+        "name": "extract",
+        "description": "Get subfield from date/time",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": "text,timestamp",
+        "return_type": "numeric",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 35
-        the_func = next(filter(lambda x: x["name"] == "extract", result))
-        assert the_func == {
-            "name": "extract",
-            "description": "Get subfield from date/time",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": "text,timestamp",
-            "return_type": "numeric",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int32"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_parser = FunctionCsvParser(os.path.join(function_list_path, "postgres.csv"))
+    sql_generator = SqlTestGenerator("postgres")
+    for function in csv_parser.parse():
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int32"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_parser = FunctionCsvParser(os.path.join(function_list_path, "postgres.csv"))
-        sql_generator = SqlTestGenerator("postgres")
-        for function in csv_parser.parse():
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -2,9 +2,7 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from tests.routers.v3.connector.postgres.conftest import base_url
 
 manifest = {
@@ -94,226 +92,235 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_query(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 10
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        "2024-01-16 04:00:00.000000 UTC",  # utc-5
+        "2024-07-16 03:00:00.000000 UTC",  # utc-4
+        172799.49,
+        "1_370",
+        370,
+        "1996-01-02",
+        1,
+        "O",
+    ]
+    assert result["dtypes"] == {
+        "o_orderkey": "int32",
+        "o_custkey": "int32",
+        "o_orderstatus": "object",
+        "o_totalprice_double": "float64",
+        "o_orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "dst_utc_minus_5": "object",
+        "dst_utc_minus_4": "object",
+    }
 
-    def test_query(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 10
-        assert len(result["data"]) == 1
-        assert result["data"][0] == [
-            "2024-01-01 23:59:59.000000",
-            "2024-01-01 23:59:59.000000 UTC",
-            "2024-01-16 04:00:00.000000 UTC",  # utc-5
-            "2024-07-16 03:00:00.000000 UTC",  # utc-4
-            172799.49,
-            "1_370",
-            370,
-            "1996-01-02",
-            1,
-            "O",
-        ]
-        assert result["dtypes"] == {
-            "o_orderkey": "int32",
-            "o_custkey": "int32",
-            "o_orderstatus": "object",
-            "o_totalprice_double": "float64",
-            "o_orderdate": "object",
-            "order_cust_key": "object",
-            "timestamp": "object",
-            "timestamptz": "object",
-            "dst_utc_minus_5": "object",
-            "dst_utc_minus_4": "object",
-        }
 
-    def test_query_with_connection_url(manifest_str, connection_url):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": {"connectionUrl": connection_url},
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 10
-        assert len(result["data"]) == 1
-        assert result["data"][0][0] == "2024-01-01 23:59:59.000000"
-        assert result["dtypes"] is not None
+async def test_query_with_connection_url(client, manifest_str, connection_url):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 10
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == "2024-01-01 23:59:59.000000"
+    assert result["dtypes"] is not None
 
-    def test_query_with_limit(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
 
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"limit": 1},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 10",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["data"]) == 1
+async def test_query_with_limit(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_with_invalid_manifest_str(connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": "xxx",
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Base64 decode error: Invalid padding"
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 10",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
 
-    def test_query_without_manifest(connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "manifestStr"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_without_sql(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "sql"]
-        assert result["detail"][0]["msg"] == "Field required"
+async def test_query_with_invalid_manifest_str(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": "xxx",
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Base64 decode error: Invalid padding"
 
-    def test_query_without_connection_info(manifest_str):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
-        assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM wren.public.orders LIMIT 1",
-            },
-        )
-        assert response.status_code == 204
+async def test_query_without_manifest(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "manifestStr"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-    def test_query_with_dry_run_and_invalid_sql(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            params={"dryRun": True},
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT * FROM X",
-            },
-        )
-        assert response.status_code == 422
-        assert response.text is not None
 
-    def test_query_to_many_calculation(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT sum_totalprice FROM wren.public.customer limit 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["dtypes"] == {"sum_totalprice": "float64"}
+async def test_query_without_sql(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "sql"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT sum_totalprice FROM wren.public.customer where c_name = 'Customer#000000001' limit 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 1
-        assert len(result["data"]) == 1
-        assert result["dtypes"] == {"sum_totalprice": "float64"}
 
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT c_name, sum_totalprice FROM wren.public.customer limit 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 2
-        assert len(result["data"]) == 1
-        assert result["dtypes"] == {"c_name": "object", "sum_totalprice": "float64"}
+async def test_query_without_connection_info(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "connectionInfo"]
+    assert result["detail"][0]["msg"] == "Field required"
 
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT c_custkey, sum_totalprice FROM wren.public.customer limit 1",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result["columns"]) == 2
-        assert len(result["data"]) == 1
-        assert result["dtypes"] == {"c_custkey": "int32", "sum_totalprice": "float64"}
+
+async def test_query_with_dry_run(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 1",
+        },
+    )
+    assert response.status_code == 204
+
+
+async def test_query_with_dry_run_and_invalid_sql(
+    client, manifest_str, connection_info
+):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM X",
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
+
+
+async def test_query_to_many_calculation(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT sum_totalprice FROM wren.public.customer limit 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["dtypes"] == {"sum_totalprice": "float64"}
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT sum_totalprice FROM wren.public.customer where c_name = 'Customer#000000001' limit 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 1
+    assert len(result["data"]) == 1
+    assert result["dtypes"] == {"sum_totalprice": "float64"}
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT c_name, sum_totalprice FROM wren.public.customer limit 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 2
+    assert len(result["data"]) == 1
+    assert result["dtypes"] == {"c_name": "object", "sum_totalprice": "float64"}
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT c_custkey, sum_totalprice FROM wren.public.customer limit 1",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 2
+    assert len(result["data"]) == 1
+    assert result["dtypes"] == {"c_custkey": "int32", "sum_totalprice": "float64"}

--- a/ibis-server/tests/routers/v3/connector/postgres/test_validate.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_validate.py
@@ -2,9 +2,7 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
-from app.main import app
 from app.model.validator import rules
 from tests.routers.v3.connector.postgres.conftest import base_url
 
@@ -26,97 +24,98 @@ manifest = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
 
-with TestClient(app) as client:
+async def test_validate_with_unknown_rule(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/validate/unknown_rule",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "orders", "columnName": "o_orderkey"},
+        },
+    )
+    assert response.status_code == 404
+    assert (
+        response.text == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
+    )
 
-    def test_validate_with_unknown_rule(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/validate/unknown_rule",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "orders", "columnName": "o_orderkey"},
-            },
-        )
-        assert response.status_code == 404
-        assert (
-            response.text
-            == f"The rule `unknown_rule` is not in the rules, rules: {rules}"
-        )
 
-    def test_validate_rule_column_is_valid(manifest_str, connection_info):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "orders", "columnName": "o_orderkey"},
-            },
-        )
-        assert response.status_code == 204
+async def test_validate_rule_column_is_valid(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "orders", "columnName": "o_orderkey"},
+        },
+    )
+    assert response.status_code == 204
 
-    def test_validate_rule_column_is_valid_with_invalid_parameters(
-        manifest_str, connection_info
-    ):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "X", "columnName": "o_orderkey"},
-            },
-        )
-        assert response.status_code == 422
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "orders", "columnName": "X"},
-            },
-        )
-        assert response.status_code == 422
+async def test_validate_rule_column_is_valid_with_invalid_parameters(
+    client, manifest_str, connection_info
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "X", "columnName": "o_orderkey"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_parameters(
-        manifest_str, connection_info
-    ):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={"connectionInfo": connection_info, "manifestStr": manifest_str},
-        )
-        assert response.status_code == 422
-        result = response.json()
-        assert result["detail"][0] is not None
-        assert result["detail"][0]["type"] == "missing"
-        assert result["detail"][0]["loc"] == ["body", "parameters"]
-        assert result["detail"][0]["msg"] == "Field required"
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "orders", "columnName": "X"},
+        },
+    )
+    assert response.status_code == 422
 
-    def test_validate_rule_column_is_valid_without_one_parameter(
-        manifest_str, connection_info
-    ):
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"modelName": "orders"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `columnName`"
 
-        response = client.post(
-            url=f"{base_url}/validate/column_is_valid",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "parameters": {"columnName": "o_orderkey"},
-            },
-        )
-        assert response.status_code == 422
-        assert response.text == "Missing required parameter: `modelName`"
+async def test_validate_rule_column_is_valid_without_parameters(
+    client, manifest_str, connection_info
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={"connectionInfo": connection_info, "manifestStr": manifest_str},
+    )
+    assert response.status_code == 422
+    result = response.json()
+    assert result["detail"][0] is not None
+    assert result["detail"][0]["type"] == "missing"
+    assert result["detail"][0]["loc"] == ["body", "parameters"]
+    assert result["detail"][0]["msg"] == "Field required"
+
+
+async def test_validate_rule_column_is_valid_without_one_parameter(
+    client, manifest_str, connection_info
+):
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "orders"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `columnName`"
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"columnName": "o_orderkey"},
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == "Missing required parameter: `modelName`"

--- a/ibis-server/tests/routers/v3/connector/snowflake/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/snowflake/test_functions.py
@@ -2,10 +2,8 @@ import base64
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.snowflake.conftest import base_url
 
@@ -29,7 +27,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -42,68 +40,68 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 70
+    the_func = next(filter(lambda x: x["name"] == "abs", result))
+    assert the_func == {
+        "name": "abs",
+        "description": "Returns absolute value",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": None,
+        "return_type": "number",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 70
-        the_func = next(filter(lambda x: x["name"] == "abs", result))
-        assert the_func == {
-            "name": "abs",
-            "description": "Returns absolute value",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": None,
-            "return_type": "number",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["COL"],
-            "data": [[1]],
-            "dtypes": {"COL": "int64"},
-        }
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["COL"],
+        "data": [[1]],
+        "dtypes": {"COL": "int64"},
+    }
 
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["COL"],
-            "data": [[1]],
-            "dtypes": {"COL": "int64"},
-        }
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["COL"],
+        "data": [[1]],
+        "dtypes": {"COL": "int64"},
+    }

--- a/ibis-server/tests/routers/v3/connector/trino/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/trino/test_functions.py
@@ -3,10 +3,8 @@ import os
 
 import orjson
 import pytest
-from fastapi.testclient import TestClient
 
 from app.config import get_config
-from app.main import app
 from tests.conftest import DATAFUSION_FUNCTION_COUNT, file_path
 from tests.routers.v3.connector.trino.conftest import base_url
 from tests.util import FunctionCsvParser, SqlTestGenerator
@@ -31,7 +29,7 @@ manifest = {
 function_list_path = file_path("../resources/function_list")
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def manifest_str():
     return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
 
@@ -44,83 +42,84 @@ def set_remote_function_list_path():
     config.set_remote_function_list_path(None)
 
 
-with TestClient(app) as client:
+async def test_function_list(client):
+    config = get_config()
 
-    def test_function_list():
-        config = get_config()
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
+    config.set_remote_function_list_path(function_list_path)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 9
+    the_func = next(filter(lambda x: x["name"] == "array_distinct", result))
+    assert the_func == {
+        "name": "array_distinct",
+        "description": "Removes duplicate values from array",
+        "function_type": "scalar",
+        "param_names": None,
+        "param_types": "array",
+        "return_type": "array",
+    }
 
-        config.set_remote_function_list_path(function_list_path)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT + 9
-        the_func = next(filter(lambda x: x["name"] == "array_distinct", result))
-        assert the_func == {
-            "name": "array_distinct",
-            "description": "Removes duplicate values from array",
-            "function_type": "scalar",
-            "param_names": None,
-            "param_types": "array",
-            "return_type": "array",
-        }
+    config.set_remote_function_list_path(None)
+    response = await client.get(url=f"{base_url}/functions")
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-        config.set_remote_function_list_path(None)
-        response = client.get(url=f"{base_url}/functions")
-        assert response.status_code == 200
-        result = response.json()
-        assert len(result) == DATAFUSION_FUNCTION_COUNT
 
-    def test_scalar_function(manifest_str: str, connection_info):
-        response = client.post(
+async def test_scalar_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT ABS(-1) AS col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int32"},
+    }
+
+
+async def test_aggregate_function(client, manifest_str: str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result == {
+        "columns": ["col"],
+        "data": [[1]],
+        "dtypes": {"col": "int64"},
+    }
+
+
+async def test_functions(client, manifest_str: str, connection_info):
+    csv_parser = FunctionCsvParser(os.path.join(function_list_path, "trino.csv"))
+    sql_generator = SqlTestGenerator("trino")
+    for function in csv_parser.parse():
+        sql = sql_generator.generate_sql(function)
+        response = await client.post(
             url=f"{base_url}/query",
             json={
                 "connectionInfo": connection_info,
                 "manifestStr": manifest_str,
-                "sql": "SELECT ABS(-1) AS col",
+                "sql": sql,
             },
         )
         assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int32"},
-        }
-
-    def test_aggregate_function(manifest_str: str, connection_info):
-        response = client.post(
-            url=f"{base_url}/query",
-            json={
-                "connectionInfo": connection_info,
-                "manifestStr": manifest_str,
-                "sql": "SELECT COUNT(*) AS col FROM (SELECT 1) AS temp_table",
-            },
-        )
-        assert response.status_code == 200
-        result = response.json()
-        assert result == {
-            "columns": ["col"],
-            "data": [[1]],
-            "dtypes": {"col": "int64"},
-        }
-
-    def test_functions(manifest_str: str, connection_info):
-        csv_parser = FunctionCsvParser(os.path.join(function_list_path, "trino.csv"))
-        sql_generator = SqlTestGenerator("trino")
-        for function in csv_parser.parse():
-            sql = sql_generator.generate_sql(function)
-            response = client.post(
-                url=f"{base_url}/query",
-                json={
-                    "connectionInfo": connection_info,
-                    "manifestStr": manifest_str,
-                    "sql": sql,
-                },
-            )
-            assert response.status_code == 200


### PR DESCRIPTION
Use `httpx.AsyncClient` to enhance performance.
- Use `httpx.Client` instead of `httpx.request` to keep the client for reducing handshake for every request.
- Use `httpx.AsyncClient` for better performance.
- Make test class with AsyncClient

Additional information
https://fastapi.tiangolo.com/advanced/async-tests/
https://fastapi.tiangolo.com/async/
https://anyio.readthedocs.io/en/stable/testing.html