### PR TITLE
fix(ibis): Resolved MySQL connection error when password is None

### DIFF
--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -165,7 +165,7 @@ class DataSourceExtension(Enum):
             port=int(info.port.get_secret_value()),
             database=info.database.get_secret_value(),
             user=info.user.get_secret_value(),
-            password=(info.password and info.password.get_secret_value()),
+            password=info.password.get_secret_value() if info.password else "",
             **kwargs,
         )
 


### PR DESCRIPTION
## Description

This PR fixes a `TypeError` raised during MySQL connection when the password field is `None`. Although the `password` field is optional and defaults to `None`, passing `None` directly to `ibis.mysql.connect()` causes the following error:
```python
TypeError: connect() argument 3 must be str, not None
```



https://github.com/Canner/WrenAI/issues/1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of MySQL connection passwords to prevent issues when no password is provided. The system now consistently passes an empty string instead of `None` when no password is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->