### PR TITLE
fix(bigquery): fix nested column grouping logic

### DIFF
--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -382,11 +382,23 @@ async def test_validate_rule_column_is_valid_without_one_parameter(
 
 
 async def test_metadata_list_tables(client):
+    def _assert_nested_column(column):
+        if column["nestedColumns"] is not None:
+            for nested_column in column["nestedColumns"]:
+                assert ".".join(nested_column["name"].split(".")[:-1]) == column["name"]
+                _assert_nested_column(nested_column)
+
     response = await client.post(
         url=f"{base_url}/metadata/tables",
         json={"connectionInfo": connection_info},
     )
     assert response.status_code == 200
+    res = response.json()
+
+    # assert nest_column is correct
+    for table in res:
+        for column in table["columns"]:
+            _assert_nested_column(column)
 
 
 async def test_metadata_list_constraints(client):


### PR DESCRIPTION
Fix nested column grouping logic.
Should consider the order of nested columns might start from another nested column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced BigQuery metadata retrieval with improved handling of nested columns.
  - Introduced new methods for streamlined table and column metadata management.

- **Refactor**
  - Simplified column metadata extraction logic.
  - Improved sorting of results in the metadata retrieval process.

- **Tests**
  - Added validation for the structure of nested columns in test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->