### PR TITLE
fix(core): simplify the available function lists

### DIFF
--- a/ibis-server/tests/conftest.py
+++ b/ibis-server/tests/conftest.py
@@ -11,7 +11,7 @@ def file_path(path: str) -> str:
     return os.path.join(os.path.dirname(__file__), path)
 
 
-DATAFUSION_FUNCTION_COUNT = 25941
+DATAFUSION_FUNCTION_COUNT = 276
 
 
 @pytest.fixture(scope="session")

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_functions.py
@@ -48,8 +48,7 @@ async def test_function_list(client):
     assert len(result) == DATAFUSION_FUNCTION_COUNT + 34
     the_func = next(
         filter(
-            lambda x: x["name"] == "string_agg"
-            and x["param_types"] == "LargeUtf8,LargeUtf8",
+            lambda x: x["name"] == "string_agg",
             result,
         )
     )
@@ -57,9 +56,9 @@ async def test_function_list(client):
         "name": "string_agg",
         "description": "Concatenates the values of string expressions and places separator values between them.",
         "function_type": "aggregate",
-        "param_names": "expression,delimiter",
-        "param_types": "LargeUtf8,LargeUtf8",
-        "return_type": "LargeUtf8",
+        "param_names": None,
+        "param_types": None,
+        "return_type": None,
     }
 
     config.set_remote_function_list_path(None)

--- a/ibis-server/tests/routers/v3/connector/local_file/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/local_file/test_functions.py
@@ -60,9 +60,9 @@ async def test_function_list(client):
         "name": "regexp_escape",
         "description": "Escapes all potentially meaningful regexp characters in the input string",
         "function_type": "scalar",
-        "param_names": "string",
-        "param_types": "Utf8",
-        "return_type": "Utf8",
+        "param_names": None,
+        "param_types": None,
+        "return_type": None,
     }
 
     config.set_remote_function_list_path(None)

--- a/ibis-server/tests/routers/v3/connector/mysql/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/mysql/test_functions.py
@@ -61,8 +61,8 @@ async def test_function_list(client):
         "description": "Synonym for LOWER()",
         "function_type": "scalar",
         "param_names": None,
-        "param_types": "Utf8",
-        "return_type": "Utf8",
+        "param_types": None,
+        "return_type": None,
     }
 
     config.set_remote_function_list_path(None)

--- a/ibis-server/tests/routers/v3/connector/postgres/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_functions.py
@@ -62,8 +62,8 @@ async def test_function_list(client):
         "description": "Get subfield from date/time",
         "function_type": "scalar",
         "param_names": None,
-        "param_types": "Utf8,Timestamp(Nanosecond, None)",
-        "return_type": "Decimal128(38, 10)",
+        "param_types": None,
+        "return_type": None,
     }
 
     config.set_remote_function_list_path(None)

--- a/ibis-server/tests/routers/v3/connector/trino/test_functions.py
+++ b/ibis-server/tests/routers/v3/connector/trino/test_functions.py
@@ -60,8 +60,8 @@ async def test_function_list(client):
         "description": "Converts binary to base64",
         "function_type": "scalar",
         "param_names": None,
-        "param_types": "Binary",
-        "return_type": "Utf8",
+        "param_types": None,
+        "return_type": None,
     }
 
     config.set_remote_function_list_path(None)

--- a/wren-core-py/tests/test_modeling_core.py
+++ b/wren-core-py/tests/test_modeling_core.py
@@ -106,7 +106,7 @@ def test_read_function_list():
     path = "tests/functions.csv"
     session_context = SessionContext(manifest_str, path)
     functions = session_context.get_available_functions()
-    assert len(functions) == 25948
+    assert len(functions) == 283
 
     rewritten_sql = session_context.transform_sql(
         "SELECT add_two(c_custkey, c_custkey) FROM my_catalog.my_schema.customer"
@@ -118,7 +118,7 @@ def test_read_function_list():
 
     session_context = SessionContext(manifest_str, None)
     functions = session_context.get_available_functions()
-    assert len(functions) == 25941
+    assert len(functions) == 276
 
 
 def test_get_available_functions():
@@ -128,9 +128,9 @@ def test_get_available_functions():
     assert add_two.name == "add_two"
     assert add_two.function_type == "scalar"
     assert add_two.description == "Adds two numbers together."
-    assert add_two.return_type == "Int32"
-    assert add_two.param_names == "f1,f2"
-    assert add_two.param_types == "Int32,Int32"
+    assert add_two.return_type is None
+    assert add_two.param_names is None
+    assert add_two.param_types is None
 
     max_if = next(f for f in functions if f.name == "max_if")
     assert max_if.name == "max_if"
@@ -142,9 +142,9 @@ def test_get_available_functions():
     assert func.name == "add_custom"
     assert func.function_type == "scalar"
     assert func.description == "Adds two numbers together."
-    assert func.return_type == "Int32"
+    assert func.return_type is None
     assert func.param_names is None
-    assert func.param_types == "Int32,Int32"
+    assert func.param_types is None
 
     func = next(f for f in functions if f.name == "test_same_as_input_array")
     assert func.name == "test_same_as_input_array"


### PR DESCRIPTION
# Description
To avoid making the list too large for the LLM promotion, we only return the function name, description, and the function type. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the function registration and metadata retrieval process to return only essential details (name, type, and an optional description), omitting previous parameter and return type specifics.
  - Adjusted the reported count of available functions for a clearer, more accurate overview.

- **Tests**
  - Updated test validations across multiple connectors to align with the simplified function metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->