### PR TITLE
deps(core): upgrade to datafusion 0.46.1

### DIFF
--- a/wren-core-py/Cargo.lock
+++ b/wren-core-py/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "lexical-core",
  "num",
  "serde",
@@ -349,11 +349,11 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
- "bzip2 0.4.4",
+ "bzip2",
  "flate2",
  "futures-core",
  "memchr",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
+checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -505,16 +505,6 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
 
 [[package]]
 name = "bzip2"
@@ -747,16 +737,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b879c1aa3a85ecbfa376704f0fe4bfebae1a44a5d35faa4466bf85469b6a0e"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "arrow-ipc",
  "arrow-schema",
  "async-trait",
  "bytes",
- "bzip2 0.5.2",
+ "bzip2",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -798,9 +787,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e42f516243fe30137f2b7d5712611286baf8d1d758a46157bada7c35fdf38df"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -818,9 +806,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e495290c231d617f0a940860a885cb2f4c3efe46c1983c30d3fa12faf1ccb208"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -840,9 +827,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af67ddc82e1c8e6843c326ca13aa20e5420cce9f886b4e1ee39ea43defae3145"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -850,7 +836,7 @@ dependencies = [
  "base64",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "libc",
  "log",
  "object_store",
@@ -864,9 +850,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ee9403a2ec39183437825d232f556a5dee89f13f6fd78f8c7f8f999489e4ca"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "log",
  "tokio",
@@ -874,15 +859,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c8b7568b638dd309bcc1cdeb66776f233b110d44bdc6fd67ef1919f9ec9803"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "async-compression",
  "async-trait",
  "bytes",
- "bzip2 0.5.2",
+ "bzip2",
  "chrono",
  "datafusion-catalog",
  "datafusion-common",
@@ -908,15 +892,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8612c81304578a2e2b82d31caf8173312cb086a7a23a23556b9fff3ac7c18221"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 
 [[package]]
 name = "datafusion-execution"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3591e6d4900e57bad7f861f14f5c763f716da76553b0d037ec91c192c876f09c"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "dashmap",
@@ -933,9 +915,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033d0f6198d177f50a7721d80db141af15dd12f45ad6dce34e2cdbb6538e39d"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "chrono",
@@ -945,7 +926,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "paste",
  "recursive",
  "serde_json",
@@ -954,22 +935,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56def48a7dfb9f92aa18e18dfdffaca79b5383f03c59bb0107959c1698634557"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.14.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a79b703b42b0aac97485b84c6810c78114b0974a75a33514840ba0bbe0de38f"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -996,9 +975,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdad20375e85365ed262b5583955c308840efc6ff9271ff463cf86789adfb686"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -1017,9 +995,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff73249ee3cdc81ad04317d3b4231fc02a8c03a3a1b4b13953244e6443f6b498"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -1030,9 +1007,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20dcd70c58f17b7ce937866e43c75293a3250aadc1db830ad6d502967aaffb40"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1051,9 +1027,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac12628c3e43461118e95d5772f729e1cc39db883d8ee52e4b80038b0f614bbf"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1067,9 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03eb449555c7cc03bb61d43d90edef70d070d34bc4a0d8f7e358d157232f3220"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "datafusion-common",
  "datafusion-doc",
@@ -1084,9 +1058,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0c7606e568ee6a15d33a2532eb0d18e7769bb88af55f6b70be4db9fd937d18"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1094,9 +1067,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64030e805d3d257e3012e4378500d4ac90b1ebacd03f1110e8ec927b77f09486"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "datafusion-expr",
  "quote",
@@ -1105,16 +1077,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6af7bdae7565aa7a4cb1deb7fe18d89c63c5d93b5203b473ca1dbe02a1cd3d"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -1124,9 +1095,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f68601feda90c255c9023a881e833efca9d7539bab0565ac1355b0249326e91"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -1137,7 +1107,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.14.0",
  "log",
  "paste",
@@ -1146,9 +1116,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c1a08b00d340ca3bc1cd2f094ecaeaf6f099a2980e11255976660fa0409182"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -1160,9 +1129,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd34f3438cf9629ea0e3425027582334fb6671a05ee43671ca3c47896b75dda"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1179,9 +1147,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7624484ada341d30ef465eae61f760e779f080c621bbc3dc0335a75fa78e8dec"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "ahash",
  "arrow",
@@ -1199,7 +1166,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "itertools 0.14.0",
  "log",
  "parking_lot",
@@ -1209,15 +1176,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "46.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e717736a394ed92d9dcf2d74439c655474dd39aa65a064a6bae697b6d20e5fe"
+version = "46.0.1"
+source = "git+https://github.com/Canner/datafusion.git?branch=v46.0.1#80009c4c820c1e6347a66e5cf3232150bd5bc0a2"
 dependencies = [
  "arrow",
  "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "log",
  "recursive",
  "regex",
@@ -1490,9 +1456,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1720,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -1862,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -2167,7 +2133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -2349,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2589,7 +2555,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2760,9 +2726,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2883,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2906,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2929,7 +2895,7 @@ version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
- "indexmap 2.7.1",
+ "indexmap 2.8.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3036,9 +3002,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
  "js-sys",

--- a/wren-core/Cargo.toml
+++ b/wren-core/Cargo.toml
@@ -13,9 +13,9 @@ rust-version = "1.78"
 version = "0.1.0"
 
 [workspace.dependencies]
-async-trait = "0.1.80"
+async-trait = "0.1.88"
 # We require the latest sqlparser-rs to support the latest SQL syntax
-datafusion = { version = "46.0.0" }
+datafusion = { git = "https://github.com/Canner/datafusion.git", branch = "v46.0.1" }
 env_logger = "0.11.3"
 hashbrown = "0.15.2"
 log = { version = "0.4.14" }


### PR DESCRIPTION
We use our [DataFusion fork ](https://github.com/Canner/datafusion)to more easily maintain the dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded a core asynchronous utility to a newer version.
	- Adjusted the data processing dependency to follow the latest updates from its development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->