### PR TITLE
fix: trino metadata query with many catalogs

### DIFF
--- a/ibis-server/app/model/metadata/trino.py
+++ b/ibis-server/app/model/metadata/trino.py
@@ -43,6 +43,7 @@ class TrinoMetadata(Metadata):
                     AND t.table_schema = tc.schema_name
                     AND t.table_name = tc.table_name
                 WHERE t.table_schema = '{schema}'
+                AND c.table_catalog = (SELECT current_catalog)
                 """
         response = self.connection.sql(sql).to_pandas().to_dict(orient="records")
         unique_tables = {}


### PR DESCRIPTION
Add additional filter in Trino metadata query
Fixes issue #1251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of table listings by ensuring only tables from the current catalog are included in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->