### PR TITLE
chore: fix BigQuery v3 test cases

### DIFF
--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -47,7 +47,7 @@ async def test_function_list(client):
     response = await client.get(url=f"{base_url}/functions")
     assert response.status_code == 200
     result = response.json()
-    assert len(result) == DATAFUSION_FUNCTION_COUNT + 35
+    assert len(result) == DATAFUSION_FUNCTION_COUNT + 34
     the_func = next(filter(lambda x: x["name"] == "string_agg", result))
     assert the_func == {
         "name": "string_agg",

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -87,7 +87,7 @@ async def test_query(client, manifest_str, connection_info):
         "1992-06-06",
         36485,
         "F",
-        356711.63,
+        "356711.63",
     ]
     assert result["dtypes"] == {
         "o_orderkey": "int64",


### PR DESCRIPTION
# Changed
- the number of functions
- the format of floating value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test case for BigQuery function list to expect 34 functions instead of 35
	- Modified test query assertion to expect `o_totalprice` as a string value instead of a float

<!-- end of auto-generated comment: release notes by coderabbit.ai -->