### PR TITLE
fix(development): upgrade python image to fix nightly image building 

### DIFF
--- a/ibis-server/Dockerfile
+++ b/ibis-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-buster AS builder
+FROM python:3.11-bookworm AS builder
 
 ARG ENV
 ENV ENV=$ENV
@@ -42,8 +42,8 @@ FROM python:3.11-slim-bookworm AS runtime
 # Add microsoft package list
 RUN apt-get update \
     && apt-get install -y curl gnupg \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
-    && curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+    && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg \
+    && echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" | tee /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update
 
 # Install msodbcsql 18 driver for mssql

--- a/ibis-server/Dockerfile
+++ b/ibis-server/Dockerfile
@@ -37,13 +37,13 @@ COPY . .
 RUN just install --without dev
 
 
-FROM python:3.11-slim-buster AS runtime
+FROM python:3.11-slim-bookworm AS runtime
 
 # Add microsoft package list
 RUN apt-get update \
     && apt-get install -y curl gnupg \
     && curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
-    && curl https://packages.microsoft.com/config/debian/11/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update
 
 # Install msodbcsql 18 driver for mssql


### PR DESCRIPTION
# Description
- Debain Buster has been deperacted. It leads to [the building failure](https://github.com/Canner/wren-engine/actions/runs/16286446133/job/45986089293).
    - https://wiki.debian.org/DebianReleases
- Upgrade to Bookworm. It worked well. https://github.com/Canner/wren-engine/actions/runs/16309370570
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the underlying operating system version used in the server environment to improve compatibility and package support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->