### PR TITLE
chore: add class State and use state instead of singleton

### DIFF
--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import TypedDict
 from uuid import uuid4
 
 from asgi_correlation_id import CorrelationIdMiddleware
@@ -9,7 +10,7 @@ from loguru import logger
 from starlette.responses import PlainTextResponse
 
 from app.config import get_config
-from app.mdl.java_engine import JavaEngineConnector, get_java_engine_connector
+from app.mdl.java_engine import JavaEngineConnector
 from app.middleware import ProcessTimeMiddleware, RequestLogMiddleware
 from app.model import ConfigModel, CustomHttpError
 from app.routers import v2, v3
@@ -17,9 +18,13 @@ from app.routers import v2, v3
 get_config().init_logger()
 
 
+class State(TypedDict):
+    java_engine_connector: JavaEngineConnector
+
+
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[dict[str, JavaEngineConnector]]:
-    async with get_java_engine_connector() as java_engine_connector:
+async def lifespan(app: FastAPI) -> AsyncIterator[State]:
+    async with JavaEngineConnector() as java_engine_connector:
         yield {"java_engine_connector": java_engine_connector}
 
 

--- a/ibis-server/app/main.py
+++ b/ibis-server/app/main.py
@@ -18,6 +18,8 @@ from app.routers import v2, v3
 get_config().init_logger()
 
 
+# Define the state of the application
+# Use state to store the singleton instance
 class State(TypedDict):
     java_engine_connector: JavaEngineConnector
 

--- a/ibis-server/app/mdl/java_engine.py
+++ b/ibis-server/app/mdl/java_engine.py
@@ -4,12 +4,11 @@ import httpx
 from orjson import orjson
 
 from app.config import get_config
-from app.pattern import Singleton
 
 wren_engine_endpoint = get_config().wren_engine_endpoint
 
 
-class JavaEngineConnector(metaclass=Singleton):
+class JavaEngineConnector:
     def __init__(self):
         self.client = httpx.AsyncClient(
             base_url=wren_engine_endpoint,

--- a/ibis-server/app/mdl/java_engine.py
+++ b/ibis-server/app/mdl/java_engine.py
@@ -4,17 +4,9 @@ import httpx
 from orjson import orjson
 
 from app.config import get_config
+from app.pattern import Singleton
 
 wren_engine_endpoint = get_config().wren_engine_endpoint
-
-
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]
 
 
 class JavaEngineConnector(metaclass=Singleton):
@@ -58,7 +50,3 @@ class JavaEngineConnector(metaclass=Singleton):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
-
-
-def get_java_engine_connector() -> JavaEngineConnector:
-    return JavaEngineConnector()

--- a/ibis-server/app/pattern/__init__.py
+++ b/ibis-server/app/pattern/__init__.py
@@ -1,0 +1,7 @@
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/ibis-server/app/pattern/__init__.py
+++ b/ibis-server/app/pattern/__init__.py
@@ -1,7 +1,0 @@
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
-        return cls._instances[cls]


### PR DESCRIPTION
Add class `State` for lifespan and use state of lifespan instead of Singleton and remove unused `get_java_engine_connector` function