### PR TITLE
fix(core): remove unused check to fix union syntax

### DIFF
--- a/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
+++ b/wren-base/src/main/java/io/wren/base/sqlrewrite/analyzer/StatementAnalyzer.java
@@ -70,10 +70,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.QueryUtil.getQualifiedName;
 import static io.trino.sql.parser.AstBuilder.DUCKDB_TABLE_FUNCTIONS;
-import static io.wren.base.metadata.StandardErrorCode.TYPE_MISMATCH;
 import static io.wren.base.sqlrewrite.Utils.toCatalogSchemaTableName;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
@@ -508,23 +506,7 @@ public final class StatementAnalyzer
             checkState(node.getRelations().size() >= 2);
             List<RelationType> relationTypes = node.getRelations().stream()
                     .map(relation -> process(relation, scope).getRelationType()).collect(toImmutableList());
-            String setOperationName = node.getClass().getSimpleName().toUpperCase(ENGLISH);
             List<Field> outputFields = relationTypes.get(0).getFields();
-            for (RelationType relationType : relationTypes) {
-                int outputFieldSize = outputFields.size();
-                int descFieldSize = relationType.getFields().size();
-                if (outputFieldSize != descFieldSize) {
-                    throw SemanticExceptions.semanticException(
-                            TYPE_MISMATCH,
-                            node,
-                            "%s query has different number of fields: %d, %d",
-                            setOperationName,
-                            outputFieldSize,
-                            descFieldSize);
-                }
-
-                // TODO: check type compatibility
-            }
 
             return createAndAssignScope(node, scope, new RelationType(outputFields));
         }

--- a/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
+++ b/wren-tests/src/test/java/io/wren/testing/duckdb/TestWrenWithDuckDB.java
@@ -251,4 +251,11 @@ public class TestWrenWithDuckDB
                         column("totalprice", "DECIMAL(15,2)"),
                         column("orderdate", "DATE")));
     }
+
+    @Test
+    public void testUnionDifferentModel()
+    {
+        QueryResultDto queryResultDto = query(manifest, "select custkey from Orders union select custkey from Customer limit 100");
+        assertThat(queryResultDto.getColumns().size()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
# Description
Because the scope analysis isn't fully finished in the Java engine, the check for the union schema is wrong. The Java engine's main purpose is to be a pure SQL planner. We don't need to do too many checks. Just focus on collecting which columns and models are required.
This PR removes the checks for the union's input to ensure the union works well.