### PR TITLE
chore(ibis): add kwargs and security-related arguments for connection info

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -223,6 +223,18 @@ class OracleConnectionInfo(BaseConnectionInfo):
     password: SecretStr | None = Field(
         examples=["password"], description="the password of your database", default=None
     )
+    sid: SecretStr | None = Field(
+        default=None,
+        description="Unique name of an Oracle Instance, used to construct a DSN if provided.",
+    )
+    service_name: SecretStr | None = Field(
+        default=None,
+        description="Oracle service name, used to construct a DSN if provided. Only one of database and service_name should be provided.",
+    )
+    dsn: SecretStr | None = Field(
+        default=None,
+        description="An Oracle Data Source Name. If provided, overrides all other connection arguments except username and password.",
+    )
 
 
 class SnowflakeConnectionInfo(BaseConnectionInfo):

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -131,6 +131,14 @@ class ClickHouseConnectionInfo(BaseConnectionInfo):
     password: SecretStr | None = Field(
         description="the password of your database", examples=["password"], default=None
     )
+    secure: bool = Field(
+        description="Whether or not to use an authenticated endpoint",
+        default=False,
+        examples=[True, False],
+    )
+    kwargs: dict[str, str] | None = Field(
+        description="Client specific keyword arguments", default=None
+    )
 
 
 class MSSqlConnectionInfo(BaseConnectionInfo):
@@ -200,6 +208,10 @@ class PostgresConnectionInfo(BaseConnectionInfo):
     password: SecretStr | None = Field(
         examples=["password"], description="the password of your database", default=None
     )
+    kwargs: dict[str, str] | None = Field(
+        description="Additional keyword arguments to pass to the backend client connection.",
+        default=None,
+    )
 
 
 class OracleConnectionInfo(BaseConnectionInfo):
@@ -236,6 +248,10 @@ class SnowflakeConnectionInfo(BaseConnectionInfo):
         description="the schema name of your database",
         examples=["myschema"],
     )  # Use `sf_schema` to avoid `schema` shadowing in BaseModel
+    kwargs: dict[str, str] | None = Field(
+        description="Additional arguments passed to the DBAPI connection call.",
+        default=None,
+    )
 
 
 class TrinoConnectionInfo(BaseConnectionInfo):
@@ -256,6 +272,10 @@ class TrinoConnectionInfo(BaseConnectionInfo):
     )
     password: SecretStr | None = Field(
         description="the password of your database", examples=["password"], default=None
+    )
+    kwargs: dict[str, str] | None = Field(
+        description="Additional keyword arguments passed directly to the trino.dbapi.connect API.",
+        default=None,
     )
 
 

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -211,11 +211,17 @@ class PostgresConnectionInfo(BaseConnectionInfo):
 
 class OracleConnectionInfo(BaseConnectionInfo):
     host: SecretStr = Field(
-        examples=["localhost"], description="the hostname of your database"
+        examples=["localhost"],
+        description="the hostname of your database",
+        default="default",
     )
-    port: SecretStr = Field(examples=[1521], description="the port of your database")
+    port: SecretStr = Field(
+        examples=[1521], description="the port of your database", default="1521"
+    )
     database: SecretStr = Field(
-        examples=["orcl"], description="the database name of your database"
+        examples=["orcl"],
+        description="the database name of your database",
+        default="orcl",
     )
     user: SecretStr = Field(
         examples=["admin"], description="the username of your database"
@@ -223,17 +229,10 @@ class OracleConnectionInfo(BaseConnectionInfo):
     password: SecretStr | None = Field(
         examples=["password"], description="the password of your database", default=None
     )
-    sid: SecretStr | None = Field(
-        default=None,
-        description="Unique name of an Oracle Instance, used to construct a DSN if provided.",
-    )
-    service_name: SecretStr | None = Field(
-        default=None,
-        description="Oracle service name, used to construct a DSN if provided. Only one of database and service_name should be provided.",
-    )
     dsn: SecretStr | None = Field(
         default=None,
         description="An Oracle Data Source Name. If provided, overrides all other connection arguments except username and password.",
+        examples=["localhost:1521/orcl"],
     )
 
 

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -213,7 +213,7 @@ class OracleConnectionInfo(BaseConnectionInfo):
     host: SecretStr = Field(
         examples=["localhost"],
         description="the hostname of your database",
-        default="default",
+        default="localhost",
     )
     port: SecretStr = Field(
         examples=[1521], description="the port of your database", default="1521"

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -131,11 +131,6 @@ class ClickHouseConnectionInfo(BaseConnectionInfo):
     password: SecretStr | None = Field(
         description="the password of your database", examples=["password"], default=None
     )
-    secure: bool = Field(
-        description="Whether or not to use an authenticated endpoint",
-        default=False,
-        examples=[True, False],
-    )
     kwargs: dict[str, str] | None = Field(
         description="Client specific keyword arguments", default=None
     )

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -183,17 +183,20 @@ class DataSourceExtension(Enum):
 
     @staticmethod
     def get_oracle_connection(info: OracleConnectionInfo) -> BaseBackend:
+        # if dsn is provided, use it to connect
+        # otherwise, use host, port, database, user, password, and sid
+        if hasattr(info, "dsn") and info.dsn:
+            return ibis.oracle.connect(
+                dsn=info.dsn.get_secret_value(),
+                user=info.user.get_secret_value(),
+                password=(info.password and info.password.get_secret_value()),
+            )
         return ibis.oracle.connect(
             host=info.host.get_secret_value(),
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
-            sid=info.sid.get_secret_value() if info.sid else None,
-            service_name=info.service_name.get_secret_value()
-            if info.service_name
-            else None,
-            dsn=info.dsn.get_secret_value() if info.dsn else None,
         )
 
     @staticmethod

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -135,7 +135,7 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
-            secure = info.secure,
+            secure=info.secure,
             **info.kwargs if info.kwargs else dict(),
         )
 

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -189,6 +189,11 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
+            sid=info.sid.get_secret_value() if info.sid else None,
+            service_name=info.service_name.get_secret_value()
+            if info.service_name
+            else None,
+            dsn=info.dsn.get_secret_value() if info.dsn else None,
         )
 
     @staticmethod

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -135,7 +135,6 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
-            secure=info.secure,
             **info.kwargs if info.kwargs else dict(),
         )
 

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -135,6 +135,8 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
+            secure = info.secure,
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @classmethod
@@ -177,6 +179,7 @@ class DataSourceExtension(Enum):
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
             password=(info.password and info.password.get_secret_value()),
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod
@@ -197,6 +200,7 @@ class DataSourceExtension(Enum):
             account=info.account.get_secret_value(),
             database=info.database.get_secret_value(),
             schema=info.sf_schema.get_secret_value(),
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod
@@ -208,6 +212,7 @@ class DataSourceExtension(Enum):
             schema=info.trino_schema.get_secret_value(),
             user=(info.user and info.user.get_secret_value()),
             password=(info.password and info.password.get_secret_value()),
+            **info.kwargs if info.kwargs else dict(),
         )
 
     @staticmethod

--- a/ibis-server/tests/routers/v3/connector/oracle/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/oracle/test_query.py
@@ -132,3 +132,29 @@ async def test_query_with_connection_url(client, manifest_str, connection_url):
     assert len(result["data"]) == 1
     assert result["data"][0][0] == 1
     assert result["dtypes"] is not None
+
+
+async def test_query_with_dsn(client, manifest_str, connection_info):
+    dsn = f"{connection_info['host']}:{connection_info['port']}/{connection_info['database']}"
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": {
+                "dsn": dsn,
+                "user": connection_info["user"],
+                "password": connection_info["password"],
+            },
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" LIMIT 1',
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    # include one hidden column
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"]) - 1
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == 1
+    assert result["dtypes"] is not None


### PR DESCRIPTION
# Changed
Add the security-related arguments for the following data source:
- Clikchouse
- Postgres
- Snowflake
- Trino
- Oracle: `dsn` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying additional client-specific options when connecting to ClickHouse, Postgres, Snowflake, and Trino data sources.
  - Enabled Oracle connections using a Data Source Name (DSN) that overrides other connection parameters.
  - Added default connection values for Oracle including host, port, and database.

- **Enhancements**
  - Improved flexibility for database connections by allowing extra configuration parameters to be passed to each backend.

- **Tests**
  - Added a new test validating Oracle connections using the DSN format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->