### PR TITLE
feat(ibis): introduce S3 File connector

### DIFF
--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Run tests
         env:
           WREN_ENGINE_ENDPOINT: http://localhost:8080
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         run: poetry run pytest -m "not bigquery and not snowflake and not canner"
       - name: Test bigquery if need
         if: contains(github.event.pull_request.labels.*.name, 'bigquery')

--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -71,7 +71,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-        run: poetry run pytest -m "not bigquery and not snowflake and not canner"
+        run: poetry run pytest -m "not bigquery and not snowflake and not canner and not s3_file"
       - name: Test bigquery if need
         if: contains(github.event.pull_request.labels.*.name, 'bigquery')
         env:

--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -72,7 +72,7 @@ class Rewriter:
     def _get_write_dialect(cls, data_source: DataSource) -> str:
         if data_source == DataSource.canner:
             return "trino"
-        elif data_source == DataSource.local_file:
+        elif data_source in {DataSource.local_file, DataSource.s3_file}:
             return "duckdb"
         return data_source.name
 

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -56,6 +56,10 @@ class QueryLocalFileDTO(QueryDTO):
     connection_info: LocalFileConnectionInfo = connection_info_field
 
 
+class QueryS3FileDTO(QueryDTO):
+    connection_info: S3FileConnectionInfo = connection_info_field
+
+
 class BigQueryConnectionInfo(BaseModel):
     project_id: SecretStr
     dataset_id: SecretStr
@@ -147,6 +151,17 @@ class LocalFileConnectionInfo(BaseModel):
     )
 
 
+class S3FileConnectionInfo(BaseModel):
+    url: SecretStr = Field(description="the root path of the s3 bucket", default="/")
+    format: str = Field(
+        description="File format", default="csv", examples=["csv", "parquet", "json"]
+    )
+    bucket: SecretStr
+    region: SecretStr
+    access_key: SecretStr
+    secret_key: SecretStr
+
+
 ConnectionInfo = (
     BigQueryConnectionInfo
     | CannerConnectionInfo
@@ -157,6 +172,7 @@ ConnectionInfo = (
     | SnowflakeConnectionInfo
     | TrinoConnectionInfo
     | LocalFileConnectionInfo
+    | S3FileConnectionInfo
 )
 
 

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -10,6 +10,7 @@ import ibis.expr.schema as sch
 import ibis.formats
 import pandas as pd
 import sqlglot.expressions as sge
+from duckdb import HTTPException
 from google.cloud import bigquery
 from google.oauth2 import service_account
 from ibis import BaseBackend
@@ -163,10 +164,16 @@ class DuckDBConnector:
             init_duckdb_s3(self.connection, connection_info)
 
     def query(self, sql: str, limit: int) -> pd.DataFrame:
-        return self.connection.execute(sql).fetch_df().head(limit)
+        try:
+            return self.connection.execute(sql).fetch_df().head(limit)
+        except HTTPException as e:
+            raise UnprocessableEntityError(f"Failed to execute query: {e!s}")
 
     def dry_run(self, sql: str) -> None:
-        self.connection.execute(sql)
+        try:
+            self.connection.execute(sql)
+        except HTTPException as e:
+            raise QueryDryRunError(f"Failed to execute query: {e!s}")
 
 
 @cache

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -160,7 +160,7 @@ class DuckDBConnector:
 
         self.connection = duckdb.connect()
         if isinstance(connection_info, S3FileConnectionInfo):
-            init_duckdb_s3(connection_info)
+            init_duckdb_s3(self.connection, connection_info)
 
     def query(self, sql: str, limit: int) -> pd.DataFrame:
         return self.connection.execute(sql).fetch_df().head(limit)

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -26,6 +26,7 @@ from app.model import (
     QueryMSSqlDTO,
     QueryMySqlDTO,
     QueryPostgresDTO,
+    QueryS3FileDTO,
     QuerySnowflakeDTO,
     QueryTrinoDTO,
     SnowflakeConnectionInfo,
@@ -44,6 +45,7 @@ class DataSource(StrEnum):
     snowflake = auto()
     trino = auto()
     local_file = auto()
+    s3_file = auto()
 
     def get_connection(self, info: ConnectionInfo) -> BaseBackend:
         try:
@@ -68,6 +70,7 @@ class DataSourceExtension(Enum):
     snowflake = QuerySnowflakeDTO
     trino = QueryTrinoDTO
     local_file = QueryLocalFileDTO
+    s3_file = QueryS3FileDTO
 
     def __init__(self, dto: QueryDTO):
         self.dto = dto

--- a/ibis-server/app/model/metadata/factory.py
+++ b/ibis-server/app/model/metadata/factory.py
@@ -5,7 +5,7 @@ from app.model.metadata.clickhouse import ClickHouseMetadata
 from app.model.metadata.metadata import Metadata
 from app.model.metadata.mssql import MSSQLMetadata
 from app.model.metadata.mysql import MySQLMetadata
-from app.model.metadata.object_storage import LocalFileMetadata
+from app.model.metadata.object_storage import LocalFileMetadata, S3FileMetadata
 from app.model.metadata.postgres import PostgresMetadata
 from app.model.metadata.snowflake import SnowflakeMetadata
 from app.model.metadata.trino import TrinoMetadata
@@ -20,6 +20,7 @@ mapping = {
     DataSource.trino: TrinoMetadata,
     DataSource.snowflake: SnowflakeMetadata,
     DataSource.local_file: LocalFileMetadata,
+    DataSource.s3_file: S3FileMetadata,
 }
 
 

--- a/ibis-server/app/model/metadata/object_storage.py
+++ b/ibis-server/app/model/metadata/object_storage.py
@@ -166,7 +166,7 @@ class LocalFileMetadata(ObjectStorageMetadata):
 
 
 class S3FileMetadata(ObjectStorageMetadata):
-    def __init__(self, connection_info):
+    def __init__(self, connection_info: S3FileConnectionInfo):
         super().__init__(connection_info)
 
     def get_version(self):

--- a/ibis-server/app/model/utils.py
+++ b/ibis-server/app/model/utils.py
@@ -1,4 +1,4 @@
-from duckdb import DuckDBPyConnection
+from duckdb import DuckDBPyConnection, HTTPException
 
 from app.model import S3FileConnectionInfo
 
@@ -14,6 +14,9 @@ def init_duckdb_s3(
         REGION '{connection_info.region.get_secret_value()}'
     )
     """
-    result = connection.execute(create_secret).fetchone()
-    if result is None or not result[0]:
-        raise Exception("Failed to create secret")
+    try:
+        result = connection.execute(create_secret).fetchone()
+        if result is None or not result[0]:
+            raise Exception("Failed to create secret")
+    except HTTPException as e:
+        raise Exception("Failed to create secret", e)

--- a/ibis-server/app/model/utils.py
+++ b/ibis-server/app/model/utils.py
@@ -1,0 +1,19 @@
+from duckdb import DuckDBPyConnection
+
+from app.model import S3FileConnectionInfo
+
+
+def init_duckdb_s3(
+    connection: DuckDBPyConnection, connection_info: S3FileConnectionInfo
+):
+    create_secret = f"""
+    CREATE SECRET wren_s3 (
+        TYPE S3,
+        KEY_ID '{connection_info.access_key.get_secret_value()}',
+        SECRET '{connection_info.secret_key.get_secret_value()}',
+        REGION '{connection_info.region.get_secret_value()}'
+    )
+    """
+    result = connection.execute(create_secret).fetchone()
+    if result is None or not result[0]:
+        raise Exception("Failed to create secret")

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -64,6 +64,7 @@ markers = [
   "snowflake: mark a test as a snowflake test",
   "trino: mark a test as a trino test",
   "local_file: mark a test as a local file test",
+  "s3_file: mark a test as a s3 file test",
   "beta: mark a test as a test for beta versions of the engine",
 ]
 

--- a/ibis-server/tests/routers/v2/connector/test_local_file.py
+++ b/ibis-server/tests/routers/v2/connector/test_local_file.py
@@ -243,8 +243,8 @@ async def test_unsupported_format(client):
             },
         },
     )
-    assert response.status_code == 501
-    assert response.text == "Unsupported format: unsupported"
+    assert response.status_code == 422
+    assert response.text == "Failed to list files: Unsupported format: unsupported"
 
 
 async def test_list_parquet_files(client):

--- a/ibis-server/tests/routers/v2/connector/test_s3_file.py
+++ b/ibis-server/tests/routers/v2/connector/test_s3_file.py
@@ -290,8 +290,8 @@ async def test_unsupported_format(client):
             },
         },
     )
-    assert response.status_code == 501
-    assert response.text == "Unsupported format: unsupported"
+    assert response.status_code == 422
+    assert response.text == "Failed to list files: Unsupported format: unsupported"
 
 
 async def test_list_parquet_files(client):

--- a/ibis-server/tests/routers/v2/connector/test_s3_file.py
+++ b/ibis-server/tests/routers/v2/connector/test_s3_file.py
@@ -1,0 +1,473 @@
+import base64
+import os
+
+import orjson
+import pytest
+
+pytestmark = pytest.mark.s3_file
+
+access_key = os.getenv("AWS_ACCESS_KEY_ID")
+secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+region = os.getenv("AWS_REGION")
+bucket = os.getenv("AWS_S3_BUCKET")
+
+base_url = "/v2/connector/s3_file"
+manifest = {
+    "catalog": "my_calalog",
+    "schema": "my_schema",
+    "models": [
+        {
+            "name": "Orders",
+            "tableReference": {
+                "table": f"s3://{bucket}/tpch/data/orders.parquet",
+            },
+            "columns": [
+                {"name": "orderkey", "expression": "o_orderkey", "type": "integer"},
+                {"name": "custkey", "expression": "o_custkey", "type": "integer"},
+                {
+                    "name": "orderstatus",
+                    "expression": "o_orderstatus",
+                    "type": "varchar",
+                },
+                {
+                    "name": "totalprice",
+                    "expression": "o_totalprice",
+                    "type": "float",
+                },
+                {"name": "orderdate", "expression": "o_orderdate", "type": "date"},
+                {
+                    "name": "order_cust_key",
+                    "expression": "concat(o_orderkey, '_', o_custkey)",
+                    "type": "varchar",
+                },
+            ],
+            "primaryKey": "orderkey",
+        },
+        {
+            "name": "Customer",
+            "tableReference": {
+                "table": f"s3://{bucket}/tpch/data/customer.parquet",
+            },
+            "columns": [
+                {
+                    "name": "custkey",
+                    "type": "integer",
+                    "expression": "c_custkey",
+                },
+                {
+                    "name": "orders",
+                    "type": "Orders",
+                    "relationship": "CustomerOrders",
+                },
+                {
+                    "name": "sum_totalprice",
+                    "type": "float",
+                    "isCalculated": True,
+                    "expression": "sum(orders.totalprice)",
+                },
+            ],
+            "primaryKey": "custkey",
+        },
+    ],
+    "relationships": [
+        {
+            "name": "CustomerOrders",
+            "models": ["Customer", "Orders"],
+            "joinType": "ONE_TO_MANY",
+            "condition": "Customer.custkey = Orders.custkey",
+        }
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def manifest_str():
+    return base64.b64encode(orjson.dumps(manifest)).decode("utf-8")
+
+
+@pytest.fixture(scope="module")
+def connection_info() -> dict[str, str]:
+    return {
+        "url": "/tpch/data",
+        "format": "parquet",
+        "bucket": bucket,
+        "region": region,
+        "access_key": access_key,
+        "secret_key": secret_key,
+    }
+
+
+async def test_query(client, manifest_str, connection_info):
+    response = await client.post(
+        f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02 00:00:00.000000",
+        "1_370",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int32",
+        "custkey": "int32",
+        "orderstatus": "object",
+        "totalprice": "float64",
+        "orderdate": "object",
+        "order_cust_key": "object",
+    }
+
+
+async def test_query_with_limit(client, manifest_str, connection_info):
+    response = await client.post(
+        f"{base_url}/query",
+        params={"limit": 1},
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" limit 2',
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+
+
+async def test_query_calculated_field(client, manifest_str, connection_info):
+    response = await client.post(
+        f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT custkey, sum_totalprice FROM "Customer" WHERE custkey = 370',
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 2
+    assert len(result["data"]) == 1
+    assert result["data"][0] == [
+        370,
+        "2860895.79",
+    ]
+    assert result["dtypes"] == {
+        "custkey": "int32",
+        "sum_totalprice": "float64",
+    }
+
+
+async def test_dry_run(client, manifest_str, connection_info):
+    response = await client.post(
+        f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 204
+
+    response = await client.post(
+        f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "NotFound" LIMIT 1',
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 422
+    assert response.text is not None
+
+
+async def test_metadata_list_tables(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+
+    result = next(filter(lambda x: x["name"] == "orders", response.json()))
+    assert result["name"] == "orders"
+    assert result["primaryKey"] is None
+    assert result["description"] is None
+    assert result["properties"] == {
+        "catalog": None,
+        "schema": None,
+        "table": "orders",
+        "path": f"s3://{bucket}/tpch/data/orders.parquet",
+    }
+    assert len(result["columns"]) == 9
+    assert result["columns"][8] == {
+        "name": "o_comment",
+        "nestedColumns": None,
+        "type": "STRING",
+        "notNull": False,
+        "description": None,
+        "properties": None,
+    }
+
+
+async def test_metadata_list_constraints(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/metadata/constraints",
+        json={
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+
+
+async def test_metadata_db_version(client, connection_info):
+    response = await client.post(
+        url=f"{base_url}/metadata/version",
+        json={
+            "connectionInfo": connection_info,
+        },
+    )
+    assert response.status_code == 200
+    assert "S3" in response.text
+
+
+async def test_unsupported_format(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": {
+                "url": "/tpch/data",
+                "format": "unsupported",
+                "bucket": bucket,
+                "region": region,
+                "access_key": access_key,
+                "secret_key": secret_key,
+            },
+        },
+    )
+    assert response.status_code == 501
+    assert response.text == "Unsupported format: unsupported"
+
+
+async def test_list_parquet_files(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": {
+                "url": "/test_file_source",
+                "format": "parquet",
+                "bucket": bucket,
+                "region": region,
+                "access_key": access_key,
+                "secret_key": secret_key,
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == 2
+    table_names = [table["name"] for table in result]
+    assert "type-test-parquet" in table_names
+    assert "type-test" in table_names
+    columns = result[0]["columns"]
+    assert len(columns) == 23
+    assert columns[0]["name"] == "c_bigint"
+    assert columns[0]["type"] == "INT64"
+    assert columns[1]["name"] == "c_bit"
+    assert columns[1]["type"] == "STRING"
+    assert columns[2]["name"] == "c_blob"
+    assert columns[2]["type"] == "BYTES"
+    assert columns[3]["name"] == "c_boolean"
+    assert columns[3]["type"] == "BOOL"
+    assert columns[4]["name"] == "c_date"
+    assert columns[4]["type"] == "DATE"
+    assert columns[5]["name"] == "c_double"
+    assert columns[5]["type"] == "DOUBLE"
+    assert columns[6]["name"] == "c_float"
+    assert columns[6]["type"] == "FLOAT"
+    assert columns[7]["name"] == "c_integer"
+    assert columns[7]["type"] == "INT"
+    assert columns[8]["name"] == "c_hugeint"
+    assert columns[8]["type"] == "DOUBLE"
+    assert columns[9]["name"] == "c_interval"
+    assert columns[9]["type"] == "INTERVAL"
+    assert columns[10]["name"] == "c_json"
+    assert columns[10]["type"] == "JSON"
+    assert columns[11]["name"] == "c_smallint"
+    assert columns[11]["type"] == "INT2"
+    assert columns[12]["name"] == "c_time"
+    assert columns[12]["type"] == "TIME"
+    assert columns[13]["name"] == "c_timestamp"
+    assert columns[13]["type"] == "TIMESTAMP"
+    assert columns[14]["name"] == "c_timestamptz"
+    assert columns[14]["type"] == "TIMESTAMPTZ"
+    assert columns[15]["name"] == "c_tinyint"
+    assert columns[15]["type"] == "INT2"
+    assert columns[16]["name"] == "c_ubigint"
+    assert columns[16]["type"] == "INT64"
+    assert columns[17]["name"] == "c_uhugeint"
+    assert columns[17]["type"] == "DOUBLE"
+    assert columns[18]["name"] == "c_uinteger"
+    assert columns[18]["type"] == "INT"
+    assert columns[19]["name"] == "c_usmallint"
+    assert columns[19]["type"] == "INT2"
+    assert columns[20]["name"] == "c_utinyint"
+    assert columns[20]["type"] == "INT2"
+    assert columns[21]["name"] == "c_uuid"
+    assert columns[21]["type"] == "UUID"
+    assert columns[22]["name"] == "c_varchar"
+    assert columns[22]["type"] == "STRING"
+
+
+async def test_list_csv_files(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": {
+                "url": "/test_file_source",
+                "format": "csv",
+                "bucket": bucket,
+                "region": region,
+                "access_key": access_key,
+                "secret_key": secret_key,
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == 3
+    table_names = [table["name"] for table in result]
+    assert "type-test-csv" in table_names
+    assert "type-test" in table_names
+    # `invalid` will be considered as a one column csv file
+    assert "invalid" in table_names
+    columns = result[0]["columns"]
+    assert columns[0]["name"] == "c_bigint"
+    assert columns[0]["type"] == "INT64"
+    assert columns[1]["name"] == "c_bit"
+    assert columns[1]["type"] == "STRING"
+    assert columns[2]["name"] == "c_blob"
+    assert columns[2]["type"] == "STRING"
+    assert columns[3]["name"] == "c_boolean"
+    assert columns[3]["type"] == "BOOL"
+    assert columns[4]["name"] == "c_date"
+    assert columns[4]["type"] == "DATE"
+    assert columns[5]["name"] == "c_double"
+    assert columns[5]["type"] == "DOUBLE"
+    assert columns[6]["name"] == "c_float"
+    assert columns[6]["type"] == "DOUBLE"
+    assert columns[7]["name"] == "c_integer"
+    assert columns[7]["type"] == "INT64"
+    assert columns[8]["name"] == "c_hugeint"
+    assert columns[8]["type"] == "INT64"
+    assert columns[9]["name"] == "c_interval"
+    assert columns[9]["type"] == "STRING"
+    assert columns[10]["name"] == "c_json"
+    assert columns[10]["type"] == "STRING"
+    assert columns[11]["name"] == "c_smallint"
+    assert columns[11]["type"] == "INT64"
+    assert columns[12]["name"] == "c_time"
+    assert columns[12]["type"] == "TIME"
+    assert columns[13]["name"] == "c_timestamp"
+    assert columns[13]["type"] == "TIMESTAMP"
+    assert columns[14]["name"] == "c_timestamptz"
+    assert columns[14]["type"] == "TIMESTAMP"
+    assert columns[15]["name"] == "c_tinyint"
+    assert columns[15]["type"] == "INT64"
+    assert columns[16]["name"] == "c_ubigint"
+    assert columns[16]["type"] == "INT64"
+    assert columns[17]["name"] == "c_uhugeint"
+    assert columns[17]["type"] == "INT64"
+    assert columns[18]["name"] == "c_uinteger"
+    assert columns[18]["type"] == "INT64"
+    assert columns[19]["name"] == "c_usmallint"
+    assert columns[19]["type"] == "INT64"
+    assert columns[20]["name"] == "c_utinyint"
+    assert columns[20]["type"] == "INT64"
+    assert columns[21]["name"] == "c_uuid"
+    assert columns[21]["type"] == "STRING"
+    assert columns[22]["name"] == "c_varchar"
+    assert columns[22]["type"] == "STRING"
+
+
+async def test_list_json_files(client):
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": {
+                "url": "/test_file_source",
+                "format": "json",
+                "bucket": bucket,
+                "region": region,
+                "access_key": access_key,
+                "secret_key": secret_key,
+            },
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result) == 2
+    table_names = [table["name"] for table in result]
+    assert "type-test-json" in table_names
+    assert "type-test" in table_names
+
+    columns = result[0]["columns"]
+    assert columns[0]["name"] == "c_bigint"
+    assert columns[0]["type"] == "INT64"
+    # `c_bit` is a string in json which value is `00000000000000000000000000000001`
+    # It's considered as a UUID by DuckDB json reader.
+    assert columns[1]["name"] == "c_bit"
+    assert columns[1]["type"] == "UUID"
+    assert columns[2]["name"] == "c_blob"
+    assert columns[2]["type"] == "STRING"
+    assert columns[3]["name"] == "c_boolean"
+    assert columns[3]["type"] == "BOOL"
+    assert columns[4]["name"] == "c_date"
+    assert columns[4]["type"] == "DATE"
+    assert columns[5]["name"] == "c_double"
+    assert columns[5]["type"] == "DOUBLE"
+    assert columns[6]["name"] == "c_float"
+    assert columns[6]["type"] == "DOUBLE"
+    assert columns[7]["name"] == "c_integer"
+    assert columns[7]["type"] == "INT64"
+    assert columns[8]["name"] == "c_hugeint"
+    assert columns[8]["type"] == "DOUBLE"
+    assert columns[9]["name"] == "c_interval"
+    assert columns[9]["type"] == "STRING"
+    assert columns[10]["name"] == "c_json"
+    assert columns[10]["type"] == "UNKNOWN"
+    assert columns[11]["name"] == "c_smallint"
+    assert columns[11]["type"] == "INT64"
+    assert columns[12]["name"] == "c_time"
+    assert columns[12]["type"] == "TIME"
+    assert columns[13]["name"] == "c_timestamp"
+    assert columns[13]["type"] == "TIMESTAMP"
+    assert columns[14]["name"] == "c_timestamptz"
+    assert columns[14]["type"] == "STRING"
+    assert columns[15]["name"] == "c_tinyint"
+    assert columns[15]["type"] == "INT64"
+    assert columns[16]["name"] == "c_ubigint"
+    assert columns[16]["type"] == "INT64"
+    assert columns[17]["name"] == "c_uhugeint"
+    assert columns[17]["type"] == "DOUBLE"
+    assert columns[18]["name"] == "c_uinteger"
+    assert columns[18]["type"] == "INT64"
+    assert columns[19]["name"] == "c_usmallint"
+    assert columns[19]["type"] == "INT64"
+    assert columns[20]["name"] == "c_utinyint"
+    assert columns[20]["type"] == "INT64"
+    assert columns[21]["name"] == "c_uuid"
+    assert columns[21]["type"] == "UUID"
+    assert columns[22]["name"] == "c_varchar"
+    assert columns[22]["type"] == "STRING"

--- a/ibis-server/tests/routers/v2/connector/test_s3_file.py
+++ b/ibis-server/tests/routers/v2/connector/test_s3_file.py
@@ -191,6 +191,40 @@ async def test_dry_run(client, manifest_str, connection_info):
     assert response.text is not None
 
 
+async def test_query_with_invalid_connection_info(client, manifest_str):
+    response = await client.post(
+        f"{base_url}/query",
+        json={
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+            "connectionInfo": {
+                "url": "/tpch/data",
+                "format": "parquet",
+                "bucket": bucket,
+                "region": region,
+                "access_key": "invalid",
+                "secret_key": "invalid",
+            },
+        },
+    )
+    assert response.status_code == 422
+
+    response = await client.post(
+        url=f"{base_url}/metadata/tables",
+        json={
+            "connectionInfo": {
+                "url": "/tpch/data",
+                "format": "parquet",
+                "bucket": bucket,
+                "region": region,
+                "access_key": "invalid",
+                "secret_key": "invalid",
+            },
+        },
+    )
+    assert response.status_code == 422
+
+
 async def test_metadata_list_tables(client, connection_info):
     response = await client.post(
         url=f"{base_url}/metadata/tables",


### PR DESCRIPTION
# Description
- Introduce the S3 File connector.
- The usage is the same as the local file connector but the connection info differs.

## URL
```
/v2/connector/s3_file
/v3/connector/s3_file
```

## Connection Info
```json
{
        "url": "/tpch/data",
        "format": "parquet",
        "bucket": "s3-bucket-name",
        "region": "aws-region",
        "access_key": "1234568888",
        "secret_key": "sxxaa2311133sd"
}
```
- `url`: The root path of the dataset. (It doesn't include the bucket name)
- `format`: The specific file format.
- `bucket`: The bucket name.
- `region`: The aws region.
- `access_key`: The access key ID. (`AWS_ACCESS_KEY_ID`)
- `secret_kety`: The secret key. (`AWS_SECRET_ACCESS_KEY`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added support for S3 file data sources in the application.
  - Introduced new connection type for S3 file storage.
  - Enhanced metadata handling for S3 file connections.

- **Improvements**
  - Expanded data source management to include S3 file connections.
  - Improved error handling for S3 file operations.
  - Enhanced test execution with new filtering criteria.

- **Testing**
  - Implemented a comprehensive test suite for S3 file connector.
  - Added pytest markers for S3 file-related tests.
  - Updated error handling for unsupported formats in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->