### PR TITLE
chore(doc): Revert 'add mcp demo mp4'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ Check our full article
 ## 🚀 Get Started with MCP 
 [MCP Server README](mcp-server/README.md)
 
-<video src="https://github.com/Canner/wren-engine/raw/main/misc/local-mcp-demo.mp4" controls="controls" style="max-width: 730px;">
-</video>
 
 ## 🤔 Concepts
 


### PR DESCRIPTION
This reverts #1119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the demo video from the documentation, changing how users experience the local MCP demonstration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->