### PR TITLE
chore(mcp): move to v3 query api

### DIFF
--- a/mcp-server/app/wren.py
+++ b/mcp-server/app/wren.py
@@ -41,7 +41,7 @@ async def make_query_request(sql: str, dry_run: bool = False):
     async with httpx.AsyncClient() as client:
         try:
             response = await client.post(
-                f"http://{WREN_URL}/v2/connector/{data_source}/query?dry_run={dry_run}",
+                f"http://{WREN_URL}/v3/connector/{data_source}/query?dry_run={dry_run}",
                 headers=headers,
                 json={
                     "sql": sql,


### PR DESCRIPTION
Using the v3 API instead of v2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the integration for executing SQL queries to use the latest API endpoint version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->