### PR TITLE
fix(core): handle the unnest table factor for the specific dialect

### DIFF
--- a/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -36,12 +36,18 @@ pub trait InnerDialect: Send + Sync {
     ) -> Result<Option<ast::Expr>> {
         Ok(None)
     }
+
+    /// A wrapper for [datafusion::sql::unparser::dialect::Dialect::unnest_as_table_factor].
+    fn unnest_as_table_factor(&self) -> bool {
+        false
+    }
 }
 
 /// [get_inner_dialect] returns the suitable InnerDialect for the given data source.
 pub fn get_inner_dialect(data_source: &DataSource) -> Box<dyn InnerDialect> {
     match data_source {
         DataSource::MySQL => Box::new(MySQLDialect {}),
+        DataSource::BigQuery => Box::new(BigQueryDialect {}),
         _ => Box::new(GenericDialect {}),
     }
 }
@@ -66,5 +72,25 @@ impl InnerDialect for MySQLDialect {
             "btrim" => scalar_function_to_sql_internal(unparser, "trim", args),
             _ => Ok(None),
         }
+    }
+}
+
+pub struct BigQueryDialect {}
+
+impl InnerDialect for BigQueryDialect {
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        function_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        match function_name {
+            "btrim" => scalar_function_to_sql_internal(unparser, "trim", args),
+            _ => Ok(None),
+        }
+    }
+
+    fn unnest_as_table_factor(&self) -> bool {
+        true
     }
 }

--- a/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -83,6 +83,10 @@ impl Dialect for WrenDialect {
             _ => Ok(None),
         }
     }
+
+    fn unnest_as_table_factor(&self) -> bool {
+        self.inner_dialect.unnest_as_table_factor()
+    }
 }
 
 impl Default for WrenDialect {


### PR DESCRIPTION
# Description
`unnest_as_table_factor` is required for the specific dialect only (e.g. BigQuery). We should enable it for BigQuery only.