### PR TITLE
feat(ibis): Add safe rounding for Decimal columns to support PyArrow Decimal128 limits

### DIFF
--- a/ibis-server/app/query_cache/__init__.py
+++ b/ibis-server/app/query_cache/__init__.py
@@ -9,6 +9,8 @@ from duckdb import DuckDBPyConnection, connect
 from loguru import logger
 from opentelemetry import trace
 
+from app.util import round_decimal_columns
+
 tracer = trace.get_tracer(__name__)
 
 
@@ -27,9 +29,11 @@ class QueryCacheManager:
         if op.exists(cache_file_name):
             try:
                 logger.info(f"Reading query cache {cache_file_name}")
-                df = ibis.read_parquet(full_path).to_pyarrow()
+                ibis_table = ibis.read_parquet(full_path)
+                ibis_table = round_decimal_columns(ibis_table)
+                arrow_table = ibis_table.to_pyarrow()
                 logger.info("query cache to dataframe")
-                return df
+                return arrow_table
             except Exception as e:
                 logger.debug(f"Failed to read query cache {e}")
                 return None

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -188,13 +188,13 @@ def pd_to_arrow_schema(df: pd.DataFrame) -> pa.Schema:
     return pa.schema(fields)
 
 
-def round_decimal_columns(ibis_table: Table, scale: int = 8) -> Table:
+def round_decimal_columns(ibis_table: Table, scale: int = 9) -> Table:
     fields = []
     for name, dtype in ibis_table.schema().items():
         col = ibis_table[name]
         if isinstance(dtype, Decimal):
-            # maxinum precision for pyarrow decimal is 38, so we limit it to 36
-            decimal_type = Decimal(precision=36, scale=scale)
+            # maxinum precision for pyarrow decimal is 38
+            decimal_type = Decimal(precision=38, scale=scale)
             col = col.cast(decimal_type).round(scale)
             fields.append(col.name(name))
         else:

--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -6,6 +6,8 @@ import pandas as pd
 import pyarrow as pa
 import wren_core
 from fastapi import Header
+from ibis.expr.datatypes import Decimal
+from ibis.expr.types import Table
 from loguru import logger
 from opentelemetry import trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
@@ -184,6 +186,20 @@ def pd_to_arrow_schema(df: pd.DataFrame) -> pa.Schema:
             pa_type = pa.string()
         fields.append(pa.field(column, pa_type))
     return pa.schema(fields)
+
+
+def round_decimal_columns(ibis_table: Table, scale: int = 8) -> Table:
+    fields = []
+    for name, dtype in ibis_table.schema().items():
+        col = ibis_table[name]
+        if isinstance(dtype, Decimal):
+            # maxinum precision for pyarrow decimal is 38, so we limit it to 36
+            decimal_type = Decimal(precision=36, scale=scale)
+            col = col.cast(decimal_type).round(scale)
+            fields.append(col.name(name))
+        else:
+            fields.append(col)
+    return ibis_table.select(*fields)
 
 
 def update_response_headers(response, required_headers: dict):

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -1023,7 +1023,7 @@ async def test_decimal_precision(client, manifest_str, postgres: PostgresContain
     assert response.status_code == 200
     result = response.json()
     assert len(result["data"]) == 1
-    assert result["data"][0][0] == "0.33333333"
+    assert result["data"][0][0] == "0.333333333"
 
 
 def _to_connection_info(pg: PostgresContainer):

--- a/ibis-server/tests/routers/v2/connector/test_postgres.py
+++ b/ibis-server/tests/routers/v2/connector/test_postgres.py
@@ -1010,6 +1010,22 @@ async def test_postgis_geometry(client, manifest_str, postgis: PostgresContainer
     assert result["data"][0] == [74.66265347816136]
 
 
+async def test_decimal_precision(client, manifest_str, postgres: PostgresContainer):
+    connection_info = _to_connection_info(postgres)
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT cast(1 as decimal(38, 8)) / cast(3 as decimal(38, 8)) as result",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == "0.33333333"
+
+
 def _to_connection_info(pg: PostgresContainer):
     return {
         "host": pg.get_container_host_ip(),

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -335,4 +335,4 @@ async def test_decimal_precision(client, manifest_str, connection_info):
     assert response.status_code == 200
     result = response.json()
     assert len(result["data"]) == 1
-    assert result["data"][0][0] == "0.33333333"
+    assert result["data"][0][0] == "0.333333333"

--- a/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/bigquery/test_query.py
@@ -321,3 +321,18 @@ async def test_timestamp_func(client, manifest_str, connection_info):
     assert result["dtypes"] == {
         "compare": "bool",
     }
+
+
+async def test_decimal_precision(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT cast(1 as decimal(38, 8)) / cast(3 as decimal(38, 8)) as result",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+    assert result["data"][0][0] == "0.33333333"

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -697,3 +697,19 @@ SELECT
         "1.123456789",  # round_to_9_decimal_places
         "0.12345678912345678",  # round_to_18_decimal_places
     ]
+
+
+async def test_decimal_precision(client, manifest_str, connection_info):
+    response = await client.post(
+        url=f"{base_url}/query",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT cast(1 as decimal(38, 8)) / cast(3 as decimal(38, 8)) as result",
+        },
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert len(result["data"]) == 1
+    assert len(result["data"][0]) == 1
+    assert result["data"][0][0] == "0.33333333"

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -711,4 +711,4 @@ async def test_decimal_precision(client, manifest_str, connection_info):
     assert response.status_code == 200
     result = response.json()
     assert len(result["data"]) == 1
-    assert result["data"][0][0] == "0.33333333"
+    assert result["data"][0][0] == "0.333333333"

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -711,5 +711,4 @@ async def test_decimal_precision(client, manifest_str, connection_info):
     assert response.status_code == 200
     result = response.json()
     assert len(result["data"]) == 1
-    assert len(result["data"][0]) == 1
     assert result["data"][0][0] == "0.33333333"


### PR DESCRIPTION
We ensures decimal columns are cast and rounded to a fixed scale (default: 9) with a maximum precision of 36, aligning with the pyarrow Decimal128 limit (max 38). 

It prevents overflow or unsupported precision issues when exporting or operating on decimal columns using pyarrow backends.