### PR TITLE
feat(substitute): add default header to model substitute

### DIFF
--- a/ibis-server/app/dependencies.py
+++ b/ibis-server/app/dependencies.py
@@ -1,3 +1,6 @@
+from fastapi import Request
+from starlette.datastructures import Headers
+
 from app.model import QueryDTO
 from app.model.data_source import DataSource
 
@@ -5,3 +8,7 @@ from app.model.data_source import DataSource
 # Rebuild model to validate the dto is correct via validation of the pydantic
 def verify_query_dto(data_source: DataSource, dto: QueryDTO):
     data_source.get_dto_type()(**dto.model_dump(by_alias=True))
+
+
+def get_wren_headers(request: Request) -> Headers:
+    return request.headers

--- a/ibis-server/app/mdl/substitute.py
+++ b/ibis-server/app/mdl/substitute.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from opentelemetry import trace
 from sqlglot import exp, parse_one
 from sqlglot.optimizer.scope import build_scope
@@ -40,6 +41,12 @@ class ModelSubstitute:
     def _build_model_dict(models) -> dict:
         def key(model):
             table_ref = model["tableReference"]
+
+            if not table_ref.get("catalog") and not table_ref.get("schema"):
+                logger.debug(
+                    "Try to substitute a tableReference has empty catalog and empty schema"
+                )
+
             return f"{table_ref.get('catalog', '')}.{table_ref.get('schema', '')}.{table_ref.get('table', '')}"
 
         return {key(model): model for model in models if "tableReference" in model}

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, Query, Request, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.responses import ORJSONResponse
 from loguru import logger
 from opentelemetry import trace
@@ -58,7 +58,7 @@ async def query(
     limit: int | None = Query(None, description="limit the number of rows returned"),
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
     query_cache_manager: QueryCacheManager = Depends(get_query_cache_manager),
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> Response:
     span_name = f"v2_query_{data_source}"
     if dry_run:
@@ -161,7 +161,7 @@ async def validate(
     rule_name: str,
     dto: ValidateDTO,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> Response:
     span_name = f"v2_validate_{data_source}"
     with tracer.start_as_current_span(
@@ -188,7 +188,7 @@ async def validate(
 def get_table_list(
     data_source: DataSource,
     dto: MetadataDTO,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> list[Table]:
     span_name = f"v2_metadata_tables_{data_source}"
     with tracer.start_as_current_span(
@@ -208,7 +208,7 @@ def get_table_list(
 def get_constraints(
     data_source: DataSource,
     dto: MetadataDTO,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> list[Constraint]:
     span_name = f"v2_metadata_constraints_{data_source}"
     with tracer.start_as_current_span(
@@ -232,7 +232,7 @@ def get_db_version(data_source: DataSource, dto: MetadataDTO) -> str:
 async def dry_plan(
     dto: DryPlanDTO,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> str:
     with tracer.start_as_current_span(
         name="dry_plan", kind=trace.SpanKind.SERVER, context=build_context(headers)
@@ -251,7 +251,7 @@ async def dry_plan_for_data_source(
     data_source: DataSource,
     dto: DryPlanDTO,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> str:
     span_name = f"v2_dry_plan_{data_source}"
     with tracer.start_as_current_span(
@@ -272,7 +272,7 @@ async def dry_plan_for_data_source(
 async def model_substitute(
     data_source: DataSource,
     dto: TranspileDTO,
-    headers: Annotated[Headers, Depends(get_wren_headers)],
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
 ) -> str:
     span_name = f"v2_model_substitute_{data_source}"

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -271,6 +271,7 @@ async def dry_plan_for_data_source(
 async def model_substitute(
     data_source: DataSource,
     dto: TranspileDTO,
+    request: Request,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
     headers: Annotated[str | None, Header()] = None,
 ) -> str:
@@ -278,9 +279,9 @@ async def model_substitute(
     with tracer.start_as_current_span(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ):
-        sql = ModelSubstitute(data_source, dto.manifest_str).substitute(
-            dto.sql, write="trino"
-        )
+        sql = ModelSubstitute(
+            data_source, dto.manifest_str, dict(request.headers)
+        ).substitute(dto.sql, write="trino")
         Connector(data_source, dto.connection_info).dry_run(
             await Rewriter(
                 dto.manifest_str,

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -279,7 +279,7 @@ async def model_substitute(
     with tracer.start_as_current_span(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ):
-        sql = ModelSubstitute(data_source, dto.manifest_str, dict(headers)).substitute(
+        sql = ModelSubstitute(data_source, dto.manifest_str, headers).substitute(
             dto.sql, write="trino"
         )
         Connector(data_source, dto.connection_info).dry_run(

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, Query, Response
+from fastapi import APIRouter, Depends, Header, Query, Request, Response
 from fastapi.responses import ORJSONResponse
 from loguru import logger
 from opentelemetry import trace
@@ -258,6 +258,7 @@ def functions(
 async def model_substitute(
     data_source: DataSource,
     dto: TranspileDTO,
+    request: Request,
     headers: Annotated[str | None, Header()] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
 ) -> str:
@@ -266,7 +267,9 @@ async def model_substitute(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ):
         try:
-            sql = ModelSubstitute(data_source, dto.manifest_str).substitute(dto.sql)
+            sql = ModelSubstitute(
+                data_source, dto.manifest_str, dict(request.headers)
+            ).substitute(dto.sql)
             Connector(data_source, dto.connection_info).dry_run(
                 await Rewriter(
                     dto.manifest_str,
@@ -280,5 +283,5 @@ async def model_substitute(
                 "Failed to execute v3 model-substitute, fallback to v2: {}", str(e)
             )
             return await v2.connector.model_substitute(
-                data_source, dto, java_engine_connector, headers
+                data_source, dto, request, java_engine_connector, headers
             )

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -267,9 +267,9 @@ async def model_substitute(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ):
         try:
-            sql = ModelSubstitute(
-                data_source, dto.manifest_str, dict(headers)
-            ).substitute(dto.sql)
+            sql = ModelSubstitute(data_source, dto.manifest_str, headers).substitute(
+                dto.sql
+            )
             Connector(data_source, dto.connection_info).dry_run(
                 await Rewriter(
                     dto.manifest_str,

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, Query, Response
+from fastapi import APIRouter, Depends, Query, Response
 from fastapi.responses import ORJSONResponse
 from loguru import logger
 from opentelemetry import trace
@@ -52,7 +52,7 @@ async def query(
         bool, Query(alias="overrideCache", description="ovrride the exist cache")
     ] = False,
     limit: int | None = Query(None, description="limit the number of rows returned"),
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
     query_cache_manager: QueryCacheManager = Depends(get_query_cache_manager),
 ) -> Response:
@@ -156,7 +156,7 @@ async def query(
 @router.post("/dry-plan", description="get the planned WrenSQL")
 async def dry_plan(
     dto: DryPlanDTO,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
 ) -> str:
     with tracer.start_as_current_span(
@@ -180,7 +180,7 @@ async def dry_plan(
 async def dry_plan_for_data_source(
     data_source: DataSource,
     dto: DryPlanDTO,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
 ) -> str:
     span_name = f"v3_dry_plan_{data_source}"
@@ -209,7 +209,7 @@ async def validate(
     data_source: DataSource,
     rule_name: str,
     dto: ValidateDTO,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
     java_engine_connector: JavaEngineConnector = Depends(get_java_engine_connector),
 ) -> Response:
     span_name = f"v3_validate_{data_source}"
@@ -240,7 +240,7 @@ async def validate(
 )
 def functions(
     data_source: DataSource,
-    headers: Annotated[str | None, Header()] = None,
+    headers: Annotated[Headers, Depends(get_wren_headers)] = None,
 ) -> Response:
     span_name = f"v3_functions_{data_source}"
     with tracer.start_as_current_span(

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -742,6 +742,42 @@ async def test_model_substitute(client, manifest_str, postgres: PostgresContaine
         == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
     )
 
+    # Test only have x-user-catalog
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-catalog": "test"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "orders"',
+        },
+    )
+    assert response.status_code == 422
+
+    # Test only have x-user-catalog but have schema in SQL
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-catalog": "test"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "public"."orders"',
+        },
+    )
+    assert response.status_code == 422
+
+    # Test only have x-user-schema
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-schema": "public"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "orders"',
+        },
+    )
+    assert response.status_code == 422
+
 
 async def test_model_substitute_with_cte(
     client, manifest_str, postgres: PostgresContainer

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -793,6 +793,7 @@ async def test_model_substitute_with_subquery(
     client, manifest_str, postgres: PostgresContainer
 ):
     connection_info = _to_connection_info(postgres)
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
@@ -811,13 +812,47 @@ async def test_model_substitute_with_subquery(
         == '"SELECT * FROM (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") AS orders_subquery"'
     )
 
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-catalog": "test", "x-user-schema": "public"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": """
+                SELECT * FROM (
+                    SELECT * FROM "orders"
+                ) AS orders_subquery;
+            """,
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"SELECT * FROM (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") AS orders_subquery"'
+    )
+
 
 async def test_model_substitute_out_of_scope(
     client, manifest_str, postgres: PostgresContainer
 ):
     connection_info = _to_connection_info(postgres)
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Nation" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == 'Model not found: "Nation"'
+
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-catalog": "test", "x-user-schema": "public"},
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
@@ -832,12 +867,26 @@ async def test_model_substitute_non_existent_column(
     client, manifest_str, postgres: PostgresContainer
 ):
     connection_info = _to_connection_info(postgres)
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
             "sql": 'SELECT x FROM "test"."public"."orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    assert 'column "x" does not exist' in response.text
+
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-catalog": "test", "x-user-schema": "public"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT x FROM "orders" LIMIT 1',
         },
     )
     assert response.status_code == 422

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -764,7 +764,11 @@ async def test_model_substitute(client, manifest_str, postgres: PostgresContaine
             "sql": 'SELECT * FROM "public"."orders"',
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
+    )
 
     # Test only have x-user-schema
     response = await client.post(

--- a/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
@@ -90,7 +90,11 @@ async def test_model_substitute(client, manifest_str, connection_info):
             "sql": 'SELECT * FROM "public"."orders"',
         },
     )
-    assert response.status_code == 422
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
+    )
 
     # Test only have x-user-schema
     response = await client.post(

--- a/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
@@ -64,6 +64,48 @@ async def test_model_substitute(client, manifest_str, connection_info):
         == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
     )
 
+    # Test only have x-user-catalog
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "orders"',
+        },
+    )
+    assert response.status_code == 422
+
+    # Test only have x-user-catalog but have schema in SQL
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "public"."orders"',
+        },
+    )
+    assert response.status_code == 422
+
+    # Test only have x-user-schema
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-schema": "public",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "orders"',
+        },
+    )
+    assert response.status_code == 422
+
 
 async def test_model_substitute_with_cte(client, manifest_str, connection_info):
     # Test with catalog and schema in SQL

--- a/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
@@ -30,6 +30,7 @@ def manifest_str():
 
 
 async def test_model_substitute(client, manifest_str, connection_info):
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
@@ -44,8 +45,28 @@ async def test_model_substitute(client, manifest_str, connection_info):
         == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
     )
 
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+            "x-user-schema": "public",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "orders"',
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\""'
+    )
+
 
 async def test_model_substitute_with_cte(client, manifest_str, connection_info):
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
@@ -65,8 +86,33 @@ async def test_model_substitute_with_cte(client, manifest_str, connection_info):
         == '"WITH orders_cte AS (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") SELECT * FROM orders_cte"'
     )
 
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+            "x-user-schema": "public",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": """
+                WITH orders_cte AS (
+                    SELECT * FROM "orders"
+                )
+                SELECT * FROM orders_cte;
+            """,
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"WITH orders_cte AS (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") SELECT * FROM orders_cte"'
+    )
+
 
 async def test_model_substitute_with_subquery(client, manifest_str, connection_info):
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
@@ -85,10 +131,50 @@ async def test_model_substitute_with_subquery(client, manifest_str, connection_i
         == '"SELECT * FROM (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") AS orders_subquery"'
     )
 
-
-async def test_model_substitute_out_of_scope(client, manifest_str, connection_info):
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
     response = await client.post(
         url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+            "x-user-schema": "public",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": """
+                SELECT * FROM (
+                    SELECT * FROM "orders"
+                ) AS orders_subquery;
+            """,
+        },
+    )
+    assert response.status_code == 200
+    assert (
+        response.text
+        == '"SELECT * FROM (SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"orders\\") AS orders_subquery"'
+    )
+
+
+async def test_model_substitute_out_of_scope(client, manifest_str, connection_info):
+    # Test with catalog and schema in SQL
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Nation" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+    assert response.text == 'Model not found: "Nation"'
+
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+            "x-user-schema": "public",
+        },
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
@@ -102,12 +188,28 @@ async def test_model_substitute_out_of_scope(client, manifest_str, connection_in
 async def test_model_substitute_non_existent_column(
     client, manifest_str, connection_info
 ):
+    # Test with catalog and schema in SQL
     response = await client.post(
         url=f"{base_url}/model-substitute",
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
             "sql": 'SELECT x FROM "test"."public"."orders" LIMIT 1',
+        },
+    )
+    assert response.status_code == 422
+
+    # Test without catalog and schema in SQL but in headers(x-user-xxx)
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={
+            "x-user-catalog": "test",
+            "x-user-schema": "public",
+        },
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT x FROM "orders" LIMIT 1',
         },
     )
     assert response.status_code == 422

--- a/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_model_substitute.py
@@ -12,6 +12,7 @@ manifest = {
         {
             "name": "Orders",
             "tableReference": {
+                "catalog": "test",
                 "schema": "public",
                 "table": "orders",
             },
@@ -34,7 +35,7 @@ async def test_model_substitute(client, manifest_str, connection_info):
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
-            "sql": 'SELECT * FROM "public"."orders"',
+            "sql": 'SELECT * FROM "test"."public"."orders"',
         },
     )
     assert response.status_code == 200
@@ -52,7 +53,7 @@ async def test_model_substitute_with_cte(client, manifest_str, connection_info):
             "manifestStr": manifest_str,
             "sql": """
                 WITH orders_cte AS (
-                    SELECT * FROM "public"."orders"
+                    SELECT * FROM "test"."public"."orders"
                 )
                 SELECT * FROM orders_cte;
             """,
@@ -73,7 +74,7 @@ async def test_model_substitute_with_subquery(client, manifest_str, connection_i
             "manifestStr": manifest_str,
             "sql": """
                 SELECT * FROM (
-                    SELECT * FROM "public"."orders"
+                    SELECT * FROM "test"."public"."orders"
                 ) AS orders_subquery;
             """,
         },
@@ -106,7 +107,7 @@ async def test_model_substitute_non_existent_column(
         json={
             "connectionInfo": connection_info,
             "manifestStr": manifest_str,
-            "sql": 'SELECT x FROM "public"."orders" LIMIT 1',
+            "sql": 'SELECT x FROM "test"."public"."orders" LIMIT 1',
         },
     )
     assert response.status_code == 422


### PR DESCRIPTION
This PR adds support for two optional HTTP header `x-user-catalog` and `x-user-schema` in the following endpoints:

POST `/v2/connector/{data_source}/model-substitute`

POST `/v3/connector/{data_source}/model-substitute`

These headers allow clients to explicitly specify the catalog and schema context when performing model substitution. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying catalog and schema via HTTP headers across multiple endpoints, including model substitution.

- **Bug Fixes**
  - Ensured consistent model substitution behavior regardless of whether catalog and schema are included in SQL queries or provided via headers.
  - Improved error handling when only one of the required headers (`x-user-catalog` or `x-user-schema`) is provided.

- **Tests**
  - Expanded test coverage to validate model substitution with catalog and schema in both SQL and headers, covering success and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->