### PR TITLE
fix(ibis): Correctly filter Oracle tables by connected user's schema

### DIFF
--- a/ibis-server/app/model/metadata/oracle.py
+++ b/ibis-server/app/model/metadata/oracle.py
@@ -19,7 +19,8 @@ class OracleMetadata(Metadata):
         self.connection = DataSource.oracle.get_connection(connection_info)
 
     def get_table_list(self) -> list[Table]:
-        sql = """
+        user = self.connection_info.user.get_secret_value()
+        sql = f"""
             SELECT
                 t.owner AS TABLE_CATALOG,
                 t.owner AS TABLE_SCHEMA,
@@ -46,7 +47,7 @@ class OracleMetadata(Metadata):
                 AND cc.table_name = c.table_name
                 AND cc.column_name = c.column_name
             WHERE
-                t.owner = 'SYSTEM'
+                t.owner = '{user}'
             ORDER BY
                 t.table_name, c.column_id;
         """

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -180,14 +180,14 @@ async def test_query(client, manifest_str, connection_info):
     assert result["dtypes"] == {
         "o_orderkey": "int32",
         "o_custkey": "int32",
-        "o_orderstatus": "object",
-        "o_totalprice_double": "float64",
-        "o_orderdate": "datetime64[s]",
-        "order_cust_key": "object",
-        "timestamp": "datetime64[ns]",
-        "timestamptz": "datetime64[ns, UTC]",
-        "dst_utc_minus_5": "datetime64[ns, UTC]",
-        "dst_utc_minus_4": "datetime64[ns, UTC]",
+        "o_orderstatus": "string",
+        "o_totalprice_double": "double",
+        "o_orderdate": "date32[day]",
+        "order_cust_key": "string",
+        "timestamp": "timestamp[us]",
+        "timestamptz": "timestamp[us, tz=UTC]",
+        "dst_utc_minus_5": "timestamp[us, tz=UTC]",
+        "dst_utc_minus_4": "timestamp[us, tz=UTC]",
     }
 
 


### PR DESCRIPTION
**Summary**
This PR addresses a bug in the `OracleMetadata.get_table_list` method where the table discovery was incorrectly limited to the SYSTEM schema. The fix ensures that the query correctly uses the connected user's schema to find tables.

**The Problem**
Currently, the SQL query within the `get_table_list` method contains a hardcoded WHERE clause: `t.owner = 'SYSTEM'`. This means that regardless of which user is configured in the connection, the system will only ever search for tables owned by SYSTEM.

**Related Issues**
Closes https://github.com/Canner/wren-engine/issues/1213
Closes https://github.com/Canner/wren-engine/issues/1175
Closes https://github.com/Canner/WrenAI/issues/1743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table filtering to display only tables belonging to the current user’s schema when viewing Oracle database metadata.
  * Updated data type representations for query results to enhance accuracy in PostgreSQL connector tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->