### PR TITLE
chore(java): fix the maven test dependency

### DIFF
--- a/wren-base/pom.xml
+++ b/wren-base/pom.xml
@@ -149,6 +149,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/wren-tests/pom.xml
+++ b/wren-tests/pom.xml
@@ -123,6 +123,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Due to: 
- https://github.com/Canner/wren-engine/pull/1071

The JUnit dependency should be added in the POM file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configurations to enhance the testing framework for improved quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->