### PR TITLE
feat(substitute): smart case model substitute 

### DIFF
--- a/ibis-server/app/mdl/substitute.py
+++ b/ibis-server/app/mdl/substitute.py
@@ -39,7 +39,7 @@ class ModelSubstitute:
 
                 # if model name is ambiguous, raise an error
                 duplicate_keys = get_case_insensitive_duplicate_keys(self.model_dict)
-                if model is not None and key in duplicate_keys:
+                if model is not None and key.lower() in duplicate_keys:
                     raise SubstituteError(
                         f"Ambiguous model: found multiple matches for {source}"
                     )
@@ -125,9 +125,9 @@ def quote(s: str) -> str:
 def get_case_insensitive_duplicate_keys(d):
     key_map = defaultdict(list)
     for k in d:
-        key_map[k.lower()].append(k)
+        key_map[k.lower()].append(k.lower())
 
-    duplicates = [keys for keys in key_map.values() if len(keys) > 1]
+    duplicates = [key for keys in key_map.values() if len(keys) > 1 for key in keys]
     return duplicates
 
 

--- a/ibis-server/app/mdl/substitute.py
+++ b/ibis-server/app/mdl/substitute.py
@@ -30,7 +30,7 @@ class ModelSubstitute:
                     continue
 
                 model = self._find_model(source) or self._find_model(
-                    source, case_insensitive=False
+                    source, case_sensitive=False
                 )
                 if model is None:
                     raise SubstituteError(f"Model not found: {source}")
@@ -80,7 +80,7 @@ class ModelSubstitute:
 
         return {key(model): model for model in models if "tableReference" in model}
 
-    def _find_model(self, source: exp.Table, case_insensitive=True) -> dict | None:
+    def _find_model(self, source: exp.Table, case_sensitive=True) -> dict | None:
         # Determine catalog
         if source.catalog:
             catalog = source.catalog
@@ -96,7 +96,7 @@ class ModelSubstitute:
         table = source.name
 
         # Determine if case insensitive search is needed
-        if case_insensitive:
+        if case_sensitive:
             model_dict = self.model_dict
             # catalog and schema is not None and not empty string
             if catalog and schema:

--- a/ibis-server/app/mdl/substitute.py
+++ b/ibis-server/app/mdl/substitute.py
@@ -14,26 +14,36 @@ class ModelSubstitute:
         self.data_source = data_source
         self.manifest = base64_to_dict(manifest_str)
         self.model_dict = self._build_model_dict(self.manifest["models"])
+        self.model_dict_case_insensitive = self._build_case_insensitive_model_dict(
+            self.manifest["models"]
+        )
         self.headers = dict(headers) if headers else None
 
     @tracer.start_as_current_span("substitute", kind=trace.SpanKind.INTERNAL)
     def substitute(self, sql: str, write: str | None = None) -> str:
         ast = parse_one(sql, dialect=self.data_source.value)
         root = build_scope(ast)
+
         for scope in root.traverse():
             for alias, (node, source) in scope.selected_sources.items():
-                if isinstance(source, exp.Table):
-                    model = self._find_model(source)
-                    if model is None:
-                        raise SubstituteError(f"Model not found: {source}")
-                    source.replace(
-                        exp.Table(
-                            catalog=quote(self.manifest["catalog"]),
-                            db=quote(self.manifest["schema"]),
-                            this=quote(model["name"]),
-                            alias=quote(alias),
-                        )
+                if not isinstance(source, exp.Table):
+                    continue
+
+                model = self._find_model(source) or self._find_model(
+                    source, case_insensitive=False
+                )
+                if model is None:
+                    raise SubstituteError(f"Model not found: {source}")
+
+                source.replace(
+                    exp.Table(
+                        catalog=quote(self.manifest["catalog"]),
+                        db=quote(self.manifest["schema"]),
+                        this=quote(model["name"]),
+                        alias=quote(alias),
                     )
+                )
+
         return ast.sql(dialect=write)
 
     @staticmethod
@@ -53,7 +63,24 @@ class ModelSubstitute:
 
         return {key(model): model for model in models if "tableReference" in model}
 
-    def _find_model(self, source: exp.Table) -> dict | None:
+    @staticmethod
+    def _build_case_insensitive_model_dict(models) -> dict:
+        def key(model):
+            table_ref = model["tableReference"]
+
+            # fully qualified catalog.schema.table
+            if table_ref.get("catalog") and table_ref.get("schema"):
+                return f"{table_ref.get('catalog', '')}.{table_ref.get('schema', '')}.{table_ref.get('table', '')}".lower()
+            # schema.table
+            elif table_ref.get("schema"):
+                return f"{table_ref.get('schema', '')}.{table_ref.get('table', '')}".lower()
+            # table
+            else:
+                return table_ref.get("table", "").lower()
+
+        return {key(model): model for model in models if "tableReference" in model}
+
+    def _find_model(self, source: exp.Table, case_insensitive=True) -> dict | None:
         # Determine catalog
         if source.catalog:
             catalog = source.catalog
@@ -68,14 +95,28 @@ class ModelSubstitute:
 
         table = source.name
 
-        # catalog and schema is not None and not empty string
-        if catalog and schema:
-            return self.model_dict.get(f"{catalog}.{schema}.{table}", None)
-        # catalog is not None and not empty string
-        elif schema:
-            return self.model_dict.get(f"{schema}.{table}", None)
+        # Determine if case insensitive search is needed
+        if case_insensitive:
+            model_dict = self.model_dict
+            # catalog and schema is not None and not empty string
+            if catalog and schema:
+                return model_dict.get(f"{catalog}.{schema}.{table}", None)
+            # catalog is not None and not empty string
+            elif schema:
+                return model_dict.get(f"{schema}.{table}", None)
+            else:
+                return model_dict.get(f"{table}", None)
+
         else:
-            return self.model_dict.get(f"{table}", None)
+            model_dict = self.model_dict_case_insensitive
+            # catalog and schema is not None and not empty string
+            if catalog and schema:
+                return model_dict.get(f"{catalog}.{schema}.{table}".lower(), None)
+            # catalog is not None and not empty string
+            elif schema:
+                return model_dict.get(f"{schema}.{table}".lower(), None)
+            else:
+                return model_dict.get(f"{table}".lower(), None)
 
 
 def quote(s: str) -> str:

--- a/ibis-server/tests/routers/v2/connector/test_oracle.py
+++ b/ibis-server/tests/routers/v2/connector/test_oracle.py
@@ -76,6 +76,34 @@ manifest = {
     ],
 }
 
+# for testing substitute case sensitivity
+duplicate_key_manifest = {
+    "catalog": "my_catalog",
+    "schema": "my_schema",
+    "models": [
+        {
+            "name": "ORDERS",
+            "tableReference": {
+                "schema": "SYSTEM",  # uppercase schema name
+                "table": "ORDERS",
+            },
+            "columns": [
+                {"name": "orderkey", "expression": "O_ORDERKEY", "type": "number"},
+            ],
+        },
+        {
+            "name": "orders",
+            "tableReference": {
+                "schema": "system",  # lowercase schema name
+                "table": "ORDERS",
+            },
+            "columns": [
+                {"name": "orderkey", "expression": "O_ORDERKEY", "type": "number"},
+            ],
+        },
+    ],
+}
+
 
 @pytest.fixture(scope="module")
 def manifest_str():
@@ -433,6 +461,18 @@ async def test_model_substitute(client, manifest_str, oracle: OracleDbContainer)
         response.text
         == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"ORDERS\\""'
     )
+
+    response = await client.post(
+        url=f"{base_url}/model-substitute",
+        headers={"x-user-schema": "system"},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": duplicate_key_manifest,
+            "modelName": "Orders",
+            "sql": 'SELECT * FROM "ORDERS"',
+        },
+    )
+    assert response.status_code == 422
 
 
 def _to_connection_info(oracle: OracleDbContainer):

--- a/ibis-server/tests/routers/v2/connector/test_oracle.py
+++ b/ibis-server/tests/routers/v2/connector/test_oracle.py
@@ -469,6 +469,7 @@ async def test_model_substitute(
         == '"SELECT * FROM \\"my_catalog\\".\\"my_schema\\".\\"Orders\\" AS \\"ORDERS\\""'
     )
 
+    # test ambiguous model name
     response = await client.post(
         url=f"{base_url}/model-substitute",
         headers={"x-user-schema": "system"},


### PR DESCRIPTION
In data sources like `Oracle` and `Snowflake`, schema and table names are case-insensitive. For example:

```sql 
SELECT * FROM SYSTEM.ORDERS
```

is equivalent to:

```sql
SELECT * FROM system.orders
```


However, in our current model definition, `TableReference` is case-sensitive by default.
This PR introduces logic to automatically match `TableReference` entries in a case-insensitive manner when resolving catalog and schema names, aligning with the behavior of these data sources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved model substitution to support case-insensitive lookups, ensuring more robust handling of model names regardless of letter casing.

- **Tests**
  - Added tests to verify that model substitution works correctly with different casing in schema names, confirming case insensitivity in the substitution process.
  - Added validation to detect and reject ambiguous model names differing only by case, preventing substitution errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->