### PR TITLE
fix(core): ensure that the RLAC can be applied when the relationship access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           rust-version: stable
       - name: Run tests (excluding doctests)
-        run: cargo test --lib --tests --bins
+        run: RUST_MIN_STACK=8388608 cargo test --lib --tests --bins
       - name: Verify Working Directory Clean
         run: git diff --exit-code
 
@@ -77,7 +77,7 @@ jobs:
       - name: Run tests (excluding doctests)
         shell: bash
         run: |
-          cargo test --lib --tests --bins
+          RUST_MIN_STACK=8388608 cargo test --lib --tests --bins
 
   macos:
     name: cargo test (macos)
@@ -90,7 +90,7 @@ jobs:
         uses: ./.github/actions/rust/setup-macos-builder
       - name: Run tests (excluding doctests)
         shell: bash
-        run: cargo test --lib --tests --bins
+        run: RUST_MIN_STACK=8388608 cargo test --lib --tests --bins
 
   macos-aarch64:
     name: cargo test (macos-aarch64)
@@ -103,7 +103,7 @@ jobs:
         uses: ./.github/actions/rust/setup-macos-aarch64-builder
       - name: Run tests (excluding doctests)
         shell: bash
-        run: cargo test --lib --tests --bins
+        run: RUST_MIN_STACK=8388608 cargo test --lib --tests --bins
 
   check-fmt:
     name: Check cargo fmt

--- a/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Field;
 use datafusion::common::{
-    internal_err, plan_err, Column, DFSchema, DFSchemaRef, TableReference,
+    internal_datafusion_err, internal_err, plan_err, Column, DFSchema, DFSchemaRef,
+    TableReference,
 };
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::expr::WildcardOptions;
@@ -584,7 +585,9 @@ fn collect_partial_model_required_fields(
         if !column.is_calculated {
             let expr = create_wren_expr_for_model(
                 &c.name,
-                dataset.try_as_model().unwrap(),
+                dataset.try_as_model().ok_or_else(|| {
+                    internal_datafusion_err!("Only support model as source dataset")
+                })?,
                 Arc::clone(&session_state_ref),
             )?;
             required_fields


### PR DESCRIPTION
# Description
This PR fixes the issue that the RLAC won't be applied when the relationship accesses the model. For example:
- Given a model `orders` with the column `customer_name` which points to the column `name` in another model `customer` through the relationship.
- If `customer` has the RLAC rules, the SQL trying to query `orders.customer_name` should also apply the RLAC rules for the model `customer`.

# Changed
Because we apply the RLAC in `ModelPlanNode`, we can reuse the logic for the relationship accessing. Previously, we built the to-one relationship access through `ModelSourceNode` that won't be applied RLAC.
This PR will build `PartialModelPlanNode` instead of `ModelSourceNode` for the relationship accessing to ensure the RLAC can be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of required fields for partial models, ensuring correct application of row-level access control (RLAC) rules across related models and calculated fields.
  - Enhanced error handling during model plan construction.
  - Simplified model plan construction logic by unifying plan node creation for model targets.

- **Tests**
  - Added comprehensive tests to verify RLAC rule application on both base and related models, especially when using calculated fields and relationships.
  - Updated test snapshots for better readability.

- **Chores**
  - Updated workflow to set a specific environment variable when running Rust tests on multiple platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->