### PR TITLE
chore(ibis): Added support for MySQL SSL connection

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -95,6 +95,9 @@ class MySqlConnectionInfo(BaseModel):
     database: SecretStr
     user: SecretStr
     password: SecretStr
+    kwargs: dict[str, str] | None = Field(
+        description="Additional keyword arguments to pass to PyMySQL", default=None
+    )
 
 
 class ConnectionUrl(BaseModel):

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -131,6 +131,7 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=info.password.get_secret_value(),
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod


### PR DESCRIPTION
### Description
This PR allows receiving SSL-related configurations (e.g., client key, certificate authority file path) from the frontend and passing them to ibis to establish a secure MySQL connection.

### Related Issue
https://github.com/Canner/WrenAI/issues/886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced MySQL connection configuration by adding support for additional keyword arguments
	- Introduced more flexible connection parameters for MySQL database connections

- **Improvements**
	- Expanded `MySqlConnectionInfo` to allow optional custom connection settings
	- Improved connection method to handle extra configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->