### PR TITLE
fix(core): disable EliminateLimit rule

### DIFF
--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -3,7 +3,7 @@ import base64
 import orjson
 import pytest
 
-from app.dependencies import X_WREN_VARIABLE_PREFIX
+from app.dependencies import X_WREN_FALLBACK_DISABLE, X_WREN_VARIABLE_PREFIX
 from tests.routers.v3.connector.postgres.conftest import base_url
 
 manifest = {
@@ -160,6 +160,34 @@ async def test_query(client, manifest_str, connection_info):
         "timestamptz": "object",
         "dst_utc_minus_5": "object",
         "dst_utc_minus_4": "object",
+    }
+
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM wren.public.orders LIMIT 0",
+        },
+        headers={
+            X_WREN_FALLBACK_DISABLE: "true",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == 10
+    assert len(result["data"]) == 0
+    assert result["dtypes"] == {
+        "o_orderkey": "int32",
+        "o_custkey": "int32",
+        "o_orderstatus": "object",
+        "o_totalprice_double": "float64",
+        "o_orderdate": "datetime64[s]",
+        "order_cust_key": "object",
+        "timestamp": "datetime64[ns]",
+        "timestamptz": "datetime64[ns, UTC]",
+        "dst_utc_minus_5": "datetime64[ns, UTC]",
+        "dst_utc_minus_4": "datetime64[ns, UTC]",
     }
 
 

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -195,7 +195,7 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         Arc::new(EliminateCrossJoin::new()),
         // Disable CommonSubexprEliminate to avoid generate invalid projection plan
         // Arc::new(CommonSubexprEliminate::new()),
-        Arc::new(EliminateLimit::new()),
+        // Arc::new(EliminateLimit::new()),
         Arc::new(PropagateEmptyRelation::new()),
         // Must be after PropagateEmptyRelation
         Arc::new(EliminateOneUnion::new()),

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -2586,6 +2586,36 @@ mod test {
         );
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_disable_eliminate_limit() -> Result<()> {
+        let ctx = SessionContext::new();
+
+        // test required property
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("customer")
+                    .table_reference("customer")
+                    .column(ColumnBuilder::new("c_nationkey", "int").build())
+                    .column(ColumnBuilder::new("c_name", "string").build())
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+        )?);
+        let sql = "SELECT * FROM customer limit 0";
+        let headers = Arc::new(HashMap::default());
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], headers, sql).await?,
+            @"SELECT customer.c_nationkey, customer.c_name FROM (SELECT customer.c_name, customer.c_nationkey FROM (SELECT __source.c_name AS c_name, __source.c_nationkey AS c_nationkey FROM customer AS __source) AS customer) AS customer LIMIT 0"
+        );
+        Ok(())
+    }
+
     /// Return a RecordBatch with made up data about customer
     fn customer() -> RecordBatch {
         let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));


### PR DESCRIPTION
The EliminateLimit optimization rule will skip the plan if the plan is limited to 0. The unparser can't handle the generated plans. For example:
```
SELECT * FROM orders LIMIT 0
```
It will be unparsed to 
```
SELECT *
```

We should disable the rule to get the correct result.
