### PR TITLE
fix: fix the context typo for build-image flow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -123,7 +123,7 @@ jobs:
           build-contexts: |
             wren-core-py=./wren-core-py
             wren-core=./wren-core
-            wren-core=./wren-core-base
+            wren-core-base=./wren-core-base
           outputs: type=image,name=${{ env.IBIS_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |


### PR DESCRIPTION
Fix the typo in the action flow.

Has been tested:
https://github.com/Canner/wren-engine/actions/runs/12479200940