### PR TITLE
ci(release): fix missing tag

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -69,6 +69,15 @@ jobs:
     outputs:
       next_version: ${{ steps.next_version.outputs.value }}
       maven_version: ${{ steps.maven_prepare_release.outputs.version_number }}
+  push-tag:
+    needs: prepare-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push tag
+        run: |
+          git tag -a ${{ needs.prepare-version.outputs.next_version }} -m "Release ${{ needs.prepare-version.outputs.next_version }}"
+          git push origin ${{ needs.prepare-version.outputs.next_version }}
   gh-releasse:
     needs: prepare-version
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow https://github.com/Canner/wren-engine/pull/994
We mistakenly remove the tag.
The `action-gh-release` does not create a tag. We need to generate a tag by ourselves.