### PR TITLE
fix(core): disable ScalarSubqueryToJoin

### DIFF
--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -34,7 +34,6 @@ use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
 use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
 use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
 use datafusion::optimizer::replace_distinct_aggregate::ReplaceDistinctWithAggregate;
-use datafusion::optimizer::scalar_subquery_to_join::ScalarSubqueryToJoin;
 use datafusion::optimizer::unwrap_cast_in_comparison::UnwrapCastInComparison;
 use datafusion::optimizer::{AnalyzerRule, OptimizerRule};
 use datafusion::physical_plan::ExecutionPlan;
@@ -158,7 +157,8 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         Arc::new(ReplaceDistinctWithAggregate::new()),
         Arc::new(EliminateJoin::new()),
         Arc::new(DecorrelatePredicateSubquery::new()),
-        Arc::new(ScalarSubqueryToJoin::new()),
+        // Disable ScalarSubqueryToJoin to avoid generate invalid sql (join without condition)
+        // Arc::new(ScalarSubqueryToJoin::new()),
         Arc::new(ExtractEquijoinPredicate::new()),
         // Disable SimplifyExpressions to avoid apply some function locally
         // Arc::new(SimplifyExpressions::new()),


### PR DESCRIPTION
# Description
Before https://github.com/apache/datafusion/pull/15334 is fixed, we need to disable `ScalarSubqueryToJoin` temporarily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL query processing to avoid generating joins without conditions, ensuring valid SQL output.
- **Tests**
  - Enhanced test coverage to confirm correct handling of scalar subqueries and reliable query transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->