### PR TITLE
chore(tool): add manifest extract for query_local_run

### DIFF
--- a/ibis-server/tools/query_local_run.py
+++ b/ibis-server/tools/query_local_run.py
@@ -22,6 +22,7 @@ from dotenv import load_dotenv
 from wren_core import SessionContext
 from app.model.data_source import BigQueryConnectionInfo
 from app.model.data_source import DataSourceExtension
+import wren_core
 
 if sys.stdin.isatty():
     print("please provide the SQL query via stdin, e.g. `python query_local_run.py < test.sql`", file=sys.stderr)
@@ -57,14 +58,22 @@ with open(manifest_json_path) as file:
 with open(connection_info_path) as file:
     connection_info = json.load(file)
 
+# Extract the requried tables from the SQL query
+extractor = wren_core.ManifestExtractor(encoded_str)
+tables = extractor.resolve_used_table_names(sql)
+print("# Tables used in the SQL query:", tables)
+# Extract the manifest for the required tables
+manifest = extractor.extract_by(tables)
+encoded_str = wren_core.to_json_base64(manifest)
+
 print("### Starting the session context ###")
 print("#")
-session_context = SessionContext(encoded_str, function_list_path + f"{data_source}.csv")
+session_context = SessionContext(encoded_str, function_list_path + f"/{data_source}.csv")
 planned_sql = session_context.transform_sql(sql)
 print("# Planned SQL:\n", planned_sql)
 
 # Transpile the planned SQL
-dialect_sql = sqlglot.transpile(planned_sql, read="trino", write=data_source)[0]
+dialect_sql = sqlglot.transpile(planned_sql, read=None, write=data_source)[0]
 print("# Dialect SQL:\n", dialect_sql)
 print("#")
 


### PR DESCRIPTION
To align the behavior of the real query scenario. I added the manifest extractor to the `query_local_run.py` script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The script now identifies and uses only the relevant tables from your SQL query, optimizing session initialization.
- **Improvements**
  - Adjusted SQL transpilation to use default source dialect.
  - Improved file path handling for function list files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->