### PR TITLE
fix(ibis): Increase Redshift get_table_list limit

### DIFF
--- a/ibis-server/app/model/metadata/redshift.py
+++ b/ibis-server/app/model/metadata/redshift.py
@@ -51,7 +51,7 @@ class RedshiftMetadata(Metadata):
         # we reuse the connector.query method to execute the SQL
         # so we have to give a limit to avoid too many rows
         # the default limit for tables metadata is 500, i think it's a sensible limit
-        response = self.connector.query(sql, limit=500).to_pylist()
+        response = self.connector.query(sql, limit=50000).to_pylist()
 
         unique_tables = {}
         for row in response:
@@ -104,7 +104,7 @@ class RedshiftMetadata(Metadata):
         # we reuse the connector.query method to execute the SQL
         # so we have to give a limit to avoid too many rows
         # the default limit for constraints metadata is 500, i think it's a sensible limit
-        response = self.connector.query(sql, limit=500).to_pylist()
+        response = self.connector.query(sql, limit=50000).to_pylist()
         constraints = []
         for row in response:
             constraints.append(


### PR DESCRIPTION
Setting a limit of 500 means that, if you have more than 500 total columns across all tables, any further columns will silently be ignored. This issue is made worse by the fact that subsequent queries to check for schema updates won't necessarily return the columns in the same order, which means different columns might be ignored which are detected as columns being deleted.

This change increases the limit to 50,000. It doesn't _solve_ the issue, but makes it highly unlikely to happen.