### PR TITLE
chore: add command and doc for tracing with jaeger

### DIFF
--- a/ibis-server/README.md
+++ b/ibis-server/README.md
@@ -81,6 +81,23 @@ OpenTelemetry zero-code instrumentation is highly configurable. You can set the 
 
 [Metrics we are tracing right now](./Metrics.md)
 
+### Tracing with Jaeger
+- Follow the [Jaeger official documentation](https://www.jaegertracing.io/docs/2.5/getting-started/#all-in-one) to start Jaeger in a container. Use the following command:
+```
+docker run --rm --name jaeger \
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
+  -p 5778:5778 \
+  -p 9411:9411 \
+  jaegertracing/jaeger:2.5.0
+```
+- Use the following `just` command to start the `ibis-server` and export tracing logs to Jaeger:
+```
+just run-trace-otlp 
+```
+- Open the Jaeger UI at [http://localhost:16686](http://localhost:16686) to view the tracing logs for your requests.
+
 ## Contributing
 Please see [CONTRIBUTING.md](docs/CONTRIBUTING.md) for more information.
 

--- a/ibis-server/justfile
+++ b/ibis-server/justfile
@@ -26,6 +26,13 @@ run:
 run-trace-console:
     opentelemetry-instrument --traces_exporter console --metrics_exporter none fastapi run --port {{ port }}
 
+run-trace-otlp:
+    opentelemetry-instrument \
+        --traces_exporter otlp \
+        --exporter_otlp_endpoint http://localhost:4318 \
+        --exporter_otlp_protocol http/protobuf \
+        --service_name wren-engine \
+        fastapi run --port {{ port }}
 dev:
     poetry run fastapi dev --port {{ port }}
 


### PR DESCRIPTION
 Add command and doc for tracing with [Jaeger](https://www.jaegertracing.io/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README with instructions for setting up Jaeger tracing, including how to run Jaeger in Docker and view tracing logs in the Jaeger UI.

- **Chores**
  - Added a new command to enable exporting tracing logs to an OTLP collector endpoint for improved observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->