### PR TITLE
chore(tool): update data source tool for mysql and postgres

### DIFF
--- a/ibis-server/poetry.lock
+++ b/ibis-server/poetry.lock
@@ -4483,6 +4483,50 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "polars"
+version = "1.32.3"
+description = "Blazingly fast DataFrame library"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "polars-1.32.3-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c7c472ea1d50a5104079cb64e34f78f85774bcc69b875ba8daf21233f4c70d42"},
+    {file = "polars-1.32.3-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd87275f0cc795e72a2030b58293198cfa748d4b009cf52218e27db5397ed07f"},
+    {file = "polars-1.32.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a9b9668ef310e5a77a7e7daa9c753874779c8da52e93f654bfd7953eb4b60b"},
+    {file = "polars-1.32.3-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:c8f5d2f43b80b68e39bfaa2948ce632563633466576f12e74e8560d6481f5851"},
+    {file = "polars-1.32.3-cp39-abi3-win_amd64.whl", hash = "sha256:db56a7cb4898e173d62634e182f74bdff744c62be5470e0fe20df8d10f659af7"},
+    {file = "polars-1.32.3-cp39-abi3-win_arm64.whl", hash = "sha256:a2e3f87c60f54eefe67b1bebd3105918d84df0fd6d59cc6b870c2f16d2d26ca1"},
+    {file = "polars-1.32.3.tar.gz", hash = "sha256:57c500dc1b5cba49b0589034478db031815f3d57a20cb830b05ecee1a9ba56b1"},
+]
+
+[package.extras]
+adbc = ["adbc-driver-manager[dbapi]", "adbc-driver-sqlite[dbapi]"]
+all = ["polars[async,cloudpickle,database,deltalake,excel,fsspec,graph,iceberg,numpy,pandas,plot,pyarrow,pydantic,style,timezone]"]
+async = ["gevent"]
+calamine = ["fastexcel (>=0.9)"]
+cloudpickle = ["cloudpickle"]
+connectorx = ["connectorx (>=0.3.2)"]
+database = ["polars[adbc,connectorx,sqlalchemy]"]
+deltalake = ["deltalake (>=1.0.0)"]
+excel = ["polars[calamine,openpyxl,xlsx2csv,xlsxwriter]"]
+fsspec = ["fsspec"]
+gpu = ["cudf-polars-cu12"]
+graph = ["matplotlib"]
+iceberg = ["pyiceberg (>=0.7.1)"]
+numpy = ["numpy (>=1.16.0)"]
+openpyxl = ["openpyxl (>=3.0.0)"]
+pandas = ["pandas", "polars[pyarrow]"]
+plot = ["altair (>=5.4.0)"]
+polars-cloud = ["polars-cloud (>=0.0.1a1)"]
+pyarrow = ["pyarrow (>=7.0.0)"]
+pydantic = ["pydantic"]
+sqlalchemy = ["polars[pandas]", "sqlalchemy"]
+style = ["great-tables (>=0.8.0)"]
+timezone = ["tzdata ; platform_system == \"Windows\""]
+xlsx2csv = ["xlsx2csv (>=0.8.0)"]
+xlsxwriter = ["xlsxwriter"]
+
+[[package]]
 name = "pre-commit"
 version = "4.2.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -7860,4 +7904,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.12"
-content-hash = "79ecb0f9426e1bb48d92b63c397d7f7251532fd2790ee37903b52c60667f4523"
+content-hash = "89c181d35151cc9581c32eae7db74d73369abe043d8eae31871e4f7732217a0e"

--- a/ibis-server/pyproject.toml
+++ b/ibis-server/pyproject.toml
@@ -80,6 +80,7 @@ trino = ">=0.321,<1"
 psycopg2 = ">=2.8.4,<3"
 clickhouse-connect = "0.8.15"
 asgi-lifespan = "2.1.0"
+polars = ">=1.32.0"
 
 [tool.pytest.ini_options]
 addopts = ["--strict-markers"]

--- a/ibis-server/tools/data_source/mysql.py
+++ b/ibis-server/tools/data_source/mysql.py
@@ -2,11 +2,13 @@
 # Following are the steps to run this script:
 #   docker pull --platform linux/amd64 mysql:5.7.44
 #   docker run --name test-mysql -e MYSQL_ROOT_PASSWORD=my-pwd -e MYSQL_DATABASE={database_name} --platform linux/amd64 -p 3306:3306 -d mysql:5.7.44
+# Or newer version
+#   docker pull --platform linux/amd64 mysql:latest
+#   docker run --name test-mysql -e MYSQL_ROOT_PASSWORD=my-pwd -e MYSQL_DATABASE={database_name} --platform linux/amd64 -p 3306:3306 -d mysql:latest
 
 import argparse
 import sqlalchemy
-from sqlalchemy import create_engine
-import pandas as pd
+import polars as pl
 import json
 import os
 
@@ -34,6 +36,8 @@ engine = sqlalchemy.create_engine(connection_url)
 
 for model in mdl["models"]:
     path = f"{args.dataset_path}/{model['name']}.parquet"
-    pd.read_parquet(path).to_sql(
-        model["tableReference"]["table"], engine, index=False, if_exists="replace"
+    pl.read_parquet(path).write_database(
+        table_name=model["tableReference"]["table"],
+        connection=connection_url,
+        if_table_exists="replace"
     )

--- a/ibis-server/tools/data_source/postgres.py
+++ b/ibis-server/tools/data_source/postgres.py
@@ -1,0 +1,49 @@
+# This script is used to import data into a PostgreSQL database using SQLAlchemy and Pandas.
+# Following are the steps to run this script:
+#   docker pull postgres
+#   docker run --name test-postgres -e POSTGRES_PASSWORD=my-pwd -e POSTGRES_DB={database_name} -p 5432:5432 -d postgres
+
+import argparse
+import sqlalchemy
+import polars as pl
+import json
+import os
+
+from dotenv import load_dotenv
+
+# Set up argument parsing
+parser = argparse.ArgumentParser(description="import data to mysql")
+parser.add_argument("dataset_path", help="Path to the dataset")
+parser.add_argument("database_name", help="Name of the database")
+
+args = parser.parse_args()
+
+
+load_dotenv(override=True)
+manifest_json_path = os.getenv("WREN_MANIFEST_JSON_PATH")
+print("Manifest JSON Path:", manifest_json_path)
+
+
+# Read and encode the JSON data
+with open(manifest_json_path) as file:
+    mdl = json.load(file)
+
+connection_url = f"postgresql://postgres:my-pwd@localhost:5432/{args.database_name}"
+engine = sqlalchemy.create_engine(connection_url)
+
+for model in mdl["models"]:
+    try:
+        path = f"{args.dataset_path}/{model['name']}.parquet"
+        df = pl.read_parquet(path)
+        for column in df.columns:
+            # polars will input the decimal as text to postgres.
+            # It's better to cast a numeric type for the similar behavior.
+            if df[column].dtype == pl.Decimal:
+                df = df.with_columns(pl.col(column).cast(pl.Float64))
+        df.write_database(
+            table_name=model["tableReference"]["table"],
+            connection=connection_url,
+            if_table_exists="replace"
+        )
+    except Exception as e:
+        print(f"Error processing model {model['name']}: {e}")

--- a/ibis-server/tools/data_source/postgres.py
+++ b/ibis-server/tools/data_source/postgres.py
@@ -12,7 +12,7 @@ import os
 from dotenv import load_dotenv
 
 # Set up argument parsing
-parser = argparse.ArgumentParser(description="import data to mysql")
+parser = argparse.ArgumentParser(description="import data to postgres")
 parser.add_argument("dataset_path", help="Path to the dataset")
 parser.add_argument("database_name", help="Name of the database")
 


### PR DESCRIPTION
# Description
- Use polars to load data instead of pandas
  - Pandas can't handle uint64 type from parquet
- Add postgres  data source tool

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to load Parquet datasets into PostgreSQL, with automatic type handling and clear error reporting.
* **Improvements**
  * Migrated data import pipeline to Polars for faster, more efficient reads/writes.
  * Streamlined MySQL data loading with simplified connection handling.
* **Refactor**
  * Replaced legacy pandas/SQLAlchemy data paths with Polars-based workflows.
* **Chores**
  * Added Polars as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->