### PR TITLE
fix(ibis): skip redundant operations when query cache is hit

### DIFF
--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -127,13 +127,13 @@ async def query(
             match (cache_enable, cache_hit, override_cache):
                 # case 2 cache hit but override cache
                 case (True, True, True):
-                    query_cache_manager.set(
-                        data_source, dto.sql, result, dto.connection_info
-                    )
                     response.headers["X-Cache-Create-At"] = str(
                         query_cache_manager.get_cache_file_timestamp(
                             data_source, dto.sql, dto.connection_info
                         )
+                    )
+                    query_cache_manager.set(
+                        data_source, dto.sql, result, dto.connection_info
                     )
 
                     response.headers["X-Cache-Override"] = "true"

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -101,7 +101,7 @@ async def query(
             cache_hit = cached_result is not None
 
         # case 1: cache hit read
-        if cache_enable and cache_hit:
+        if cache_enable and cache_hit and not override_cache:
             span.add_event("cache hit")
             response = ORJSONResponse(to_json(cached_result))
             response.headers["X-Cache-Hit"] = "true"

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -117,6 +117,7 @@ async def query(
                 data_source=data_source,
                 java_engine_connector=java_engine_connector,
             ).rewrite(sql)
+            connector = Connector(data_source, dto.connection_info)
             result = connector.query(rewritten_sql, limit=limit)
             response = ORJSONResponse(to_json(result))
 

--- a/ibis-server/app/routers/v2/connector.py
+++ b/ibis-server/app/routers/v2/connector.py
@@ -76,17 +76,16 @@ async def query(
             logger.warning("Failed to pushdown limit. Using original SQL: {}", e)
             sql = dto.sql
 
-        rewritten_sql = await Rewriter(
-            dto.manifest_str,
-            data_source=data_source,
-            java_engine_connector=java_engine_connector,
-        ).rewrite(sql)
-        connector = Connector(data_source, dto.connection_info)
-
         # First check if the query is a dry run
         # If it is dry run.
         # We don't need to check query cache
         if dry_run:
+            rewritten_sql = await Rewriter(
+                dto.manifest_str,
+                data_source=data_source,
+                java_engine_connector=java_engine_connector,
+            ).rewrite(sql)
+            connector = Connector(data_source, dto.connection_info)
             connector.dry_run(rewritten_sql)
             return Response(status_code=204)
 
@@ -101,53 +100,56 @@ async def query(
             )
             cache_hit = cached_result is not None
 
-        match (cache_enable, cache_hit, override_cache):
-            # case 1 cache hit read
-            case (True, True, False):
-                span.add_event("cache hit")
-                response = ORJSONResponse(to_json(cached_result))
-                response.headers["X-Cache-Hit"] = "true"
-                response.headers["X-Cache-Create-At"] = str(
-                    query_cache_manager.get_cache_file_timestamp(
-                        data_source, dto.sql, dto.connection_info
-                    )
+        # case 1: cache hit read
+        if cache_enable and cache_hit:
+            span.add_event("cache hit")
+            response = ORJSONResponse(to_json(cached_result))
+            response.headers["X-Cache-Hit"] = "true"
+            response.headers["X-Cache-Create-At"] = str(
+                query_cache_manager.get_cache_file_timestamp(
+                    data_source, dto.sql, dto.connection_info
                 )
-            # case 2 cache hit but override cache
-            case (True, True, True):
-                result = connector.query(rewritten_sql, limit=limit)
-                response = ORJSONResponse(to_json(result))
-                # because we override the cache, so we need to set the cache hit to false
-                response.headers["X-Cache-Hit"] = "false"
-                response.headers["X-Cache-Create-At"] = str(
-                    query_cache_manager.get_cache_file_timestamp(
-                        data_source, dto.sql, dto.connection_info
-                    )
-                )
-                query_cache_manager.set(
-                    data_source, dto.sql, result, dto.connection_info
-                )
-                response.headers["X-Cache-Override"] = "true"
-                response.headers["X-Cache-Override-At"] = str(
-                    query_cache_manager.get_cache_file_timestamp(
-                        data_source, dto.sql, dto.connection_info
-                    )
-                )
-            # case 3 and  case 4 cache miss read (first time cache read need to create cache)
-            # no matter the cache override or not, we need to create cache
-            case (True, False, _):
-                result = connector.query(rewritten_sql, limit=limit)
+            )
+        # all other cases require rewriting + connecting
+        else:
+            rewritten_sql = await Rewriter(
+                dto.manifest_str,
+                data_source=data_source,
+                java_engine_connector=java_engine_connector,
+            ).rewrite(sql)
+            result = connector.query(rewritten_sql, limit=limit)
+            response = ORJSONResponse(to_json(result))
 
-                # set cache
-                query_cache_manager.set(
-                    data_source, dto.sql, result, dto.connection_info
-                )
-                response = ORJSONResponse(to_json(result))
-                response.headers["X-Cache-Hit"] = "false"
-            # case 5~8 Other cases (cache is not enabled)
-            case (False, _, _):
-                result = connector.query(rewritten_sql, limit=limit)
-                response = ORJSONResponse(to_json(result))
-                response.headers["X-Cache-Hit"] = "false"
+            # headers for all non-hit cases
+            response.headers["X-Cache-Hit"] = "false"
+
+            match (cache_enable, cache_hit, override_cache):
+                # case 2 cache hit but override cache
+                case (True, True, True):
+                    query_cache_manager.set(
+                        data_source, dto.sql, result, dto.connection_info
+                    )
+                    response.headers["X-Cache-Create-At"] = str(
+                        query_cache_manager.get_cache_file_timestamp(
+                            data_source, dto.sql, dto.connection_info
+                        )
+                    )
+
+                    response.headers["X-Cache-Override"] = "true"
+                    response.headers["X-Cache-Override-At"] = str(
+                        query_cache_manager.get_cache_file_timestamp(
+                            data_source, dto.sql, dto.connection_info
+                        )
+                    )
+                # case 3/4: cache miss but enabled (need to create cache)
+                # no matter the cache override or not, we need to create cache
+                case (True, False, _):
+                    query_cache_manager.set(
+                        data_source, dto.sql, result, dto.connection_info
+                    )
+                # case 5~8 Other cases (cache is not enabled)
+                case (False, _, _):
+                    pass
 
         if is_fallback:
             get_fallback_message(

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -69,12 +69,12 @@ async def query(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ) as span:
         try:
-            sql = pushdown_limit(dto.sql, limit)
-            rewritten_sql = await Rewriter(
-                dto.manifest_str, data_source=data_source, experiment=True
-            ).rewrite(sql)
-            connector = Connector(data_source, dto.connection_info)
             if dry_run:
+                sql = pushdown_limit(dto.sql, limit)
+                rewritten_sql = await Rewriter(
+                    dto.manifest_str, data_source=data_source, experiment=True
+                ).rewrite(sql)
+                connector = Connector(data_source, dto.connection_info)
                 connector.dry_run(rewritten_sql)
                 return Response(status_code=204)
 
@@ -88,54 +88,55 @@ async def query(
                     data_source, dto.sql, dto.connection_info
                 )
                 cache_hit = cached_result is not None
+            # case 1: cache hit read
+            if cache_enable and cache_hit:
+                span.add_event("cache hit")
+                response = ORJSONResponse(to_json(cached_result))
+                response.headers["X-Cache-Hit"] = "true"
+                response.headers["X-Cache-Create-At"] = str(
+                    query_cache_manager.get_cache_file_timestamp(
+                        data_source, dto.sql, dto.connection_info
+                    )
+                )
+            # all other cases require rewriting + connecting
+            else:
+                sql = pushdown_limit(dto.sql, limit)
+                rewritten_sql = await Rewriter(
+                    dto.manifest_str, data_source=data_source, experiment=True
+                ).rewrite(sql)
+                connector = Connector(data_source, dto.connection_info)
+                result = connector.query(rewritten_sql, limit=limit)
+                response = ORJSONResponse(to_json(result))
 
-            match (cache_enable, cache_hit, override_cache):
-                # case 1 cache hit read
-                case (True, True, False):
-                    span.add_event("cache hit")
-                    response = ORJSONResponse(to_json(cached_result))
-                    response.headers["X-Cache-Hit"] = "true"
-                    response.headers["X-Cache-Create-At"] = str(
-                        query_cache_manager.get_cache_file_timestamp(
-                            data_source, dto.sql, dto.connection_info
-                        )
-                    )
-                # case 2 cache hit but override cache
-                case (True, True, True):
-                    result = connector.query(rewritten_sql, limit=limit)
-                    response = ORJSONResponse(to_json(result))
-                    # because we override the cache, so we need to set the cache hit to false
-                    response.headers["X-Cache-Hit"] = "false"
-                    response.headers["X-Cache-Create-At"] = str(
-                        query_cache_manager.get_cache_file_timestamp(
-                            data_source, dto.sql, dto.connection_info
-                        )
-                    )
-                    query_cache_manager.set(
-                        data_source, dto.sql, result, dto.connection_info
-                    )
-                    response.headers["X-Cache-Override"] = "true"
-                    response.headers["X-Cache-Override-At"] = str(
-                        query_cache_manager.get_cache_file_timestamp(
-                            data_source, dto.sql, dto.connection_info
-                        )
-                    )
-                # case 3 and  case 4 cache miss read (first time cache read need to create cache)
-                # no matter the cache override or not, we need to create cache
-                case (True, False, _):
-                    result = connector.query(rewritten_sql, limit=limit)
+                # headers for all non-hit cases
+                response.headers["X-Cache-Hit"] = "false"
 
-                    # set cache
-                    query_cache_manager.set(
-                        data_source, dto.sql, result, dto.connection_info
-                    )
-                    response = ORJSONResponse(to_json(result))
-                    response.headers["X-Cache-Hit"] = "false"
-                # case 5~8 Other cases (cache is not enabled)
-                case (False, _, _):
-                    result = connector.query(rewritten_sql, limit=limit)
-                    response = ORJSONResponse(to_json(result))
-                    response.headers["X-Cache-Hit"] = "false"
+                match (cache_enable, cache_hit, override_cache):
+                    # case 2: override existing cache
+                    case (True, True, True):
+                        query_cache_manager.set(
+                            data_source, dto.sql, result, dto.connection_info
+                        )
+                        response.headers["X-Cache-Create-At"] = str(
+                            query_cache_manager.get_cache_file_timestamp(
+                                data_source, dto.sql, dto.connection_info
+                            )
+                        )
+                        response.headers["X-Cache-Override"] = "true"
+                        response.headers["X-Cache-Override-At"] = str(
+                            query_cache_manager.get_cache_file_timestamp(
+                                data_source, dto.sql, dto.connection_info
+                            )
+                        )
+                    # case 3/4: cache miss but enabled (need to create cache)
+                    # no matter the cache override or not, we need to create cache
+                    case (True, False, _):
+                        query_cache_manager.set(
+                            data_source, dto.sql, result, dto.connection_info
+                        )
+                    # case 5~8 Other cases (cache is not enabled)
+                    case (False, _, _):
+                        pass
 
             return response
         except Exception as e:

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -114,14 +114,15 @@ async def query(
                 match (cache_enable, cache_hit, override_cache):
                     # case 2: override existing cache
                     case (True, True, True):
-                        query_cache_manager.set(
-                            data_source, dto.sql, result, dto.connection_info
-                        )
                         response.headers["X-Cache-Create-At"] = str(
                             query_cache_manager.get_cache_file_timestamp(
                                 data_source, dto.sql, dto.connection_info
                             )
                         )
+                        query_cache_manager.set(
+                            data_source, dto.sql, result, dto.connection_info
+                        )
+
                         response.headers["X-Cache-Override"] = "true"
                         response.headers["X-Cache-Override-At"] = str(
                             query_cache_manager.get_cache_file_timestamp(

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -89,7 +89,7 @@ async def query(
                 )
                 cache_hit = cached_result is not None
             # case 1: cache hit read
-            if cache_enable and cache_hit:
+            if cache_enable and cache_hit and not override_cache:
                 span.add_event("cache hit")
                 response = ORJSONResponse(to_json(cached_result))
                 response.headers["X-Cache-Hit"] = "true"

--- a/ibis-server/app/routers/v3/connector.py
+++ b/ibis-server/app/routers/v3/connector.py
@@ -65,6 +65,11 @@ async def query(
     if cache_enable:
         span_name += "_cache_enable"
 
+    is_fallback_disable = bool(
+        headers.get(X_WREN_FALLBACK_DISABLE)
+        and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
+    )
+
     with tracer.start_as_current_span(
         name=span_name, kind=trace.SpanKind.SERVER, context=build_context(headers)
     ) as span:
@@ -78,10 +83,6 @@ async def query(
                 connector.dry_run(rewritten_sql)
                 return Response(status_code=204)
 
-            is_fallback_disable = bool(
-                headers.get(X_WREN_FALLBACK_DISABLE)
-                and safe_strtobool(headers.get(X_WREN_FALLBACK_DISABLE, "false"))
-            )
             # Not a dry run
             # Check if the query is cached
             cached_result = None

--- a/ibis-server/tests/routers/v3/connector/postgres/test_fallback_v2.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_fallback_v2.py
@@ -93,7 +93,8 @@ async def test_query_with_cache(client, manifest_str, connection_info):
     assert result1["columns"] == result2["columns"]
     assert result1["dtypes"] == result2["dtypes"]
 
-    response1 = await client.post(
+    # Even we disable the fallback, we should still hit the cache
+    response3 = await client.post(
         url=f"{base_url}/query?cacheEnable=true",  # Enable cache
         json={
             "connectionInfo": connection_info,
@@ -104,7 +105,11 @@ async def test_query_with_cache(client, manifest_str, connection_info):
             X_WREN_FALLBACK_DISABLE: "true",
         },
     )
-    assert response1.status_code == 422
+    assert response3.status_code == 200
+    result3 = response3.json()
+    assert result2["data"] == result3["data"]
+    assert result2["columns"] == result3["columns"]
+    assert result2["dtypes"] == result3["dtypes"]
 
 
 async def test_query_with_cache_override(client, manifest_str, connection_info):
@@ -129,12 +134,14 @@ async def test_query_with_cache_override(client, manifest_str, connection_info):
         },
     )
     assert response2.status_code == 200
+    result2 = response2.json()
     assert response2.headers["X-Cache-Override"] == "true"
     assert int(response2.headers["X-Cache-Override-At"]) > int(
         response2.headers["X-Cache-Create-At"]
     )
 
-    response1 = await client.post(
+    # Even we disable the fallback, we should still hit the cache
+    response3 = await client.post(
         url=f"{base_url}/query?cacheEnable=true",  # Enable cache
         json={
             "connectionInfo": connection_info,
@@ -145,7 +152,11 @@ async def test_query_with_cache_override(client, manifest_str, connection_info):
             X_WREN_FALLBACK_DISABLE: "true",
         },
     )
-    assert response1.status_code == 422
+    assert response3.status_code == 200
+    result3 = response3.json()
+    assert result2["data"] == result3["data"]
+    assert result2["columns"] == result3["columns"]
+    assert result2["dtypes"] == result3["dtypes"]
 
 
 async def test_query_with_connection_url(client, manifest_str, connection_url):
@@ -206,7 +217,8 @@ async def test_query_with_connection_url_and_cache_enable(
     assert result1["columns"] == result2["columns"]
     assert result1["dtypes"] == result2["dtypes"]
 
-    response1 = await client.post(
+    # Even we disable the fallback, we should still hit the cache
+    response3 = await client.post(
         url=f"{base_url}/query?cacheEnable=true",
         json={
             "connectionInfo": {"connectionUrl": connection_url},
@@ -217,7 +229,11 @@ async def test_query_with_connection_url_and_cache_enable(
             X_WREN_FALLBACK_DISABLE: "true",
         },
     )
-    assert response1.status_code == 422
+    assert response3.status_code == 200
+    result3 = response3.json()
+    assert result2["data"] == result3["data"]
+    assert result2["columns"] == result3["columns"]
+    assert result2["dtypes"] == result3["dtypes"]
 
 
 async def test_query_with_connection_url_and_cache_override(
@@ -244,12 +260,14 @@ async def test_query_with_connection_url_and_cache_override(
         },
     )
     assert response2.status_code == 200
+    result2 = response2.json()
     assert response2.headers["X-Cache-Override"] == "true"
     assert int(response2.headers["X-Cache-Override-At"]) > int(
         response2.headers["X-Cache-Create-At"]
     )
 
-    response1 = await client.post(
+    # Even we disable the fallback, we should still hit the cache
+    response3 = await client.post(
         url=f"{base_url}/query?cacheEnable=true",
         json={
             "connectionInfo": {"connectionUrl": connection_url},
@@ -260,7 +278,11 @@ async def test_query_with_connection_url_and_cache_override(
             X_WREN_FALLBACK_DISABLE: "true",
         },
     )
-    assert response1.status_code == 422
+    assert response3.status_code == 200
+    result3 = response3.json()
+    assert result2["data"] == result3["data"]
+    assert result2["columns"] == result3["columns"]
+    assert result2["dtypes"] == result3["dtypes"]
 
 
 async def test_dry_run(client, manifest_str, connection_info):


### PR DESCRIPTION
- Skips establishing a new database connection if the result is already cached.

- Bypasses SQL rewriting logic when cached results are used.


Previously, even on a cache hit, the system still performed operations like opening a database connection and rewriting the SQL, which were redundant. This change improves efficiency and reduces latency during cache hits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved query caching for faster responses on cache hits with clearer cache-related headers.
  - Reduced redundant SQL rewriting and connector initialization by performing them only when needed.
  - Enhanced clarity and reliability in handling cache overrides, cache misses, and fallback disable scenarios.
  - Updated test behavior to ensure consistent successful responses when fallback is disabled, validating cached results remain accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->