### PR TITLE
fix(core-py): avoid to generate duplicate models after extracting manifest

### DIFF
--- a/wren-core-base/src/mdl/manifest.rs
+++ b/wren-core-base/src/mdl/manifest.rs
@@ -288,6 +288,18 @@ impl Model {
     }
 }
 
+impl PartialOrd for Model {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Model {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
 impl Column {
     /// Return the name of the column
     pub fn name(&self) -> &str {

--- a/wren-core-py/src/context.rs
+++ b/wren-core-py/src/context.rs
@@ -20,8 +20,8 @@ use crate::manifest::to_manifest;
 use crate::remote_functions::PyRemoteFunction;
 use log::debug;
 use pyo3::types::{PyAnyMethods, PyFrozenSet, PyFrozenSetMethods, PyTuple};
-use pyo3::{PyObject, Python};
 use pyo3::{pyclass, pymethods, PyErr, PyResult};
+use pyo3::{PyObject, Python};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::ControlFlow;
@@ -187,10 +187,7 @@ impl PySessionContext {
 
     /// Transform the given Wren SQL to the equivalent Planned SQL.
     #[pyo3(signature = (sql=None))]
-    pub fn transform_sql(
-        &self,
-        sql: Option<&str>,
-    ) -> PyResult<String> {
+    pub fn transform_sql(&self, sql: Option<&str>) -> PyResult<String> {
         env_logger::try_init().ok();
         let Some(sql) = sql else {
             return Err(CoreError::new("SQL is required").into());

--- a/wren-core-py/tests/test_modeling_core.py
+++ b/wren-core-py/tests/test_modeling_core.py
@@ -249,9 +249,9 @@ def test_resolve_used_table_names(sql, expected):
 @pytest.mark.parametrize(
     ("dataset", "expected_models"),
     [
-        (["customer"], ["customer", "orders", "lineitem"]),
-        (["customer_view"], ["customer", "orders", "lineitem"]),
-        (["orders"], ["orders", "lineitem"]),
+        (["customer"], ["customer", "lineitem", "orders"]),
+        (["customer_view"], ["customer", "lineitem", "orders"]),
+        (["orders"], ["lineitem", "orders"]),
         (["lineitem"], ["lineitem"]),
     ],
 )


### PR DESCRIPTION
Currently, if a model is used by a view, both of them are used by the SQL. We will get the duplicate models. For example:
Given a `modelA` and a `viewA` whose statement is `select * from modelA`. If we try to extract the following SQL:
```
select * from modelA, viewA
```
The extracted model would be `[modelA, modelA`. It's not valid for the MDL definition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models are now consistently ordered alphabetically in relevant outputs.

* **Bug Fixes**
  * Duplicate models are removed and the ordering of models is now predictable and sorted in extraction results.

* **Tests**
  * Updated and expanded test cases to reflect the new model ordering and to ensure correct extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->