### PR TITLE
chore(tool): add tools for importing data to local testing mysql

### DIFF
--- a/ibis-server/tools/data_source/mysql_5.py
+++ b/ibis-server/tools/data_source/mysql_5.py
@@ -1,0 +1,39 @@
+# This script is used to import data into a MySQL 5.7.44 database using SQLAlchemy and Pandas.
+# Following are the steps to run this script:
+#   docker pull --platform linux/amd64 mysql:5.7.44
+#   docker run --name test-mysql -e MYSQL_ROOT_PASSWORD=my-pwd -e MYSQL_DATABASE={database_name} --platform linux/amd64 -p 3306:3306 -d mysql:5.7.44
+
+import argparse
+import sqlalchemy
+from sqlalchemy import create_engine
+import pandas as pd
+import json
+import os
+
+from dotenv import load_dotenv
+
+# Set up argument parsing
+parser = argparse.ArgumentParser(description="import data to mysql")
+parser.add_argument("dataset_path", help="Path to the dataset")
+parser.add_argument("database_name", help="Name of the database")
+
+args = parser.parse_args()
+
+
+load_dotenv(override=True)
+manifest_json_path = os.getenv("WREN_MANIFEST_JSON_PATH")
+print("Manifest JSON Path:", manifest_json_path)
+
+
+# Read and encode the JSON data
+with open(manifest_json_path) as file:
+    mdl = json.load(file)
+
+connection_url = f"mysql+pymysql://root:my-pwd@localhost:3306/{args.database_name}"
+engine = sqlalchemy.create_engine(connection_url)
+
+for model in mdl["models"]:
+    path = f"{args.dataset_path}/{model['name']}.parquet"
+    pd.read_parquet(path).to_sql(
+        model["tableReference"]["table"], engine, index=False, if_exists="replace"
+    )

--- a/ibis-server/tools/query_local_run.py
+++ b/ibis-server/tools/query_local_run.py
@@ -14,6 +14,7 @@
 import base64
 import json
 import os
+from app.model import MySqlConnectionInfo
 import sqlglot
 import sys
 
@@ -70,6 +71,13 @@ print("#")
 if data_source == "bigquery":
     connection_info = BigQueryConnectionInfo.model_validate_json(json.dumps(connection_info))
     connection = DataSourceExtension.get_bigquery_connection(connection_info)
+    df = connection.sql(dialect_sql).limit(10).to_pandas()
+    print("### Result ###")
+    print("")
+    print(df)
+elif data_source == "mysql":
+    connection_info = MySqlConnectionInfo.model_validate_json(json.dumps(connection_info))
+    connection = DataSourceExtension.get_mysql_connection(connection_info)
     df = connection.sql(dialect_sql).limit(10).to_pandas()
     print("### Result ###")
     print("")


### PR DESCRIPTION
- Add the tools for importing data to the local  testing MySQL
- Enhance the `query_local_run` script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line tool to import Parquet datasets into MySQL 5.7.44 databases.
  - Enabled support for querying MySQL as a data source in local query runs, displaying query results in the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->