### PR TITLE
feat(ibis): pushdown the limit of the query request into SQL

### DIFF
--- a/ibis-server/app/mdl/rewriter.py
+++ b/ibis-server/app/mdl/rewriter.py
@@ -105,7 +105,7 @@ class ExternalEngineRewriter:
 
     @staticmethod
     def handle_extract_exception(e: Exception):
-        logger.error("Error when extracting manifest: {}", e)
+        logger.warning("Error when extracting manifest: {}", e)
 
 
 class EmbeddedEngineRewriter:

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -18,7 +18,7 @@ from app.model import (
 from app.model.connector import Connector
 from app.model.data_source import DataSource
 from app.model.validator import Validator
-from app.util import build_context, to_json
+from app.util import build_context, pushdown_limit, to_json
 
 router = APIRouter(prefix="/connector")
 tracer = trace.get_tracer(__name__)
@@ -38,9 +38,10 @@ async def query(
     with tracer.start_as_current_span(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ):
+        sql = pushdown_limit(dto.sql, limit)
         rewritten_sql = await Rewriter(
             dto.manifest_str, data_source=data_source, experiment=True
-        ).rewrite(dto.sql)
+        ).rewrite(sql)
         connector = Connector(data_source, dto.connection_info)
         if dry_run:
             connector.dry_run(rewritten_sql)

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -4,11 +4,11 @@ import decimal
 
 import orjson
 import pandas as pd
+import wren_core
 from fastapi import Header
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.propagate import extract
-import wren_core
 from pandas.core.dtypes.common import is_datetime64_any_dtype
 
 tracer = trace.get_tracer(__name__)
@@ -99,6 +99,7 @@ def build_context(headers: Header) -> Context:
     if headers is None:
         return None
     return extract(headers)
+
 
 @tracer.start_as_current_span("pushdown_limit", kind=trace.SpanKind.INTERNAL)
 def pushdown_limit(sql: str, limit: int | None) -> str:

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -100,6 +100,7 @@ def build_context(headers: Header) -> Context:
         return None
     return extract(headers)
 
+@tracer.start_as_current_span("pushdown_limit", kind=trace.SpanKind.INTERNAL)
 def pushdown_limit(sql: str, limit: int | None) -> str:
     ctx = wren_core.SessionContext()
     return ctx.pushdown_limit(sql, limit)

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -8,6 +8,7 @@ from fastapi import Header
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.propagate import extract
+import wren_core
 from pandas.core.dtypes.common import is_datetime64_any_dtype
 
 tracer = trace.get_tracer(__name__)
@@ -98,3 +99,7 @@ def build_context(headers: Header) -> Context:
     if headers is None:
         return None
     return extract(headers)
+
+def pushdown_limit(sql: str, limit: int | None) -> str:
+    ctx = wren_core.SessionContext()
+    return ctx.pushdown_limit(sql, limit)

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -312,7 +312,7 @@ async def test_limit_pushdown(client, manifest_str, postgres: PostgresContainer)
     )
     assert response.status_code == 200
     result = response.json()
-    assert len(result["data"]) == 2
+    assert len(result["data"]) == 1
 
 
 async def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_value_error(

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -285,6 +285,22 @@ SELECT
     assert result["data"][0][26] == "12300.00000"
 
 
+async def test_limit_pushdown(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 10},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 100',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 10
+
+
 async def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_value_error(
     client, manifest_str, postgres: PostgresContainer
 ):

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -300,6 +300,20 @@ async def test_limit_pushdown(client, manifest_str, postgres: PostgresContainer)
     result = response.json()
     assert len(result["data"]) == 10
 
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 10},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT count(*) FILTER (where orderkey > 10) FROM "Orders" LIMIT 100',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 2
+
 
 async def test_dry_run_with_connection_url_and_password_with_bracket_should_not_raise_value_error(
     client, manifest_str, postgres: PostgresContainer

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -338,3 +338,18 @@ async def test_query_with_keyword_filter(client, manifest_str, connection_info):
     )
     assert response.status_code == 200
     assert response.text is not None
+
+
+async def test_limit_pushdown(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"limit": 10},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 100",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 10

--- a/wren-core-py/src/errors.rs
+++ b/wren-core-py/src/errors.rs
@@ -1,3 +1,4 @@
+use std::num::ParseIntError;
 use base64::DecodeError;
 use pyo3::exceptions::PyException;
 use pyo3::PyErr;
@@ -51,6 +52,18 @@ impl From<serde_json::Error> for CoreError {
 impl From<wren_core::DataFusionError> for CoreError {
     fn from(err: wren_core::DataFusionError) -> Self {
         CoreError::new(&format!("DataFusion error: {}", err))
+    }
+}
+
+impl From<wren_core::parser::ParserError> for CoreError {
+    fn from(err: wren_core::parser::ParserError) -> Self {
+        CoreError::new(&format!("Parser error: {}", err))
+    }
+}
+
+impl From<ParseIntError> for CoreError {
+    fn from(err: ParseIntError) -> Self {
+        CoreError::new(&format!("ParseIntError: {}", err))
     }
 }
 

--- a/wren-core-py/tests/test_modeling_core.py
+++ b/wren-core-py/tests/test_modeling_core.py
@@ -205,3 +205,36 @@ def test_to_json_base64():
         decoded_manifest = json.loads(json_str)
         assert decoded_manifest["catalog"] == "my_catalog"
         assert len(decoded_manifest["models"]) == 3
+
+
+def test_limit_pushdown():
+    session_context = SessionContext()
+    sql = "SELECT * FROM my_catalog.my_schema.customer"
+    assert (
+        session_context.pushdown_limit(sql, 10)
+        == "SELECT * FROM my_catalog.my_schema.customer LIMIT 10"
+    )
+
+    sql = "SELECT * FROM my_catalog.my_schema.customer LIMIT 100"
+    assert (
+        session_context.pushdown_limit(sql, 10)
+        == "SELECT * FROM my_catalog.my_schema.customer LIMIT 10"
+    )
+
+    sql = "SELECT * FROM my_catalog.my_schema.customer LIMIT 10"
+    assert (
+        session_context.pushdown_limit(sql, 100)
+        == "SELECT * FROM my_catalog.my_schema.customer LIMIT 10"
+    )
+
+    sql = "SELECT * FROM my_catalog.my_schema.customer LIMIT 10 OFFSET 5"
+    assert (
+        session_context.pushdown_limit(sql, 100)
+        == "SELECT * FROM my_catalog.my_schema.customer LIMIT 10 OFFSET 5"
+    )
+
+    sql = "SELECT * FROM my_catalog.my_schema.customer LIMIT 100 OFFSET 5"
+    assert (
+        session_context.pushdown_limit(sql, 10)
+        == "SELECT * FROM my_catalog.my_schema.customer LIMIT 10 OFFSET 5"
+    )

--- a/wren-core/core/src/lib.rs
+++ b/wren-core/core/src/lib.rs
@@ -4,4 +4,5 @@ pub mod mdl;
 pub use datafusion::error::DataFusionError;
 pub use datafusion::logical_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 pub use datafusion::prelude::SessionContext;
+pub use datafusion::sql::sqlparser::*;
 pub use mdl::AnalyzedWrenMDL;


### PR DESCRIPTION
# Description
This PR introduces the way to push down the limit parameter into the SQL. If the SQL has the limit clause, the smaller one of them will be used in the SQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced SQL query processing now uniformly enforces user-specified limits, ensuring that result sets are consistently and accurately trimmed.
	- Introduced a new function for handling SQL limit pushdown, improving robustness in SQL processing.

- **Bug Fixes**
	- Improved error handling for SQL limit pushdown failures, retaining the original SQL query when necessary.

- **Tests**
	- Added comprehensive test coverage to validate the improved query limit functionality across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->