### PR TITLE
feat(ibis): Added BE Support for MySQL SSL Connection

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from enum import Enum
 
 from pydantic import BaseModel, Field, SecretStr
 from starlette.status import (
@@ -209,3 +210,9 @@ class UnprocessableEntityError(CustomHttpError):
 
 class NotFoundError(CustomHttpError):
     status_code = HTTP_404_NOT_FOUND
+
+
+class SSLMode(str, Enum):
+    DISABLED = "disabled"
+    ENABLED = "enabled"
+    VERIFY_CA = "verify_ca"

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -99,6 +99,8 @@ class MySqlConnectionInfo(BaseModel):
     database: SecretStr
     user: SecretStr
     password: SecretStr
+    ssl_mode: SecretStr = Field(alias="sslMode")
+    ssl_ca: SecretStr | None = Field(alias="sslCA", default=None)
     kwargs: dict[str, str] | None = Field(
         description="Additional keyword arguments to pass to PyMySQL", default=None
     )

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -99,7 +99,7 @@ class MySqlConnectionInfo(BaseModel):
     database: SecretStr
     user: SecretStr
     password: SecretStr
-    ssl_mode: SecretStr = Field(alias="sslMode")
+    ssl_mode: SecretStr | None = Field(alias="sslMode", default=None)
     ssl_ca: SecretStr | None = Field(alias="sslCA", default=None)
     kwargs: dict[str, str] | None = Field(
         description="Additional keyword arguments to pass to PyMySQL", default=None

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -29,14 +29,9 @@ from app.model import (
     QuerySnowflakeDTO,
     QueryTrinoDTO,
     SnowflakeConnectionInfo,
+    SSLMode,
     TrinoConnectionInfo,
 )
-
-
-class SSLMode(str, Enum):
-    DISABLE = "Disable"
-    REQUIRE = "Require"
-    VERIFY_CA = "Verify CA"
 
 
 class DataSource(StrEnum):
@@ -194,13 +189,13 @@ class DataSourceExtension(Enum):
             info.ssl_mode.get_secret_value() if hasattr(info, "ssl_mode") else None
         )
 
-        if not ssl_mode or ssl_mode == SSLMode.DISABLE:
+        if not ssl_mode or ssl_mode == SSLMode.DISABLED:
             return None
 
         ctx = ssl.create_default_context()
         ctx.check_hostname = False
 
-        if ssl_mode == SSLMode.REQUIRE:
+        if ssl_mode == SSLMode.ENABLED:
             ctx.verify_mode = ssl.CERT_NONE
         elif ssl_mode == SSLMode.VERIFY_CA:
             ctx.verify_mode = ssl.CERT_REQUIRED

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import base64
+import ssl
 from enum import Enum, StrEnum, auto
 from json import loads
+from typing import Optional
 
 import ibis
 from google.oauth2 import service_account
@@ -29,6 +31,12 @@ from app.model import (
     SnowflakeConnectionInfo,
     TrinoConnectionInfo,
 )
+
+
+class SSLMode(str, Enum):
+    DISABLE = "Disable"
+    REQUIRE = "Require"
+    VERIFY_CA = "Verify CA"
 
 
 class DataSource(StrEnum):
@@ -130,15 +138,19 @@ class DataSourceExtension(Enum):
             **info.kwargs if info.kwargs else dict(),
         )
 
-    @staticmethod
-    def get_mysql_connection(info: MySqlConnectionInfo) -> BaseBackend:
+    @classmethod
+    def get_mysql_connection(cls, info: MySqlConnectionInfo) -> BaseBackend:
+        ssl_context = cls._create_ssl_context(info)
+        kwargs = {"ssl": ssl_context} if ssl_context else {}
+        if info.kwargs:
+            kwargs.update(info.kwargs)
         return ibis.mysql.connect(
             host=info.host.get_secret_value(),
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=info.password.get_secret_value(),
-            **info.kwargs if info.kwargs else dict(),
+            **kwargs,
         )
 
     @staticmethod
@@ -175,3 +187,25 @@ class DataSourceExtension(Enum):
     @staticmethod
     def _escape_special_characters_for_odbc(value: str) -> str:
         return "{" + value.replace("}", "}}") + "}"
+
+    @staticmethod
+    def _create_ssl_context(info: ConnectionInfo) -> Optional[ssl.SSLContext]:
+        ssl_mode = info.ssl_mode.get_secret_value()
+
+        if ssl_mode == SSLMode.DISABLE:
+            return None
+
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+
+        if ssl_mode == SSLMode.REQUIRE:
+            ctx.verify_mode = ssl.CERT_NONE
+        elif ssl_mode == SSLMode.VERIFY_CA:
+            ctx.verify_mode = ssl.CERT_REQUIRED
+            ctx.load_verify_locations(
+                cadata=base64.b64decode(info.ssl_ca.get_secret_value()).decode("utf-8")
+                if info.ssl_ca
+                else None
+            )
+
+        return ctx

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -189,6 +189,9 @@ class DataSourceExtension(Enum):
             info.ssl_mode.get_secret_value() if hasattr(info, "ssl_mode") else None
         )
 
+        if ssl_mode == SSLMode.VERIFY_CA and not info.ssl_ca:
+            raise ValueError("SSL CA must be provided when SSL mode is VERIFY CA")
+
         if not ssl_mode or ssl_mode == SSLMode.DISABLED:
             return None
 

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -190,9 +190,11 @@ class DataSourceExtension(Enum):
 
     @staticmethod
     def _create_ssl_context(info: ConnectionInfo) -> Optional[ssl.SSLContext]:
-        ssl_mode = info.ssl_mode.get_secret_value()
+        ssl_mode = (
+            info.ssl_mode.get_secret_value() if hasattr(info, "ssl_mode") else None
+        )
 
-        if ssl_mode == SSLMode.DISABLE:
+        if not ssl_mode or ssl_mode == SSLMode.DISABLE:
             return None
 
         ctx = ssl.create_default_context()


### PR DESCRIPTION
### Description
This PR adds SSL configuration support for MySQL connections where two new fields, `ssl_mode` and `ssl_ca`, have been introduced to enable passing SSL-related parameters to PyMySQL from ibis under the hood.

### Related Issue
https://github.com/Canner/WrenAI/issues/886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added optional SSL configuration options for MySQL connections.
	- Introduced SSL mode settings (Disabled, Enabled, Verify CA).
	- Enhanced connection security with flexible SSL context management.
	- New testing capabilities for various SSL configurations in MySQL connections.
- **Bug Fixes**
	- Improved error handling for invalid SSL modes during MySQL connection attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->