### PR TITLE
feat(ibis): add header to disable the fallback and refine fallback log

### DIFF
--- a/ibis-server/app/dependencies.py
+++ b/ibis-server/app/dependencies.py
@@ -26,6 +26,8 @@ def get_wren_headers(request: Request) -> Headers:
 def _filter_headers(header_string: str) -> bool:
     if header_string.startswith("x-wren-"):
         return True
+    elif header_string.startswith("x-user-"):
+        return True
     elif header_string == "traceparent":
         return True
     elif header_string == "tracestate":

--- a/ibis-server/app/dependencies.py
+++ b/ibis-server/app/dependencies.py
@@ -11,4 +11,23 @@ def verify_query_dto(data_source: DataSource, dto: QueryDTO):
 
 
 def get_wren_headers(request: Request) -> Headers:
-    return request.headers
+    return Headers(
+        raw=list(
+            filter(
+                lambda t: _filter_headers(t[0].decode("latin-1")),
+                request.headers.raw,
+            )
+        )
+    )
+
+
+def _filter_headers(header_string: str) -> bool:
+    if header_string.startswith("x-wren-"):
+        return True
+    elif header_string == "traceparent":
+        return True
+    elif header_string == "tracestate":
+        return True
+    elif header_string == "sentry-trace":
+        return True
+    return False

--- a/ibis-server/app/dependencies.py
+++ b/ibis-server/app/dependencies.py
@@ -4,6 +4,8 @@ from starlette.datastructures import Headers
 from app.model import QueryDTO
 from app.model.data_source import DataSource
 
+X_WREN_FALLBACK_DISABLE = "x-wren-fallback_disable"
+
 
 # Rebuild model to validate the dto is correct via validation of the pydantic
 def verify_query_dto(data_source: DataSource, dto: QueryDTO):

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, Response
@@ -25,7 +24,13 @@ from app.model.validator import Validator
 from app.query_cache import QueryCacheManager
 from app.routers import v2
 from app.routers.v2.connector import get_java_engine_connector, get_query_cache_manager
-from app.util import append_fallback_context, build_context, pushdown_limit, to_json
+from app.util import (
+    append_fallback_context,
+    build_context,
+    pushdown_limit,
+    safe_strtobool,
+    to_json,
+)
 
 router = APIRouter(prefix="/connector", tags=["connector"])
 tracer = trace.get_tracer(__name__)
@@ -136,7 +141,7 @@ async def query(
         except Exception as e:
             is_fallback_disable = bool(
                 headers.get(X_WREN_FALLBACK_DISABLE)
-                and strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
             )
             if is_fallback_disable:
                 raise e
@@ -172,7 +177,7 @@ async def dry_plan(
         except Exception as e:
             is_fallback_disable = bool(
                 headers.get(X_WREN_FALLBACK_DISABLE)
-                and strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
             )
             if is_fallback_disable:
                 raise e
@@ -210,7 +215,7 @@ async def dry_plan_for_data_source(
         except Exception as e:
             is_fallback_disable = bool(
                 headers.get(X_WREN_FALLBACK_DISABLE)
-                and strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
             )
             if is_fallback_disable:
                 raise e
@@ -253,7 +258,7 @@ async def validate(
         except Exception as e:
             is_fallback_disable = bool(
                 headers.get(X_WREN_FALLBACK_DISABLE)
-                and strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
             )
             if is_fallback_disable:
                 raise e
@@ -320,7 +325,7 @@ async def model_substitute(
         except Exception as e:
             is_fallback_disable = bool(
                 headers.get(X_WREN_FALLBACK_DISABLE)
-                and strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
             )
             if is_fallback_disable:
                 raise e

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -160,6 +160,7 @@ async def query(
                 java_engine_connector=java_engine_connector,
                 query_cache_manager=query_cache_manager,
                 headers=headers,
+                is_fallback=True,
             )
 
 

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -143,3 +143,7 @@ def get_fallback_message(
         {"datasource": datasource, "mdl_hash": mdl_hash, "sql": sql}
     ).decode("utf-8")
     logger.warning("Fallback to v2 {} -- {}\n{}", prefix, message, MIGRATION_MESSAGE)  # noqa: PLE1205
+
+
+def safe_strtobool(val: str) -> bool:
+    return val.lower() in {"1", "true", "yes", "y"}

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -134,13 +134,13 @@ def pushdown_limit(sql: str, limit: int | None) -> str:
 
 
 def get_fallback_message(
-    logger, prefix: str, datasource: DataSource, mdl_hash: str, sql: str
+    logger, prefix: str, datasource: DataSource, mdl_base64: str, sql: str
 ) -> str:
     if sql is not None:
         sql = sql.replace("\n", " ")
 
     message = orjson.dumps(
-        {"datasource": datasource, "mdl_hash": mdl_hash, "sql": sql}
+        {"datasource": datasource, "mdl_base64": mdl_base64, "sql": sql}
     ).decode("utf-8")
     logger.warning("Fallback to v2 {} -- {}\n{}", prefix, message, MIGRATION_MESSAGE)  # noqa: PLE1205
 

--- a/ibis-server/tests/routers/v3/connector/postgres/test_fallback_v2.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_fallback_v2.py
@@ -3,6 +3,7 @@ import base64
 import orjson
 import pytest
 
+from app.dependencies import X_WREN_FALLBACK_DISABLE
 from tests.routers.v3.connector.postgres.conftest import base_url
 
 # It's not a valid manifest for v3. We expect the query to fail and fallback to v2.
@@ -44,6 +45,19 @@ async def test_query(client, manifest_str, connection_info):
     assert len(result["columns"]) == 1
     assert len(result["data"]) == 1
 
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422
+
 
 async def test_query_with_cache(client, manifest_str, connection_info):
     # First request - should miss cache
@@ -79,6 +93,19 @@ async def test_query_with_cache(client, manifest_str, connection_info):
     assert result1["columns"] == result2["columns"]
     assert result1["dtypes"] == result2["dtypes"]
 
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",  # Enable cache
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response1.status_code == 422
+
 
 async def test_query_with_cache_override(client, manifest_str, connection_info):
     # First request - should miss cache then create cache
@@ -107,6 +134,19 @@ async def test_query_with_cache_override(client, manifest_str, connection_info):
         response2.headers["X-Cache-Create-At"]
     )
 
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",  # Enable cache
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response1.status_code == 422
+
 
 async def test_query_with_connection_url(client, manifest_str, connection_url):
     response = await client.post(
@@ -118,6 +158,19 @@ async def test_query_with_connection_url(client, manifest_str, connection_url):
         },
     )
     assert response.status_code == 200
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422
 
 
 async def test_query_with_connection_url_and_cache_enable(
@@ -153,6 +206,19 @@ async def test_query_with_connection_url_and_cache_enable(
     assert result1["columns"] == result2["columns"]
     assert result1["dtypes"] == result2["dtypes"]
 
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response1.status_code == 422
+
 
 async def test_query_with_connection_url_and_cache_override(
     client, manifest_str, connection_url
@@ -183,6 +249,19 @@ async def test_query_with_connection_url_and_cache_override(
         response2.headers["X-Cache-Create-At"]
     )
 
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": {"connectionUrl": connection_url},
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response1.status_code == 422
+
 
 async def test_dry_run(client, manifest_str, connection_info):
     response = await client.post(
@@ -196,6 +275,20 @@ async def test_dry_run(client, manifest_str, connection_info):
     )
     assert response.status_code == 204
 
+    response = await client.post(
+        url=f"{base_url}/query",
+        params={"dryRun": True},
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422
+
 
 async def test_dry_plan(client, manifest_str):
     response = await client.post(
@@ -207,6 +300,18 @@ async def test_dry_plan(client, manifest_str):
     )
     assert response.status_code == 200
     assert response.text is not None
+
+    response = await client.post(
+        url="/v3/connector/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422
 
 
 async def test_dry_plan_for_data_source(client, manifest_str):
@@ -220,6 +325,18 @@ async def test_dry_plan_for_data_source(client, manifest_str):
     assert response.status_code == 200
     assert response.text is not None
 
+    response = await client.post(
+        url=f"{base_url}/dry-plan",
+        json={
+            "manifestStr": manifest_str,
+            "sql": "SELECT orderkey FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422
+
 
 async def test_validate(client, manifest_str, connection_info):
     response = await client.post(
@@ -231,3 +348,16 @@ async def test_validate(client, manifest_str, connection_info):
         },
     )
     assert response.status_code == 204
+
+    response = await client.post(
+        url=f"{base_url}/validate/column_is_valid",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "parameters": {"modelName": "orders", "columnName": "orderkey"},
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
# Description
The v2 Wren core doesn't support some data sources, such as legacy MySQL (before 8). We don't need to try to fallback on this case. If we try to fallback, the error message thrown by the v2 Wren core is confusing. 

## New Header
```
x-wren-fallback_disable: true
```

# Other Changes
- Refine the migration message.
  - Now, the migration message is only printed when the v3 query fails and the v2 query succeeds. 
- Change some ordering of the arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for a request header that allows users to disable automatic fallback to a previous connector version in API endpoints.
  - Enhanced tracing and logging for fallback scenarios, improving transparency and traceability.

- **Bug Fixes**
  - Improved filtering of request headers to ensure only relevant headers are included in API processing.

- **Tests**
  - Added tests to verify correct behavior when fallback is explicitly disabled via the new request header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->