### PR TITLE
feat(extract): handle extraction failed

### DIFF
--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -617,7 +617,7 @@ async def test_keyword_filter(client, manifest_str):
         url=f"{base_url}/dry-plan",
         json={
             "manifestStr": manifest_str,
-            "sql": 'SELECT count(*) FILTER(WHERE orders.o_orderkey != NULL) FROM "Orders"',
+            "sql": 'SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM "Orders"',
         },
     )
     assert response.status_code == 200
@@ -634,7 +634,7 @@ async def test_query_with_keyword_filter(client, manifest_str, postgres):
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
-            "sql": 'SELECT count(*) FILTER(WHERE orders.o_orderkey != NULL) FROM "Orders"',
+            "sql": 'SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM "Orders"',
         },
     )
     assert response.status_code == 200

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -275,7 +275,10 @@ async def test_query_with_invalid_manifest_str(
         },
     )
     assert response.status_code == 422
-    assert response.text == "Base64 decode error: Invalid padding"
+    assert (
+        "com.fasterxml.jackson.core.JsonParseException: Unexpected character"
+        in response.text
+    )
 
 
 async def test_query_without_manifest(client, postgres: PostgresContainer):

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -356,6 +356,19 @@ async def test_query_with_dry_run_and_invalid_sql(
     assert response.text is not None
 
 
+async def test_query_with_keyword_filter(client, manifest_str, postgres):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT count(*) FILTER(WHERE orderkey IS NOT NULL) FROM "Orders"',
+        },
+    )
+    assert response.status_code == 200
+
+
 async def test_validate_with_unknown_rule(
     client, manifest_str, postgres: PostgresContainer
 ):
@@ -610,34 +623,6 @@ async def test_model_substitute_non_existent_column(
     )
     assert response.status_code == 422
     assert 'column "x" does not exist' in response.text
-
-
-async def test_keyword_filter(client, manifest_str):
-    response = await client.post(
-        url=f"{base_url}/dry-plan",
-        json={
-            "manifestStr": manifest_str,
-            "sql": 'SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM "Orders"',
-        },
-    )
-    assert response.status_code == 200
-    assert response.text is not None
-
-
-@pytest.mark.skip(
-    reason="ibis get schema via creating temporary view, the syntax is not supported with filter"
-)
-async def test_query_with_keyword_filter(client, manifest_str, postgres):
-    connection_info = _to_connection_info(postgres)
-    response = await client.post(
-        url=f"{base_url}/query",
-        json={
-            "connectionInfo": connection_info,
-            "manifestStr": manifest_str,
-            "sql": 'SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM "Orders"',
-        },
-    )
-    assert response.status_code == 200
 
 
 def _to_connection_info(pg: PostgresContainer):

--- a/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
@@ -44,16 +44,3 @@ async def test_dry_plan(client, manifest_str):
     )
     assert response.status_code == 200
     assert response.text is not None
-
-
-@pytest.mark.skip(reason="Datafusion does not implement filter yet")
-async def test_keyword_filter(client, manifest_str):
-    response = await client.post(
-        url=f"{base_url}/dry-plan",
-        json={
-            "manifestStr": manifest_str,
-            "sql": "SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM wren.public.orders",
-        },
-    )
-    assert response.status_code == 200
-    assert response.text is not None

--- a/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
@@ -52,7 +52,7 @@ async def test_keyword_filter(client, manifest_str):
         url=f"{base_url}/dry-plan",
         json={
             "manifestStr": manifest_str,
-            "sql": "SELECT count(*) FILTER(WHERE orders.o_orderkey != NULL) FROM wren.public.orders",
+            "sql": "SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM wren.public.orders",
         },
     )
     assert response.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_dry_plan.py
@@ -44,3 +44,16 @@ async def test_dry_plan(client, manifest_str):
     )
     assert response.status_code == 200
     assert response.text is not None
+
+
+@pytest.mark.skip(reason="Datafusion does not implement filter yet")
+async def test_keyword_filter(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT count(*) FILTER(WHERE orders.o_orderkey != NULL) FROM wren.public.orders",
+        },
+    )
+    assert response.status_code == 200
+    assert response.text is not None

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -324,3 +324,17 @@ async def test_query_to_many_calculation(client, manifest_str, connection_info):
     assert len(result["columns"]) == 2
     assert len(result["data"]) == 1
     assert result["dtypes"] == {"c_custkey": "int32", "sum_totalprice": "float64"}
+
+
+@pytest.mark.skip(reason="Datafusion does not implement filter yet")
+async def test_query_with_keyword_filter(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT count(*) FILTER(WHERE o_orderkey != NULL) FROM wren.public.orders",
+        },
+    )
+    assert response.status_code == 200
+    assert response.text is not None


### PR DESCRIPTION
Resolve #1004
In v2, log the error and use the original manifest when it failed
However, in v3, the error is still raised.