### PR TITLE
feat(core): add BigQuery EXTRACT function support and window frame validation

### DIFF
--- a/wren-core-base/src/mdl/utils.rs
+++ b/wren-core-base/src/mdl/utils.rs
@@ -43,7 +43,7 @@ pub(crate) fn parse_identifiers_normalized(
     })
 }
 
-pub fn quote_identifier(s: &str) -> Cow<str> {
+pub fn quote_identifier(s: &str) -> Cow<'_, str> {
     if needs_quotes(s) {
         Cow::Owned(format!("\"{}\"", s.replace('"', "\"\"")))
     } else {

--- a/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -97,12 +97,14 @@ impl ModelGenerationRule {
                     let rls_filter = filters
                         .into_iter()
                         .reduce(|acc, filter| {
-                            if acc.is_none() {
-                                filter
-                            } else if let Some(filter) = filter {
-                                Some(acc.unwrap().and(filter))
+                            if let Some(acc) = acc {
+                                if let Some(filter) = filter {
+                                    Some(acc.and(filter))
+                                } else {
+                                    Some(acc)
+                                }
                             } else {
-                                acc
+                                filter
                             }
                         })
                         .flatten();
@@ -231,7 +233,7 @@ impl ModelGenerationRule {
                             .build()?;
                         Ok(Transformed::yes(alias))
                     } else {
-                        return plan_err!("measures should have an alias");
+                        plan_err!("measures should have an alias")
                     }
                 } else if let Some(partial_model) = extension
                     .node

--- a/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -151,21 +151,31 @@ impl InnerDialect for BigQueryDialect {
         }
     }
 
-
     /// BigQuery only allow the aggregation function with window frame.
-    /// Other [window functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/window-functions) are not supported. 
+    /// Other [window functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/window-functions) are not supported.
     fn window_func_support_window_frame(
         &self,
         func_name: &str,
         _start_bound: &WindowFrameBound,
         _end_bound: &WindowFrameBound,
     ) -> bool {
-        match func_name {
-            "cume_dist" | "dense_rank" | "first_value" | "lag" | "last_value"
-            | "lead" | "nth_value" | "ntile" | "percent_rank" | "percentile_cont"
-            | "percentile_disc" | "rank" | "row_number" | "st_clusterdbscan" => false,
-            _ => true,
-        }
+        !matches!(
+            func_name,
+            "cume_dist"
+                | "dense_rank"
+                | "first_value"
+                | "lag"
+                | "last_value"
+                | "lead"
+                | "nth_value"
+                | "ntile"
+                | "percent_rank"
+                | "percentile_cont"
+                | "percentile_disc"
+                | "rank"
+                | "row_number"
+                | "st_clusterdbscan"
+        )
     }
 }
 

--- a/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -19,11 +19,12 @@
 
 use crate::mdl::dialect::utils::scalar_function_to_sql_internal;
 use crate::mdl::manifest::DataSource;
-use datafusion::common::Result;
+use datafusion::common::{plan_err, Result};
 use datafusion::logical_expr::sqlparser::keywords::ALL_KEYWORDS;
 use datafusion::logical_expr::Expr;
 
-use datafusion::sql::sqlparser::ast;
+use datafusion::scalar::ScalarValue;
+use datafusion::sql::sqlparser::ast::{self, ExtractSyntax};
 use datafusion::sql::unparser::Unparser;
 use regex::Regex;
 
@@ -114,6 +115,81 @@ impl InnerDialect for BigQueryDialect {
             Ok(Some(encoded_name))
         } else {
             Ok(Some(alias.to_string()))
+        }
+    }
+
+    fn scalar_function_to_sql_overrides(
+        &self,
+        unparser: &Unparser,
+        function_name: &str,
+        args: &[Expr],
+    ) -> Result<Option<ast::Expr>> {
+        match function_name {
+            "date_part" => Ok(Some(ast::Expr::Extract {
+                field: datetime_field_from_expr(&args[0])?,
+                syntax: ExtractSyntax::From,
+                expr: Box::new(unparser.expr_to_sql(&args[1])?),
+            })),
+            _ => Ok(None),
+        }
+    }
+}
+
+fn datetime_field_from_expr(expr: &Expr) -> Result<ast::DateTimeField> {
+    match expr {
+        Expr::Literal(ScalarValue::Utf8(Some(s))) => Ok(datetime_field_from_str(s)?),
+        _ => plan_err!("Invalid argument type for datetime field. Expected UTF8 string."),
+    }
+}
+
+fn datetime_field_from_str(s: &str) -> Result<ast::DateTimeField> {
+    match s.to_uppercase().as_str() {
+        "YEAR" => Ok(ast::DateTimeField::Year),
+        "YEARS" => Ok(ast::DateTimeField::Years),
+        "QUARTER" => Ok(ast::DateTimeField::Quarter),
+        "MONTH" => Ok(ast::DateTimeField::Month),
+        "MONTHS" => Ok(ast::DateTimeField::Months),
+        "WEEK" => Ok(ast::DateTimeField::Week(None)),
+        "WEEKS" => Ok(ast::DateTimeField::Weeks),
+        "DAY" => Ok(ast::DateTimeField::Day),
+        "DAYOFWEEK" => Ok(ast::DateTimeField::DayOfWeek),
+        "DAYOFYEAR" => Ok(ast::DateTimeField::DayOfYear),
+        "DAYS" => Ok(ast::DateTimeField::Days),
+        "DATE" => Ok(ast::DateTimeField::Date),
+        "DATETIME" => Ok(ast::DateTimeField::Datetime),
+        "HOUR" => Ok(ast::DateTimeField::Hour),
+        "HOURS" => Ok(ast::DateTimeField::Hours),
+        "MINUTE" => Ok(ast::DateTimeField::Minute),
+        "MINUTES" => Ok(ast::DateTimeField::Minutes),
+        "SECOND" => Ok(ast::DateTimeField::Second),
+        "SECONDS" => Ok(ast::DateTimeField::Seconds),
+        "CENTURY" => Ok(ast::DateTimeField::Century),
+        "DECADE" => Ok(ast::DateTimeField::Decade),
+        "DOW" => Ok(ast::DateTimeField::Dow),
+        "DOY" => Ok(ast::DateTimeField::Doy),
+        "EPOCH" => Ok(ast::DateTimeField::Epoch),
+        "ISODOW" => Ok(ast::DateTimeField::Isodow),
+        "ISOWEEK" => Ok(ast::DateTimeField::IsoWeek),
+        "ISOYEAR" => Ok(ast::DateTimeField::Isoyear),
+        "JULIAN" => Ok(ast::DateTimeField::Julian),
+        "MICROSECOND" => Ok(ast::DateTimeField::Microsecond),
+        "MICROSECONDS" => Ok(ast::DateTimeField::Microseconds),
+        "MILLENIUM" => Ok(ast::DateTimeField::Millenium),
+        "MILLENNIUM" => Ok(ast::DateTimeField::Millennium),
+        "MILLISECOND" => Ok(ast::DateTimeField::Millisecond),
+        "MILLISECONDS" => Ok(ast::DateTimeField::Milliseconds),
+        "NANOSECOND" => Ok(ast::DateTimeField::Nanosecond),
+        "NANOSECONDS" => Ok(ast::DateTimeField::Nanoseconds),
+        "TIME" => Ok(ast::DateTimeField::Time),
+        "TIMEZONE" => Ok(ast::DateTimeField::Timezone),
+        "TIMEZONE_ABBR" => Ok(ast::DateTimeField::TimezoneAbbr),
+        "TIMEZONE_HOUR" => Ok(ast::DateTimeField::TimezoneHour),
+        "TIMEZONE_MINUTE" => Ok(ast::DateTimeField::TimezoneMinute),
+        "TIMEZONE_REGION" => Ok(ast::DateTimeField::TimezoneRegion),
+        "NODATETIME" => Ok(ast::DateTimeField::NoDateTime),
+        _ => {
+            let ident = ast::Ident::new(s);
+            Ok(ast::DateTimeField::Custom(ident))
         }
     }
 }

--- a/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -22,7 +22,7 @@ use datafusion::common::{internal_err, plan_err, Result, ScalarValue};
 use datafusion::logical_expr::sqlparser::ast::{Ident, Subscript};
 use datafusion::logical_expr::sqlparser::keywords::ALL_KEYWORDS;
 use datafusion::logical_expr::Expr;
-use datafusion::sql::sqlparser::ast;
+use datafusion::sql::sqlparser::ast::{self, WindowFrameBound};
 use datafusion::sql::sqlparser::ast::{AccessExpr, Array, Value};
 use datafusion::sql::sqlparser::tokenizer::Span;
 use datafusion::sql::unparser::dialect::{Dialect, IntervalStyle};
@@ -94,6 +94,17 @@ impl Dialect for WrenDialect {
 
     fn col_alias_overrides(&self, alias: &str) -> Result<Option<String>> {
         self.inner_dialect.col_alias_overrides(alias)
+    }
+
+
+    fn window_func_support_window_frame(
+        &self,
+        func_name: &str,
+        start_bound: &WindowFrameBound,
+        end_bound: &WindowFrameBound,
+    ) -> bool {
+        self.inner_dialect
+            .window_func_support_window_frame(func_name, start_bound, end_bound)
     }
 }
 

--- a/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -96,15 +96,17 @@ impl Dialect for WrenDialect {
         self.inner_dialect.col_alias_overrides(alias)
     }
 
-
     fn window_func_support_window_frame(
         &self,
         func_name: &str,
         start_bound: &WindowFrameBound,
         end_bound: &WindowFrameBound,
     ) -> bool {
-        self.inner_dialect
-            .window_func_support_window_frame(func_name, start_bound, end_bound)
+        self.inner_dialect.window_func_support_window_frame(
+            func_name,
+            start_bound,
+            end_bound,
+        )
     }
 }
 

--- a/wren-core/core/src/mdl/function.rs
+++ b/wren-core/core/src/mdl/function.rs
@@ -598,7 +598,9 @@ mod test {
             DataType::List(Arc::new(Field::new("element", DataType::Int32, false)));
         assert_eq!(udf.name, "test");
         assert_eq!(
-            udf.return_type.to_data_type(&[list_type.clone()]).unwrap(),
+            udf.return_type
+                .to_data_type(std::slice::from_ref(&list_type))
+                .unwrap(),
             DataType::Int32
         );
         assert_eq!(

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -2958,6 +2958,36 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_window_functions_without_frame_bigquery() -> Result<()> {
+        let ctx = SessionContext::new();
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("o_orderkey", "int").build())
+                    .column(ColumnBuilder::new("o_custkey", "int").build())
+                    .column(ColumnBuilder::new("o_orderdate", "date").build())
+                    .build(),
+            )
+            .data_source(DataSource::BigQuery)
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let headers = Arc::new(HashMap::default());
+        let sql = "SELECT rank() OVER (PARTITION BY o_custkey ORDER BY o_orderdate) FROM orders";
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::clone(&headers), sql).await?,
+            @"SELECT rank() OVER (PARTITION BY orders.o_custkey ORDER BY orders.o_orderdate ASC NULLS LAST) FROM (SELECT orders.o_custkey, orders.o_orderdate FROM (SELECT __source.o_custkey AS o_custkey, __source.o_orderdate AS o_orderdate FROM orders AS __source) AS orders) AS orders"
+        );
+        Ok(())
+    }
+
     /// Return a RecordBatch with made up data about customer
     fn customer() -> RecordBatch {
         let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -2930,6 +2930,34 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_extract_roundtrip_bigquery() -> Result<()> {
+        let ctx = SessionContext::new();
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("orders")
+                    .table_reference("orders")
+                    .column(ColumnBuilder::new("o_orderdate", "date").build())
+                    .build(),
+            )
+            .data_source(DataSource::BigQuery)
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let headers = Arc::new(HashMap::default());
+        let sql = "SELECT EXTRACT(YEAR FROM o_orderdate) FROM orders";
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::clone(&headers), sql).await?,
+            @"SELECT EXTRACT(YEAR FROM orders.o_orderdate) FROM (SELECT orders.o_orderdate FROM (SELECT __source.o_orderdate AS o_orderdate FROM orders AS __source) AS orders) AS orders"
+        );
+        Ok(())
+    }
+
     /// Return a RecordBatch with made up data about customer
     fn customer() -> RecordBatch {
         let custkey: ArrayRef = Arc::new(Int64Array::from(vec![1, 2, 3]));


### PR DESCRIPTION
# Description
- DataFusion planner will plan a `EXTRACT` statement to a function call `date_part`. However, it's not a valid function for BigQuery. We should unparse the `date_part` function back to `EXTRACT` statement
- BigQuery only allows [the aggregation to have the window frame clause](https://cloud.google.com/bigquery/docs/reference/standard-sql/window-function-calls#def_window_frame). Use `window_func_support_window_frame` to check if a window function call should generate the window frame clause. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - BigQuery: date_part now emits EXTRACT(field FROM expr) SQL with broader field-name support and stricter argument validation.
  - BigQuery: adjusted window-function framing behavior for several ranking/analytic functions to match BigQuery semantics.

- Refactor
  - Safer, more idiomatic internal logic and a minor signature/lifetime clarification (no behavioral change).

- Tests
  - Added BigQuery EXTRACT and window-function round-trip tests and minor test cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->