### PR TITLE
fix(substitute): validate catalog and schema existence during mapping

### DIFF
--- a/ibis-server/app/mdl/substitute.py
+++ b/ibis-server/app/mdl/substitute.py
@@ -67,7 +67,15 @@ class ModelSubstitute:
             schema = self.headers.get("x-user-schema", "") if self.headers else ""
 
         table = source.name
-        return self.model_dict.get(f"{catalog}.{schema}.{table}", None)
+
+        # catalog and schema is not None and not empty string
+        if catalog and schema:
+            return self.model_dict.get(f"{catalog}.{schema}.{table}", None)
+        # catalog is not None and not empty string
+        elif schema:
+            return self.model_dict.get(f"{schema}.{table}", None)
+        else:
+            return self.model_dict.get(f"{table}", None)
 
 
 def quote(s: str) -> str:


### PR DESCRIPTION
During mapping, we now verify that both catalog and schema exist. This prevents cases where an empty catalog header leads to malformed keys like .public.orders (note the leading dot). Ensuring the presence of these components avoids such invalid formatting.

Also added a test case to cover the scenario of an empty catalog header.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of models that lack catalog or schema information, ensuring correct model lookup and substitution even when these fields are missing or empty.

- **Tests**
	- Added new test cases to verify correct behavior when models omit catalog information, including scenarios with only schema provided or an empty catalog header.
	- Enhanced test coverage to ensure successful responses for manifests without catalog details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->