### PR TITLE
fix(model): bigquery, avoid fetching duplicated fields when fetching it

### DIFF
--- a/ibis-server/app/model/metadata/bigquery.py
+++ b/ibis-server/app/model/metadata/bigquery.py
@@ -48,7 +48,7 @@ class BigQueryMetadata(Metadata):
                 ON cf.table_name = c.table_name 
                 AND cf.column_name = c.column_name
             LEFT JOIN {dataset_id}.INFORMATION_SCHEMA.TABLE_OPTIONS table_options
-                ON c.table_name = table_options.table_name
+                ON c.table_name = table_options.table_name AND table_options.OPTION_NAME = 'description'
             WHERE cf.data_type != 'GEOGRAPHY'
                 AND cf.data_type NOT LIKE 'RANGE%'
             ORDER BY cf.field_path ASC


### PR DESCRIPTION
The issue is present since the implementation of the connector. It's trigger on our bigquery tables because we have partitionned tables.

Indeed the TABLE_OPTIONS view can have multiple entries for each field (in our case the description and the require_partition_filter values) thus with the left join fields were present for each entry in the TABLE_OPTIONS.

So only join of the value that we want i.e. the description.

This was leading to breaking the import of the metadata later because fields were duplicated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined the process that retrieves table descriptions, ensuring that only valid details are included. This update improves the accuracy of metadata displayed for tables in BigQuery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->