### PR TITLE
chore(core): enhance error messages for access controls check

### DIFF
--- a/wren-core/core/src/logical_plan/analyze/access_control.rs
+++ b/wren-core/core/src/logical_plan/analyze/access_control.rs
@@ -20,8 +20,8 @@ use datafusion::{
         TableReference,
     },
 };
-use wren_core_base::mdl::{Column, Model, SessionProperty};
 use wren_core_base::mdl::RowLevelAccessControl;
+use wren_core_base::mdl::{Column, Model, SessionProperty};
 
 use crate::mdl::{context::SessionPropertiesRef, Dataset, SessionStateRef};
 

--- a/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -271,7 +271,7 @@ impl ModelGenerationRule {
         model: Arc<Model>,
         rule: &RowLevelAccessControl,
     ) -> Result<Option<Expr>> {
-        if validate_rule(&rule.required_properties, &self.properties)? {
+        if validate_rule(&rule.name, &rule.required_properties, &self.properties)? {
             let filter = build_filter_expression(
                 &self.session_state,
                 model,

--- a/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -406,7 +406,8 @@ impl ModelPlanNodeBuilder {
             .row_level_access_controls()
             .iter()
             .try_for_each(|rule| {
-                if validate_rule(&rule.required_properties, &self.properties)? {
+                if validate_rule(&rule.name, &rule.required_properties, &self.properties)?
+                {
                     required_fields.extend(collect_condition(model, &rule.condition)?.0);
                 }
                 Ok::<_, DataFusionError>(())

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -1935,7 +1935,7 @@ mod test {
                     @r"
                 ModelAnalyzeRule
                 caused by
-                Error during planning: session property session_nation is required, but not found in headers
+                Error during planning: session property session_nation is required for `nation` rule but not found in headers
                 "
                 )
             }
@@ -2024,7 +2024,7 @@ mod test {
                     @r"
                 ModelAnalyzeRule
                 caused by
-                Error during planning: session property session_user is required, but not found in headers
+                Error during planning: session property session_user is required for `name` rule but not found in headers
                 "
                 )
             }
@@ -2089,7 +2089,7 @@ mod test {
                     @r"
                 ModelAnalyzeRule
                 caused by
-                Error during planning: session property session_nation is required, but not found in headers
+                Error during planning: session property session_nation is required for `nation` rule but not found in headers
                 "
                 )
             }
@@ -2582,7 +2582,7 @@ mod test {
             Err(e) => {
                 assert_snapshot!(
                     e.to_string(),
-                    @"Error during planning: session property session_level is required, but not found in headers"
+                    @"Error during planning: session property session_level is required for `cls rule` rule but not found in headers"
                 )
             }
             _ => panic!("Expected error"),


### PR DESCRIPTION
# Description
Show the rule name in the error messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages related to session property validation now include the specific rule name, making it easier to identify which rule caused the error.

* **Tests**
  * Updated test cases to expect error messages that mention the relevant rule name for improved clarity and traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->