### PR TITLE
feat(bigquery): support to query BigQuery external table

### DIFF
--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -149,6 +149,12 @@ class BigQueryConnector(SimpleConnector):
                 credentials = service_account.Credentials.from_service_account_info(
                     credits_json
                 )
+                credentials = credentials.with_scopes(
+                    [
+                        "https://www.googleapis.com/auth/drive",
+                        "https://www.googleapis.com/auth/cloud-platform",
+                    ]
+                )
                 client = bigquery.Client(credentials=credentials)
                 ibis_schema_mapper = ibis.backends.bigquery.BigQuerySchema()
                 bq_fields = client.query(sql).result()

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -98,6 +98,10 @@ class DataSourceExtension(Enum):
         credentials = service_account.Credentials.from_service_account_info(
             credits_json
         )
+        credentials = credentials.with_scopes([
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/cloud-platform",
+        ])
         return ibis.bigquery.connect(
             project_id=info.project_id.get_secret_value(),
             dataset_id=info.dataset_id.get_secret_value(),

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -98,10 +98,12 @@ class DataSourceExtension(Enum):
         credentials = service_account.Credentials.from_service_account_info(
             credits_json
         )
-        credentials = credentials.with_scopes([
-            "https://www.googleapis.com/auth/drive",
-            "https://www.googleapis.com/auth/cloud-platform",
-        ])
+        credentials = credentials.with_scopes(
+            [
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/cloud-platform",
+            ]
+        )
         return ibis.bigquery.connect(
             project_id=info.project_id.get_secret_value(),
             dataset_id=info.dataset_id.get_secret_value(),


### PR DESCRIPTION
# Description
Refer to [Create credentials with scopes](https://cloud.google.com/bigquery/docs/samples/bigquery-auth-drive-scope#bigquery_auth_drive_scope-python). If a BigQuery table comes from an external data (e.g. google sheet), we need to set up require permission and scopes for the credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced integration with Google Cloud services by expanding authentication permissions, enabling more robust interactions with additional cloud functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->