### PR TITLE
feat(ibis): Include HTTP headers in query cache key generation

### DIFF
--- a/ibis-server/app/dependencies.py
+++ b/ibis-server/app/dependencies.py
@@ -7,6 +7,7 @@ from app.model.data_source import DataSource
 X_WREN_FALLBACK_DISABLE = "x-wren-fallback_disable"
 X_WREN_VARIABLE_PREFIX = "x-wren-variable-"
 X_WREN_TIMEZONE = "x-wren-timezone"
+X_WREN_DB_STATEMENT_TIMEOUT = "x-wren-db-statement_timeout"
 X_CACHE_HIT = "X-Cache-Hit"
 X_CACHE_CREATE_AT = "X-Cache-Create-At"
 X_CACHE_OVERRIDE = "X-Cache-Override"

--- a/ibis-server/app/query_cache/__init__.py
+++ b/ibis-server/app/query_cache/__init__.py
@@ -17,8 +17,10 @@ class QueryCacheManager:
         self.root = root
 
     @tracer.start_as_current_span("get_cache", kind=trace.SpanKind.INTERNAL)
-    def get(self, data_source: str, sql: str, info) -> Any | None:
-        cache_key = self._generate_cache_key(data_source, sql, info)
+    def get(
+        self, data_source: str, sql: str, info, headers: dict[str, str] | None = None
+    ) -> Any | None:
+        cache_key = self._generate_cache_key(data_source, sql, info, headers)
         cache_file_name = self._get_cache_file_name(cache_key)
         op = self._get_dal_operator()
         full_path = self._get_full_path(cache_file_name)
@@ -43,8 +45,9 @@ class QueryCacheManager:
         sql: str,
         result: pa.Table,
         info,
+        headers: dict[str, str] | None = None,
     ) -> None:
-        cache_key = self._generate_cache_key(data_source, sql, info)
+        cache_key = self._generate_cache_key(data_source, sql, info, headers)
         cache_file_name = self._set_cache_file_name(cache_key)
         op = self._get_dal_operator()
         full_path = self._get_full_path(cache_file_name)
@@ -59,8 +62,10 @@ class QueryCacheManager:
             logger.debug(f"Failed to write query cache: {e}")
             return
 
-    def get_cache_file_timestamp(self, data_source: str, sql: str, info) -> int | None:
-        cache_key = self._generate_cache_key(data_source, sql, info)
+    def get_cache_file_timestamp(
+        self, data_source: str, sql: str, info, headers: dict[str, str] | None = None
+    ) -> int | None:
+        cache_key = self._generate_cache_key(data_source, sql, info, headers)
         op = self._get_dal_operator()
         for file in op.list("/"):
             if file.path.startswith(cache_key):
@@ -75,13 +80,49 @@ class QueryCacheManager:
                     )
         return None
 
-    def _generate_cache_key(self, data_source: str, sql: str, info) -> str:
+    def _generate_cache_key(
+        self, data_source: str, sql: str, info, headers: dict[str, str] | None = None
+    ) -> str:
         connection_key = info.to_key_string()
 
-        # Combine with data source and SQL
-        key_string = f"{data_source}|{sql}|{connection_key}"
+        # Create a normalized headers string for cache key
+        headers_key = self._normalize_headers_for_cache(headers)
+
+        # Combine with data source, SQL, connection info, and headers
+        key_string = f"{data_source}|{sql}|{connection_key}|{headers_key}"
 
         return hashlib.sha256(key_string.encode()).hexdigest()
+
+    def _normalize_headers_for_cache(
+        self, headers: dict[str, str] | None = None
+    ) -> str:
+        if not headers:
+            return ""
+
+        # Define which headers should be included in cache key
+        # These are headers that can affect the query results
+        cache_relevant_headers = [
+            "x-wren-variable",  # All Wren variable headers (prefix match)
+            "x-wren-db-statement_timeout",
+            "x-wren-timezone",
+        ]
+
+        # Filter headers that are relevant for caching
+        relevant_headers = {}
+        for key, value in headers.items():
+            key_lower = key.lower()
+            for relevant_prefix in cache_relevant_headers:
+                if key_lower.startswith(relevant_prefix):
+                    relevant_headers[key_lower] = str(value)
+                    break
+
+        # Sort headers by key to ensure consistent ordering
+        sorted_headers = sorted(relevant_headers.items())
+
+        # Create a string representation
+        headers_str = "|".join([f"{k}:{v}" for k, v in sorted_headers])
+
+        return headers_str
 
     def _get_cache_file_name(self, cache_key: str) -> str:
         op = self._get_dal_operator()

--- a/ibis-server/app/query_cache/__init__.py
+++ b/ibis-server/app/query_cache/__init__.py
@@ -9,6 +9,13 @@ from duckdb import DuckDBPyConnection, connect
 from loguru import logger
 from opentelemetry import trace
 
+from app.dependencies import (
+    X_WREN_DB_STATEMENT_TIMEOUT,
+    X_WREN_FALLBACK_DISABLE,
+    X_WREN_TIMEZONE,
+    X_WREN_VARIABLE_PREFIX,
+)
+
 tracer = trace.get_tracer(__name__)
 
 
@@ -102,9 +109,10 @@ class QueryCacheManager:
         # Define which headers should be included in cache key
         # These are headers that can affect the query results
         cache_relevant_headers = [
-            "x-wren-variable",  # All Wren variable headers (prefix match)
-            "x-wren-db-statement_timeout",
-            "x-wren-timezone",
+            X_WREN_VARIABLE_PREFIX,
+            X_WREN_FALLBACK_DISABLE,
+            X_WREN_TIMEZONE,
+            X_WREN_DB_STATEMENT_TIMEOUT,
         ]
 
         # Filter headers that are relevant for caching

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -796,3 +796,334 @@ async def test_order_by_nulls_last(client, manifest_str, connection_info):
     assert result["data"][0][0] == "two"
     assert result["data"][1][0] == "one"
     assert result["data"][2][0] == "three"
+
+
+async def test_cache_with_different_wren_variables(
+    client, manifest_str, connection_info
+):
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT c_name FROM customer",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"  # Cache miss on first request
+    result1 = response1.json()
+    assert len(result1["data"]) == 1
+    assert result1["data"][0][0] == "Customer#000000001"
+
+    # Second request with same session_user - should hit cache
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT c_name FROM customer",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.headers["X-Cache-Hit"] == "true"  # Should hit cache
+    result2 = response2.json()
+    assert result1["data"] == result2["data"]
+
+    # Third request with different session_user - should miss cache and create new entry
+    response3 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT c_name FROM customer",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000002'",
+        },
+    )
+    assert response3.status_code == 200
+    assert (
+        response3.headers["X-Cache-Hit"] == "false"
+    )  # Should miss cache due to different header
+    result3 = response3.json()
+    # Results should be different due to row-level access control
+    assert result1["data"] != result3["data"] if len(result3["data"]) > 0 else True
+
+
+async def test_cache_with_different_session_levels(
+    client, manifest_str, connection_info
+):
+    # First request with session_level = 1
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"
+    result1 = response1.json()
+    assert len(result1["data"][0]) == 3  # Should show c_name column
+
+    # Second request with same session_level - should hit cache
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.headers["X-Cache-Hit"] == "true"
+    assert result1["data"] == response2.json()["data"]
+
+    # Third request with different session_level - should miss cache
+    response3 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "2",
+        },
+    )
+    assert response3.status_code == 200
+    assert (
+        response3.headers["X-Cache-Hit"] == "false"
+    )  # Different header should miss cache
+    result3 = response3.json()
+    assert len(result3["data"][0]) == 2  # Should hide c_name column
+
+
+async def test_cache_with_timeout_headers(client, manifest_str, connection_info):
+    # First request with timeout = 30
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_DB_STATEMENT_TIMEOUT: "30",
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"
+
+    # Second request with same timeout - should hit cache
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_DB_STATEMENT_TIMEOUT: "30",
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.headers["X-Cache-Hit"] == "true"
+
+    # Third request with different timeout - should miss cache
+    response3 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_DB_STATEMENT_TIMEOUT: "60",
+        },
+    )
+    assert response3.status_code == 200
+    assert (
+        response3.headers["X-Cache-Hit"] == "false"
+    )  # Different timeout should miss cache
+
+
+async def test_cache_ignores_irrelevant_headers(client, manifest_str, connection_info):
+    # First request with user-agent header
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            "User-Agent": "TestClient/1.0",
+            "X-Request-ID": "request-123",
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"
+
+    # Second request with different irrelevant headers - should still hit cache
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            "User-Agent": "TestClient/2.0",
+            "X-Request-ID": "request-456",
+            "Accept": "application/json",
+        },
+    )
+    assert response2.status_code == 200
+    assert (
+        response2.headers["X-Cache-Hit"] == "true"
+    )  # Should hit cache despite different irrelevant headers
+
+
+async def test_cache_with_multiple_wren_variables(
+    client, manifest_str, connection_info
+):
+    # First request with multiple variables
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"
+
+    # Second request with same variables - should hit cache
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.headers["X-Cache-Hit"] == "true"
+
+    # Third request with one variable changed - should miss cache
+    response3 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+            X_WREN_VARIABLE_PREFIX + "session_level": "2",  # Changed this value
+        },
+    )
+    assert response3.status_code == 200
+    assert response3.headers["X-Cache-Hit"] == "false"
+
+    # Fourth request with variables in different order - should still hit cache for first combo
+    response4 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM customer LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",  # Different order
+            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
+        },
+    )
+    assert response4.status_code == 200
+    assert (
+        response4.headers["X-Cache-Hit"] == "true"
+    )  # Should hit cache despite different header order
+
+
+async def test_cache_with_mixed_relevant_irrelevant_headers(
+    client, manifest_str, connection_info
+):
+    # First request
+    response1 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",  # Relevant
+            "User-Agent": "TestClient/1.0",  # Irrelevant
+            X_WREN_DB_STATEMENT_TIMEOUT: "30",  # Relevant
+            "X-Request-ID": "abc123",  # Irrelevant
+        },
+    )
+    assert response1.status_code == 200
+    assert response1.headers["X-Cache-Hit"] == "false"
+
+    # Second request - change irrelevant headers, keep relevant ones same
+    response2 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",  # Same
+            "User-Agent": "DifferentClient/2.0",  # Changed but irrelevant
+            X_WREN_DB_STATEMENT_TIMEOUT: "30",  # Same
+            "X-Request-ID": "xyz789",  # Changed but irrelevant
+            "Accept": "application/json",  # New but irrelevant
+        },
+    )
+    assert response2.status_code == 200
+    assert response2.headers["X-Cache-Hit"] == "true"  # Should hit cache
+
+    # Third request - change one relevant header
+    response3 = await client.post(
+        url=f"{base_url}/query?cacheEnable=true",
+        json={
+            "connectionInfo": connection_info,
+            "manifestStr": manifest_str,
+            "sql": "SELECT * FROM orders LIMIT 1",
+        },
+        headers={
+            X_WREN_VARIABLE_PREFIX + "session_level": "2",  # Changed (relevant)
+            "User-Agent": "TestClient/1.0",  # Back to original
+            X_WREN_DB_STATEMENT_TIMEOUT: "30",  # Same
+            "X-Request-ID": "abc123",  # Back to original
+        },
+    )
+    assert response3.status_code == 200
+    assert (
+        response3.headers["X-Cache-Hit"] == "false"
+    )  # Should miss cache due to changed relevant header

--- a/ibis-server/tests/routers/v3/connector/postgres/test_query.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_query.py
@@ -1042,8 +1042,9 @@ async def test_cache_with_multiple_wren_variables(
             "sql": "SELECT * FROM customer LIMIT 1",
         },
         headers={
-            X_WREN_VARIABLE_PREFIX + "session_user": "'Customer#000000001'",
-            X_WREN_VARIABLE_PREFIX + "session_level": "2",  # Changed this value
+            X_WREN_VARIABLE_PREFIX
+            + "session_user": "'Customer#000000002'",  # Changed this value
+            X_WREN_VARIABLE_PREFIX + "session_level": "1",
         },
     )
     assert response3.status_code == 200

--- a/ibis-server/tests/routers/v3/connector/postgres/test_validate.py
+++ b/ibis-server/tests/routers/v3/connector/postgres/test_validate.py
@@ -174,5 +174,5 @@ async def test_validate_rlac_condition_syntax_is_valid(
     assert response.status_code == 422
     assert (
         response.text
-        == "Error during planning: The session property @session_not_found is used, but not found in the session properties"
+        == "Error during planning: The session property @session_not_found is used for `rlac_validation` rule, but not found in the session properties"
     )


### PR DESCRIPTION
Since we introduce access control and query timeout ... , query cache now includes headers and timeout settings in cache keys to prevent incorrect data sharing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query caching now considers specific HTTP headers, including Wren variable headers and statement timeout, to enhance cache precision based on request context.

* **Bug Fixes**
  * Irrelevant headers no longer impact cache keys, reducing unnecessary cache misses.
  * Improved error handling when fallback is disabled, returning appropriate error responses.

* **Tests**
  * Added extensive tests validating cache behavior with various relevant and irrelevant headers, confirming accurate cache hits and misses.
  * Updated tests to reflect fallback behavior changes and error responses when fallback is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->