### PR TITLE
feat(ibis): add Redshift IAM credential support

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -288,7 +288,8 @@ class RedshiftConnectionInfo(BaseConnectionInfo):
 class RedshiftIAMConnectionInfo(BaseConnectionInfo):
     redshift_type: Literal["redshift_iam"] = "redshift_iam"
     cluster_identifier: SecretStr = Field(
-        description="the hostname of your database", examples=["localhost"]
+        description="the cluster identifier of your Redshift cluster",
+        examples=["my-redshift-cluster"],
     )
     database: SecretStr = Field(
         description="the database name of your database", examples=["dev"]

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -267,7 +267,7 @@ class OracleConnectionInfo(BaseConnectionInfo):
 
 
 class RedshiftConnectionInfo(BaseConnectionInfo):
-    type: Literal["redshift"] = "redshift"
+    redshift_type: Literal["redshift"] = "redshift"
     host: SecretStr = Field(
         description="the hostname of your database", examples=["localhost"]
     )
@@ -286,7 +286,7 @@ class RedshiftConnectionInfo(BaseConnectionInfo):
 # AWS Redshift IAM Connection Info
 # This class is used to connect to AWS Redshift using IAM authentication.
 class RedshiftIAMConnectionInfo(BaseConnectionInfo):
-    type: Literal["redshift_iam"] = "redshift_iam"
+    redshift_type: Literal["redshift_iam"] = "redshift_iam"
     cluster_identifier: SecretStr = Field(
         description="the hostname of your database", examples=["localhost"]
     )
@@ -309,7 +309,7 @@ class RedshiftIAMConnectionInfo(BaseConnectionInfo):
 
 RedshiftConnectionUnion = Annotated[
     Union[RedshiftConnectionInfo, RedshiftIAMConnectionInfo],
-    Field(discriminator="type"),
+    Field(discriminator="redshift_type"),
 ]
 
 

--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from enum import Enum
+from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field, SecretStr
 from starlette.status import (
@@ -65,7 +66,7 @@ class QueryPostgresDTO(QueryDTO):
 
 
 class QueryRedshiftDTO(QueryDTO):
-    connection_info: RedshiftConnectionInfo = connection_info_field
+    connection_info: RedshiftConnectionUnion = connection_info_field
 
 
 class QuerySnowflakeDTO(QueryDTO):
@@ -266,6 +267,7 @@ class OracleConnectionInfo(BaseConnectionInfo):
 
 
 class RedshiftConnectionInfo(BaseConnectionInfo):
+    type: Literal["redshift"] = "redshift"
     host: SecretStr = Field(
         description="the hostname of your database", examples=["localhost"]
     )
@@ -279,6 +281,36 @@ class RedshiftConnectionInfo(BaseConnectionInfo):
     password: SecretStr = Field(
         description="the password of your database", examples=["password"]
     )
+
+
+# AWS Redshift IAM Connection Info
+# This class is used to connect to AWS Redshift using IAM authentication.
+class RedshiftIAMConnectionInfo(BaseConnectionInfo):
+    type: Literal["redshift_iam"] = "redshift_iam"
+    cluster_identifier: SecretStr = Field(
+        description="the hostname of your database", examples=["localhost"]
+    )
+    database: SecretStr = Field(
+        description="the database name of your database", examples=["dev"]
+    )
+    user: SecretStr = Field(
+        description="the username of your database", examples=["awsuser"]
+    )
+    region: SecretStr = Field(
+        description="the region of your database", examples=["us-west-2"]
+    )
+    access_key_id: SecretStr = Field(
+        description="the access key id of your database", examples=["AKIA..."]
+    )
+    access_key_secret: SecretStr = Field(
+        description="the secret access key of your database", examples=["my-secret-key"]
+    )
+
+
+RedshiftConnectionUnion = Annotated[
+    Union[RedshiftConnectionInfo, RedshiftIAMConnectionInfo],
+    Field(discriminator="type"),
+]
 
 
 class SnowflakeConnectionInfo(BaseConnectionInfo):
@@ -419,6 +451,7 @@ ConnectionInfo = (
     | OracleConnectionInfo
     | PostgresConnectionInfo
     | RedshiftConnectionInfo
+    | RedshiftIAMConnectionInfo
     | SnowflakeConnectionInfo
     | TrinoConnectionInfo
     | LocalFileConnectionInfo

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -23,6 +23,7 @@ from app.model import (
     GcsFileConnectionInfo,
     MinioFileConnectionInfo,
     RedshiftConnectionInfo,
+    RedshiftConnectionUnion,
     RedshiftIAMConnectionInfo,
     S3FileConnectionInfo,
     UnknownIbisError,
@@ -218,7 +219,7 @@ class DuckDBConnector:
 
 
 class RedshiftConnector:
-    def __init__(self, connection_info: ConnectionInfo):
+    def __init__(self, connection_info: RedshiftConnectionUnion):
         import redshift_connector
 
         if isinstance(connection_info, RedshiftIAMConnectionInfo):

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -22,6 +22,8 @@ from app.model import (
     ConnectionInfo,
     GcsFileConnectionInfo,
     MinioFileConnectionInfo,
+    RedshiftConnectionInfo,
+    RedshiftIAMConnectionInfo,
     S3FileConnectionInfo,
     UnknownIbisError,
     UnprocessableEntityError,
@@ -219,13 +221,26 @@ class RedshiftConnector:
     def __init__(self, connection_info: ConnectionInfo):
         import redshift_connector
 
-        self.connection = redshift_connector.connect(
-            host=connection_info.host.get_secret_value(),
-            port=connection_info.port.get_secret_value(),
-            database=connection_info.database.get_secret_value(),
-            user=connection_info.user.get_secret_value(),
-            password=connection_info.password.get_secret_value(),
-        )
+        if isinstance(connection_info, RedshiftIAMConnectionInfo):
+            self.connection = redshift_connector.connect(
+                iam=True,
+                cluster_identifier=connection_info.cluster_identifier.get_secret_value(),
+                database=connection_info.database.get_secret_value(),
+                db_user=connection_info.user.get_secret_value(),
+                access_key_id=connection_info.access_key_id.get_secret_value(),
+                secret_access_key=connection_info.access_key_secret.get_secret_value(),
+                region=connection_info.region.get_secret_value(),
+            )
+        elif isinstance(connection_info, RedshiftConnectionInfo):
+            self.connection = redshift_connector.connect(
+                host=connection_info.host.get_secret_value(),
+                port=connection_info.port.get_secret_value(),
+                database=connection_info.database.get_secret_value(),
+                user=connection_info.user.get_secret_value(),
+                password=connection_info.password.get_secret_value(),
+            )
+        else:
+            raise ValueError("Invalid Redshift connection_info type")
 
     @tracer.start_as_current_span("connector_query", kind=trace.SpanKind.CLIENT)
     def query(self, sql: str, limit: int) -> pd.DataFrame:

--- a/ibis-server/tests/routers/v2/connector/test_redshift.py
+++ b/ibis-server/tests/routers/v2/connector/test_redshift.py
@@ -12,6 +12,7 @@ base_url = "/v2/connector/redshift"
 
 # The testing database "tpch" only has "orders" table.
 connection_info = {
+    "redshift_type": "redshift",
     "host": os.getenv("TEST_REDSHIFT_HOST"),
     "port": "5439",
     "database": "tpch",
@@ -20,6 +21,7 @@ connection_info = {
 }
 
 aws_iam_connection_info = {
+    "redshift_type": "redshift_iam",
     "cluster_identifier": os.getenv("TEST_REDSHIFT_CLUSTER_ID"),
     "database": "tpch",
     "user": os.getenv("TEST_REDSHIFT_USER", "awsuser"),

--- a/ibis-server/tests/routers/v2/connector/test_redshift.py
+++ b/ibis-server/tests/routers/v2/connector/test_redshift.py
@@ -19,6 +19,15 @@ connection_info = {
     "password": os.getenv("TEST_REDSHIFT_PASSWORD"),
 }
 
+aws_iam_connection_info = {
+    "cluster_identifier": os.getenv("TEST_REDSHIFT_CLUSTER_ID"),
+    "database": "tpch",
+    "user": os.getenv("TEST_REDSHIFT_USER", "awsuser"),
+    "region": os.getenv("TEST_REDSHIFT_REGION"),
+    "access_key_id": os.getenv("TEST_REDSHIFT_ACCESS_KEY_ID"),
+    "access_key_secret": os.getenv("TEST_REDSHIFT_SECRET_ACCESS_KEY"),
+}
+
 manifest = {
     "catalog": "my_catalog",
     "schema": "my_schema",
@@ -82,6 +91,46 @@ async def test_query(client, manifest_str):
         url=f"{base_url}/query",
         json={
             "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["columns"]) == len(manifest["models"][0]["columns"])
+    assert len(result["data"]) == 1
+
+    assert result["data"][0] == [
+        1,
+        655,
+        "O",
+        "347.61",
+        "2023-05-21",
+        "1_655",
+        "2024-01-01 23:59:59.000000",
+        "2024-01-01 23:59:59.000000 UTC",
+        None,
+        "abc",
+    ]
+    assert result["dtypes"] == {
+        "orderkey": "int64",
+        "custkey": "int64",
+        "orderstatus": "object",
+        "totalprice": "object",
+        "orderdate": "object",
+        "order_cust_key": "object",
+        "timestamp": "object",
+        "timestamptz": "object",
+        "test_null_time": "object",
+        "bytea_column": "object",
+    }
+
+
+async def test_query_with_aws_iam_credential(client, manifest_str):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": aws_iam_connection_info,
             "manifestStr": manifest_str,
             "sql": 'SELECT * FROM "Orders" ORDER BY orderkey LIMIT 1',
         },

--- a/ibis-server/tests/routers/v3/connector/redshift/conftest.py
+++ b/ibis-server/tests/routers/v3/connector/redshift/conftest.py
@@ -23,6 +23,7 @@ def pytest_collection_modifyitems(items):
 @pytest.fixture(scope="session")
 def connection_info():
     return {
+        "redshift_type": "redshift",
         "host": os.getenv("TEST_REDSHIFT_HOST"),
         "port": "5439",
         "database": "tpch",


### PR DESCRIPTION
Adds  IAM authentication for Amazon Redshift.

We can also connect to Redshift using an `access_key_id` and `access_key_secret`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for AWS Redshift IAM authentication, enabling connections using IAM credentials alongside traditional username/password methods.

- **Tests**
  - Introduced tests to validate Redshift queries using IAM authentication credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->