### PR TITLE
chore(ci): simplify the CI and image building

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ./docker
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             WREN_VERSION=${{ steps.prepare.outputs.WREN_VERSION }}
@@ -91,8 +91,6 @@ jobs:
         arch:
           - runner: ubuntu-latest
             platform: linux/amd64
-          - runner: linux_arm64_runner
-            platform: linux/arm64
     runs-on: ${{ matrix.arch.runner }}
     steps:
       - name: Prepare platform

--- a/.github/workflows/wren-core-base.yml
+++ b/.github/workflows/wren-core-base.yml
@@ -35,9 +35,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ./wren-core/target/
+            ./wren-core-base/target/
           # this key equals the ones on `linux-build-lib` for re-use
-          key: cargo-cache-benchmark-${{ hashFiles('wren-core/Cargo.toml') }}
+          key: cargo-cache-benchmark-${{ hashFiles('wren-core-base/Cargo.toml') }}
 
       - name: Check datafusion-common without default features
         run: cargo check --all-targets

--- a/.github/workflows/wren-core-base.yml
+++ b/.github/workflows/wren-core-base.yml
@@ -39,7 +39,7 @@ jobs:
           # this key equals the ones on `linux-build-lib` for re-use
           key: cargo-cache-benchmark-${{ hashFiles('wren-core-base/Cargo.toml') }}
 
-      - name: Check datafusion-common without default features
+      - name: Check all target
         run: cargo check --all-targets
 
   # Run tests

--- a/.github/workflows/wren-core-base.yml
+++ b/.github/workflows/wren-core-base.yml
@@ -1,0 +1,129 @@
+name: Rust
+
+on:
+  pull_request:
+    paths:
+      - 'wren-core-base/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: wren-core-base
+
+jobs:
+  # Check crate compiles
+  linux-build-lib:
+    name: cargo check
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-builder
+        with:
+          rust-version: stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ./wren-core/target/
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-benchmark-${{ hashFiles('wren-core/Cargo.toml') }}
+
+      - name: Check datafusion-common without default features
+        run: cargo check --all-targets
+
+  # Run tests
+  linux-test:
+    name: cargo test (amd64)
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-builder
+        with:
+          rust-version: stable
+      - name: Run tests (excluding doctests)
+        run: cargo test --lib --tests --bins
+      - name: Verify Working Directory Clean
+        run: git diff --exit-code
+
+  macos-aarch64:
+    name: cargo test (macos-aarch64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-macos-aarch64-builder
+      - name: Run tests (excluding doctests)
+        shell: bash
+        run: cargo test --lib --tests --bins
+
+  check-fmt:
+    name: Check cargo fmt
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-builder
+        with:
+          rust-version: stable
+      - name: Run
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-builder
+        with:
+          rust-version: stable
+      - name: Install Clippy
+        run: rustup component add clippy
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  cargo-toml-formatting-checks:
+    name: check Cargo.toml formatting
+    needs: [ linux-build-lib ]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/rust/setup-builder
+        with:
+          rust-version: stable
+      - name: Install taplo
+        run: cargo +stable install taplo-cli --version ^0.9 --locked
+      # if you encounter an error, try running 'taplo format' to fix the formatting automatically.
+      - name: Check Cargo.toml formatting
+        run: taplo format --check

--- a/.github/workflows/wren-core.yml
+++ b/.github/workflows/wren-core.yml
@@ -62,33 +62,6 @@ jobs:
       - name: Verify Working Directory Clean
         run: git diff --exit-code
 
-  windows:
-    name: cargo test (win64)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/rust/setup-windows-builder
-      - name: Run tests (excluding doctests)
-        shell: bash
-        run: |
-          cargo test --lib --tests --bins
-
-  macos:
-    name: cargo test (macos)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/rust/setup-macos-builder
-      - name: Run tests (excluding doctests)
-        shell: bash
-        run: cargo test --lib --tests --bins
-
   macos-aarch64:
     name: cargo test (macos-aarch64)
     runs-on: macos-14

--- a/.github/workflows/wren-core.yml
+++ b/.github/workflows/wren-core.yml
@@ -39,7 +39,7 @@ jobs:
           # this key equals the ones on `linux-build-lib` for re-use
           key: cargo-cache-benchmark-${{ hashFiles('wren-core/Cargo.toml') }}
 
-      - name: Check datafusion-common without default features
+      - name: Check all targets
         run: cargo check --all-targets
 
   # Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ wren-server/etc
 __pycache__/
 venv/
 **/.env*
+**/.venv/
 **/*.so


### PR DESCRIPTION
# Description
- Remove the testing for windows and mac(intel) platform.
- Add CI flow for wren-core-base
- Build amd64 image for testing image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for automating the build and testing processes of a Rust project.

- **Improvements**
	- Streamlined existing workflows by focusing on Linux and macOS ARM architecture, removing support for Windows and standard macOS.
	- Added a rule to the `.gitignore` file to prevent tracking of `.venv` directories.

- **Bug Fixes**
	- Removed support for building images for the ARM64 platform in the build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->