### PR TITLE
fix(core): disable DecorrelatePredicateSubquery rule

### DIFF
--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -21,7 +21,6 @@ use datafusion::datasource::{TableProvider, TableType, ViewTable};
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::Expr;
 use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
-use datafusion::optimizer::decorrelate_predicate_subquery::DecorrelatePredicateSubquery;
 use datafusion::optimizer::eliminate_cross_join::EliminateCrossJoin;
 use datafusion::optimizer::eliminate_duplicated_expr::EliminateDuplicatedExpr;
 use datafusion::optimizer::eliminate_filter::EliminateFilter;
@@ -226,7 +225,8 @@ fn optimize_rule_for_unparsing() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         // Arc::new(SimplifyExpressions::new()),
         Arc::new(ReplaceDistinctWithAggregate::new()),
         Arc::new(EliminateJoin::new()),
-        Arc::new(DecorrelatePredicateSubquery::new()),
+        // Unparser has some issues for handling decorrelated plans
+        // Arc::new(DecorrelatePredicateSubquery::new()),
         // Disable ScalarSubqueryToJoin to avoid generate invalid sql (join without condition)
         // Arc::new(ScalarSubqueryToJoin::new()),
         Arc::new(ExtractEquijoinPredicate::new()),


### PR DESCRIPTION
DecorrelatePredicateSubquery will generate an invalid plan for the DataFusion Unparser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled a transformation that decorrelates predicate subqueries during SQL export, resulting in more stable and readable SQL for queries using IN/EXISTS patterns.

* **Tests**
  * Added a snapshot test to validate SQL output when predicate subqueries are present in Unparse mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->