### PR TITLE
fix(ibis): Enable auto-commit to avoid table locks

### DIFF
--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -505,6 +505,10 @@ class RedshiftConnector:
         else:
             raise ValueError("Invalid Redshift connection_info type")
 
+        # Enable autocommit to prevent holding AccessShareLock indefinitely
+        # This ensures locks are released immediately after query execution
+        self.connection.autocommit = True
+
     @tracer.start_as_current_span("connector_query", kind=trace.SpanKind.CLIENT)
     def query(self, sql: str, limit: int | None = None) -> pa.Table:
         with closing(self.connection.cursor()) as cursor:


### PR DESCRIPTION
When connecting to Redshift, ibis can establish persistent, non-exclusive locks which makes it impossible to make changes to the table as that requires exclusive locks. This is particularly problematic when using dbt to update the underlying tables.

This change sets `autocommit` to true for the ibis connections to Redshift to ensure connections are closed once the query is completed; this stops the locks persisting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Reduces Redshift lock contention by ensuring queries release shared locks promptly, minimizing blocked sessions and timeouts during concurrent reads. Improves stability for dashboards, ETL jobs, and ad‑hoc analytics under load.

* Chores
  * Adjusts Redshift connection behavior to auto-commit by default for more predictable execution and fewer transaction-related issues. No public API changes and no configuration updates required; existing workflows continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->