### PR TITLE
feat(ibis): Enabled Passwordless Connection for Data Sources BE

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -82,7 +82,7 @@ class ClickHouseConnectionInfo(BaseModel):
     port: SecretStr
     database: SecretStr
     user: SecretStr
-    password: SecretStr
+    password: SecretStr | None = None
 
 
 class MSSqlConnectionInfo(BaseModel):
@@ -90,7 +90,7 @@ class MSSqlConnectionInfo(BaseModel):
     port: SecretStr
     database: SecretStr
     user: SecretStr
-    password: SecretStr
+    password: SecretStr | None = None
     driver: str = Field(default="ODBC Driver 18 for SQL Server")
     tds_version: str = Field(default="8.0", alias="TDS_Version")
     kwargs: dict[str, str] | None = Field(
@@ -103,7 +103,7 @@ class MySqlConnectionInfo(BaseModel):
     port: SecretStr
     database: SecretStr
     user: SecretStr
-    password: SecretStr
+    password: SecretStr | None = None
     ssl_mode: SecretStr | None = Field(alias="sslMode", default=None)
     ssl_ca: SecretStr | None = Field(alias="sslCA", default=None)
     kwargs: dict[str, str] | None = Field(
@@ -120,7 +120,7 @@ class PostgresConnectionInfo(BaseModel):
     port: SecretStr = Field(examples=[5432])
     database: SecretStr
     user: SecretStr
-    password: SecretStr
+    password: SecretStr | None = None
 
 
 class SnowflakeConnectionInfo(BaseModel):

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -118,7 +118,7 @@ class DataSourceExtension(Enum):
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
-            password=info.password.get_secret_value(),
+            password=(info.password and info.password.get_secret_value()),
         )
 
     @classmethod
@@ -128,8 +128,11 @@ class DataSourceExtension(Enum):
             port=info.port.get_secret_value(),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
-            password=cls._escape_special_characters_for_odbc(
-                info.password.get_secret_value()
+            password=(
+                info.password
+                and cls._escape_special_characters_for_odbc(
+                    info.password.get_secret_value()
+                )
             ),
             driver=info.driver,
             TDS_Version=info.tds_version,
@@ -147,7 +150,7 @@ class DataSourceExtension(Enum):
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
-            password=info.password.get_secret_value(),
+            password=(info.password and info.password.get_secret_value()),
             **kwargs,
         )
 
@@ -158,7 +161,7 @@ class DataSourceExtension(Enum):
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
-            password=info.password.get_secret_value(),
+            password=(info.password and info.password.get_secret_value()),
         )
 
     @staticmethod
@@ -189,7 +192,9 @@ class DataSourceExtension(Enum):
     @staticmethod
     def _create_ssl_context(info: ConnectionInfo) -> Optional[ssl.SSLContext]:
         ssl_mode = (
-            info.ssl_mode.get_secret_value() if hasattr(info, "ssl_mode") else None
+            info.ssl_mode.get_secret_value()
+            if hasattr(info, "ssl_mode") and info.ssl_mode
+            else None
         )
 
         if ssl_mode == SSLMode.VERIFY_CA and not info.ssl_ca:


### PR DESCRIPTION
### Description
This PR introduces support for passwordless connections to data sources such as `MySQL`, `PostgreSQL`, `MSSQL`, and `ClickHouse`. By setting default password value to None, users can now access these data sources without specifying a password.

**Note:** Passwordless connections are not supported for `Snowflake` [ref: [link](https://docs.snowflake.com/en/sql-reference/sql/create-user#optional-object-properties-objectproperties)]

> If no password is specified, the user cannot log into Snowflake until a password has been explicitly specified for them.

### Related Issue
https://github.com/Canner/WrenAI/issues/1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Made database connection passwords optional across multiple connection types
	- Improved error handling for password and SSL mode retrieval in database connections

- **Bug Fixes**
	- Added null checks to prevent potential runtime errors when accessing sensitive connection information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->