### PR TITLE
deps(ci): disable sccache-cache for rust action

### DIFF
--- a/.github/actions/rust/setup-rust-runtime/action.yaml
+++ b/.github/actions/rust/setup-rust-runtime/action.yaml
@@ -20,19 +20,8 @@ description: 'Setup Rust Runtime Environment'
 runs:
   using: "composite"
   steps:
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.4
     - name: Configure runtime env
       shell: bash
-      # do not produce debug symbols to keep memory usage down
-      # hardcoding other profile params to avoid profile override values
-      # More on Cargo profiles https://doc.rust-lang.org/cargo/reference/profiles.html?profile-settings#profile-settings
-      # 
-      # Set debuginfo=line-tables-only as debuginfo=0 causes immensely slow build
-      # See for more details: https://github.com/rust-lang/rust/issues/119560
       run: |
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV  
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV 
         echo "RUST_BACKTRACE=1" >> $GITHUB_ENV
         echo "RUSTFLAGS=-C debuginfo=line-tables-only -C incremental=false" >> $GITHUB_ENV
-     


### PR DESCRIPTION
This change has been tested by https://github.com/Canner/wren-engine/pull/1161

# Disable sccache
Disabled `sccache` because of the following CI error.
```
sccache: error: Server startup failed: cache storage failed to read: Unexpected (permanent) at read => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed sccache caching integration and related environment variables from the Rust runtime setup.
  - Updated environment configuration by retaining only essential variables for debugging.
  - Cleaned up comments related to debug settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->