### PR TITLE
fix(core): expand the wildcard before Wren rewrite rules

### DIFF
--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -111,16 +111,16 @@ async def test_query(client, manifest_str, connection_info):
     assert len(result["columns"]) == 10
     assert len(result["data"]) == 1
     assert result["data"][0] == [
+        1,
+        370,
+        "O",
+        "172799.49",
+        "1996-01-02 00:00:00.000000",
+        "1_370",
         "2024-01-01 23:59:59.000000",
         "2024-01-01 23:59:59.000000 UTC",
         "2024-01-16 04:00:00.000000 UTC",  # utc-5
         "2024-07-16 03:00:00.000000 UTC",  # utc-4
-        "172799.49",
-        "1_370",
-        370,
-        "1996-01-02 00:00:00.000000",
-        1,
-        "O",
     ]
     assert result["dtypes"] == {
         "o_orderkey": "int32",
@@ -212,7 +212,7 @@ async def test_query_with_connection_url(client, manifest_str, connection_url):
     result = response.json()
     assert len(result["columns"]) == 10
     assert len(result["data"]) == 1
-    assert result["data"][0][0] == "2024-01-01 23:59:59.000000"
+    assert result["data"][0][0] == 1
     assert result["dtypes"] is not None
 
 

--- a/wren-core-py/tests/test_modeling_core.py
+++ b/wren-core-py/tests/test_modeling_core.py
@@ -90,7 +90,7 @@ def test_session_context():
     rewritten_sql = session_context.transform_sql(sql)
     assert (
         rewritten_sql
-        == "SELECT customer.c_custkey, customer.c_name FROM (SELECT __source.c_custkey AS c_custkey, __source.c_name AS c_name FROM main.customer AS __source) AS customer"
+        == "SELECT customer.c_custkey, customer.c_name FROM (SELECT customer.c_custkey, customer.c_name FROM (SELECT __source.c_custkey AS c_custkey, __source.c_name AS c_name FROM main.customer AS __source) AS customer) AS customer"
     )
 
     session_context = SessionContext(manifest_str, "tests/functions.csv")

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -91,7 +91,7 @@ fn analyze_rule_for_local_runtime(
     session_state_ref: SessionStateRef,
 ) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
-        // Every rule that will generate [Expr::Wildcard] should be placed in front of [ExpandWildcardRule].
+        // To align the lastest change in datafusion, apply this this rule first.
         Arc::new(ExpandWildcardRule::new()),
         // expand the view should be the first rule
         Arc::new(ExpandWrenViewRule::new(
@@ -120,7 +120,7 @@ fn analyze_rule_for_unparsing(
     session_state_ref: SessionStateRef,
 ) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
-        // Every rule that will generate [Expr::Wildcard] should be placed in front of [ExpandWildcardRule].
+        // To align the lastest change in datafusion, apply this this rule first.
         Arc::new(ExpandWildcardRule::new()),
         // expand the view should be the first rule
         Arc::new(ExpandWrenViewRule::new(

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -91,6 +91,8 @@ fn analyze_rule_for_local_runtime(
     session_state_ref: SessionStateRef,
 ) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
+        // Every rule that will generate [Expr::Wildcard] should be placed in front of [ExpandWildcardRule].
+        Arc::new(ExpandWildcardRule::new()),
         // expand the view should be the first rule
         Arc::new(ExpandWrenViewRule::new(
             Arc::clone(&analyzed_mdl),
@@ -118,6 +120,8 @@ fn analyze_rule_for_unparsing(
     session_state_ref: SessionStateRef,
 ) -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
     vec![
+        // Every rule that will generate [Expr::Wildcard] should be placed in front of [ExpandWildcardRule].
+        Arc::new(ExpandWildcardRule::new()),
         // expand the view should be the first rule
         Arc::new(ExpandWrenViewRule::new(
             Arc::clone(&analyzed_mdl),

--- a/wren-core/sqllogictest/bin/sqllogictests.rs
+++ b/wren-core/sqllogictest/bin/sqllogictests.rs
@@ -117,12 +117,7 @@ async fn run_tests() -> Result<()> {
             futures::stream::iter(match result {
                 // Tokio panic error
                 Err(e) => Some(DataFusionError::External(Box::new(e))),
-                Ok(thread_result) => match thread_result {
-                    // Test run error
-                    Err(e) => Some(e),
-                    // success
-                    Ok(_) => None,
-                },
+                Ok(thread_result) => thread_result.err(),
             })
         })
         .collect()

--- a/wren-core/sqllogictest/test_files/model.slt
+++ b/wren-core/sqllogictest/test_files/model.slt
@@ -71,3 +71,14 @@ select "Customer_id" from wrenai.public."Orders" where exists (select 1 from wre
 02d1b5b8831241174c6ef13efd35abbd
 04eafb40a16989307464f27f1fed8907
 0732c0881c70ebcda536a4b14e9db106
+
+query RIITRTTT
+select * from "Order_items" where "Order_id" in ('03c83b31dbc387f83f1b5579b53182fb', '08cbb1d4cd574b126569b208fd4b26ea')
+----
+14.68 1 1 03c83b31dbc387f83f1b5579b53182fb 119.8 a04087ab6a96ffa041f8a2701a72b616 2023/1/15 7:26 CA
+6.9 4 1 08cbb1d4cd574b126569b208fd4b26ea 287.4 588531f8ec37e7d5ff5b7b22ea0488f8 2022/10/19 19:35 CA
+
+query RIITRTTT
+select * from "Order_items" where "Order_id" = '03c83b31dbc387f83f1b5579b53182fb'
+----
+14.68 1 1 03c83b31dbc387f83f1b5579b53182fb 119.8 a04087ab6a96ffa041f8a2701a72b616 2023/1/15 7:26 CA


### PR DESCRIPTION
The result of the following SQL is wrong:
```
select * from "Order_items" where "Order_id" in ('03c83b31dbc387f83f1b5579b53182fb', '08cbb1d4cd574b126569b208fd4b26ea')
```
The generated SQL will miss the columns because Wren Core only collects the column in the filter.
Since the `ExpandWildcardRule` will be removed from the latest DataFusion branch. To align this change, I apply the rule before all rules. This behavior is similar to expanding the wildcard in the logical plan builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal processing to prioritize key transformation steps, ensuring consistent behavior.

- **Tests**
  - Enhanced SQL query validations with additional nested query checks.
  - Introduced a new test case to validate wildcard filtering.
  - Added new queries in the test suite to verify accurate data retrieval for order items.
  - Modified expected outputs in existing test cases to reflect new SQL structures and data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->