### PR TITLE
chore: use lifespan and depends

### DIFF
--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -1,4 +1,4 @@
-import asyncio
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from uuid import uuid4
 
@@ -9,7 +9,7 @@ from loguru import logger
 from starlette.responses import PlainTextResponse
 
 from app.config import get_config
-from app.mdl.java_engine import get_java_engine_connector
+from app.mdl.java_engine import JavaEngineConnector, get_java_engine_connector
 from app.middleware import ProcessTimeMiddleware, RequestLogMiddleware
 from app.model import ConfigModel, CustomHttpError
 from app.routers import v2, v3
@@ -18,14 +18,9 @@ get_config().init_logger()
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
-    java_engine_connector = get_java_engine_connector()
-    java_engine_connector.start()
-    asyncio.create_task(java_engine_connector.warmup())  # noqa: RUF006
-
-    yield
-
-    await java_engine_connector.close()
+async def lifespan(app: FastAPI) -> AsyncIterator[dict[str, JavaEngineConnector]]:
+    async with get_java_engine_connector() as java_engine_connector:
+        yield {"java_engine_connector": java_engine_connector}
 
 
 app = FastAPI(lifespan=lifespan)


### PR DESCRIPTION
Should make the resource depend on FastAPI.

Follow this tips
https://github.com/kludex/fastapi-tips?tab=readme-ov-file#6-use-lifespan-state-instead-of-appstate
https://github.com/kludex/fastapi-tips?tab=readme-ov-file#9-your-dependencies-may-be-running-on-threads
He is a maintainer of [Uvicorn](https://github.com/encode/uvicorn) and [Starlette](https://github.com/encode/starlette), and  also considered a [FastAPI Expert](https://fastapi.tiangolo.com/fastapi-people/#experts).