### PR TITLE
chore: add MCP Trust Score link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 </p>
 
 <p align="center">
+  <a aria-label="Follow us" href="[https://x.com/getwrenai](https://archestra.ai/mcp-catalog/canner__wren-engine)">
+    <img alt="" src="https://archestra.ai/mcp-catalog/api/badge/quality/Canner/wren-engine">
+  </a>
+</p>
+
+<p align="center">
   <a aria-label="Follow us" href="https://x.com/getwrenai">
     <img alt="" src="https://img.shields.io/badge/-@getwrenai-blue?style=for-the-badge&logo=x&logoColor=white&labelColor=gray&logoWidth=20">
   </a>
@@ -21,7 +27,7 @@
   <a aria-label="Canner" href="https://cannerdata.com/">
     <img src="https://img.shields.io/badge/%F0%9F%A7%A1-Made%20by%20Canner-blue?style=for-the-badge">
   </a>
-</p>
+
 
 > Wren Engine is the Semantic Engine for MCP Clients and AI Agents. 
 > [Wren AI](https://github.com/Canner/WrenAI) GenBI AI Agent is based on Wren Engine.
@@ -108,4 +114,3 @@ The project consists of 4 main modules:
 
 - Welcome to our [Discord server](https://discord.gg/5DvshJqG8Z) to give us feedback!
 - If there is any issues, please visit [Github Issues](https://github.com/Canner/wren-engine/issues).
-[![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/Canner/wren-engine)](https://archestra.ai/mcp-catalog/Canner__wren-engine)


### PR DESCRIPTION
Hi!

This PR adds the "Trust Score" badge from our new Open Source MCP catalog.

Our catalog evaluates MCP servers based on technical quality—like protocol feature implementation and dependency health—rather than vanity metrics like GitHub stars.

The scoring process is fully transparent and reproducible:
- Evaluation Script: https://github.com/archestra-ai/website/blob/main/app/app/mcp-catalog/scripts/evaluate-catalog.ts
- Your Server's Page: https://archestra.ai/mcp-catalog/canner__wren-engine

The badge is designed to be respectful to the structure of your readme, example: [![Trust Score](https://archestra.ai/mcp-catalog/api/badge/quality/topoteretes/cognee/cognee-mcp)](https://archestra.ai/mcp-catalog/topoteretes__cognee__cognee-mcp)

Projects like Grafana MCP (https://github.com/grafana/mcp-grafana) are already participating. 

We believe that transparent and truly open source MCP catalog should help the community to identify great MCP servers like yours 😊

We'd appreciate your support by merging this PR!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a centered status badge near the top of the README to improve project visibility.
  * Cleaned up minor HTML/formatting and trailing whitespace in the README.
  * No functional changes to the application or APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->