### PR TITLE
fix(ibis): remove psycopg2 from the release envrioment

### DIFF
--- a/ibis-server/app/util.py
+++ b/ibis-server/app/util.py
@@ -6,7 +6,6 @@ import datafusion
 import orjson
 import pandas as pd
 import psycopg
-import psycopg2
 import pyarrow as pa
 import wren_core
 from fastapi import Header
@@ -268,7 +267,7 @@ async def execute_with_timeout(operation, operation_name: str):
         raise DatabaseTimeoutError(
             f"{operation_name} timeout after {app_timeout_seconds} seconds"
         )
-    except (psycopg.errors.QueryCanceled, psycopg2.errors.QueryCanceled) as e:
+    except psycopg.errors.QueryCanceled as e:
         raise DatabaseTimeoutError(f"{operation_name} was cancelled: {e}")
 
 


### PR DESCRIPTION
`psycopg2` is only used in the `dev` profile for testing. It shouldn't be imported in the formal release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved exception handling for query timeouts to streamline error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->