### PR TITLE
chore(ci): add explicit permissions for workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,8 @@
 name: Build image
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/core-py-ci.yml
+++ b/.github/workflows/core-py-ci.yml
@@ -1,4 +1,7 @@
 name: Core Python CI
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/ibis-ci.yml
+++ b/.github/workflows/ibis-ci.yml
@@ -1,5 +1,8 @@
 name: ibis CI
-
+permissions:
+  contents: read
+  pull-requests: write
+  
 on:
   pull_request:
 

--- a/.github/workflows/maven-tests.yml
+++ b/.github/workflows/maven-tests.yml
@@ -1,4 +1,7 @@
 name: Maven tests
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,7 @@
 name: Rust
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,4 +1,8 @@
 name: Stable Release
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Add explicit permissions for the workflow to fix the code scanning alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to explicitly define permissions for repository contents, packages, and pull requests. No changes were made to workflow logic or job steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->