### PR TITLE
ci(release): remove unused job for push-tag

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -64,20 +64,12 @@ jobs:
             version_number=$(./mvnw --quiet help:evaluate -Dexpression=project.version -DforceStdout | sed -n 's/^\(.*\)-SNAPSHOT/\1/p')
             ./mvnw release:prepare -B -DreleaseVersion=${version_number}
           fi
+          # push the release commit and tag from maven release:prepare
           git push
           echo "version_number=$version_number" >> $GITHUB_OUTPUT
     outputs:
       next_version: ${{ steps.next_version.outputs.value }}
       maven_version: ${{ steps.maven_prepare_release.outputs.version_number }}
-  push-tag:
-    needs: prepare-version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Push tag
-        run: |
-          git tag -a ${{ needs.prepare-version.outputs.next_version }} -m "Release ${{ needs.prepare-version.outputs.next_version }}"
-          git push origin ${{ needs.prepare-version.outputs.next_version }}
   gh-releasse:
     needs: prepare-version
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because `maven release:prepare` will create a new version tag. So we don't need to make the tag ourselves.