### PR TITLE
fix(core): remove default window frame clause

### DIFF
--- a/wren-core/core/src/mdl/dialect/wren_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/wren_dialect.rs
@@ -84,11 +84,17 @@ impl Dialect for WrenDialect {
         start_bound: &WindowFrameBound,
         end_bound: &WindowFrameBound,
     ) -> bool {
-        self.inner_dialect.window_func_support_window_frame(
-            func_name,
-            start_bound,
-            end_bound,
-        )
+        if matches!(start_bound, WindowFrameBound::Preceding(None))
+            && matches!(end_bound, WindowFrameBound::CurrentRow)
+        {
+            false
+        } else {
+            self.inner_dialect.window_func_support_window_frame(
+                func_name,
+                start_bound,
+                end_bound,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Given a SQL:
```
SELECT rank() OVER (PARTITION BY o_custkey ORDER BY o_orderdate) FROM orders
```
DataFusion unparser will generate the window frame clause with the default value `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` for it. However, it's not only unnecessary but makes the SQL be invalid for some window functions (e.g rank, dense_rank). Some databases (e.g BigQuery, [redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_WF_DENSE_RANK.html),.. ) don't support invoke `rank` with the window frame.

This PR checks if the window frame is the default value and skip generating window frame if required.