### PR TITLE
chore(mcp): update README mcp demo 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ Check our full article
 ## 🚀 Get Started with MCP 
 [MCP Server README](mcp-server/README.md)
 
-<video src="https://github.com/Canner/wren-engine/raw/main/misc/local-mcp-demo.mp4" controls="controls" style="max-width: 730px;">
-</video>
+https://github.com/Canner/wren-engine/raw/main/misc/local-mcp-demo.mp4
 
 ## 🤔 Concepts
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Check our full article
 ## 🚀 Get Started with MCP 
 [MCP Server README](mcp-server/README.md)
 
+<video src="https://github.com/Canner/wren-engine/raw/main/misc/local-mcp-demo.mp4" controls="controls" style="max-width: 730px;">
+</video>
 
 ## 🤔 Concepts
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Check our full article
 ## 🚀 Get Started with MCP 
 [MCP Server README](mcp-server/README.md)
 
-https://github.com/Canner/wren-engine/raw/main/misc/local-mcp-demo.mp4
+[Check out the comprehensive MCP guide](https://docs.getwren.ai/oss/engine/get_started/quickstart)
+
+<img src="./misc/list_table.gif" alt="List table" width="600" />   
+
 
 ## 🤔 Concepts
 


### PR DESCRIPTION
Since the original MP4 file is too large for GitHub to render directly in the README, we're using a GIF format instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a hyperlink directing users to a comprehensive MCP quickstart guide.
	- Incorporated an animated GIF to visually enhance the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->