### PR TITLE
fix(bigquery): correctly format the scientific notation decimal

### DIFF
--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -29,9 +29,13 @@ def _to_datetime_and_format(series: pd.Series) -> pd.Series:
 
 
 def _to_json_obj(df: pd.DataFrame) -> dict:
-    data = df.map(lambda x: f"{x:.9g}" if isinstance(x, float) else x).to_dict(
-        orient="split", index=False
-    )
+    data = df.map(
+        lambda x: f"{x:.9g}"
+        if isinstance(x, float)
+        else f"{x:.3f}"
+        if isinstance(x, decimal.Decimal)
+        else x
+    ).to_dict(orient="split")
 
     def default(obj):
         if pd.isna(obj):

--- a/ibis-server/tests/routers/v2/connector/test_bigquery.py
+++ b/ibis-server/tests/routers/v2/connector/test_bigquery.py
@@ -198,6 +198,20 @@ async def test_query_values(client, manifest_str):
     assert response.status_code == 204
 
 
+async def test_scientific_notation(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT cast(0 as numeric) as col",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["data"][0] == ["0.000"]
+
+
 async def test_query_empty_json(client, manifest_str):
     """Test the empty result with json column."""
     response = await client.post(


### PR DESCRIPTION
Fixes formatting issues in BigQuery when handling scientific notation decimals, ensuring accurate representation