### PR TITLE
fix(core): allow the RLAC condition invoke the hidden columns

### DIFF
--- a/wren-core-base/src/mdl/manifest.rs
+++ b/wren-core-base/src/mdl/manifest.rs
@@ -249,11 +249,19 @@ impl Model {
     /// Physical columns are columns that can be selected from the model.
     /// All physical columns are visible columns, but not all visible columns are physical columns
     /// e.g. columns that are not a relationship column
-    pub fn get_physical_columns(&self) -> Vec<Arc<Column>> {
-        self.get_visible_columns()
-            .filter(|c| c.relationship.is_none())
-            .map(|c| Arc::clone(&c))
-            .collect()
+    pub fn get_physical_columns(&self, show_visible_only: bool) -> Vec<Arc<Column>> {
+        if show_visible_only {
+            self.get_visible_columns()
+                .filter(|c| c.relationship.is_none())
+                .map(|c| Arc::clone(&c))
+                .collect()
+        } else {
+            self.columns
+                .iter()
+                .filter(|c| c.relationship.is_none())
+                .map(|c| Arc::clone(&c))
+                .collect()
+        }
     }
 
     /// Return the name of the model
@@ -267,8 +275,15 @@ impl Model {
     }
 
     /// Get the specified visible column by name
-    pub fn get_column(&self, column_name: &str) -> Option<Arc<Column>> {
+    pub fn get_visible_column(&self, column_name: &str) -> Option<Arc<Column>> {
         self.get_visible_columns()
+            .find(|c| c.name == column_name)
+            .map(|c| Arc::clone(&c))
+    }
+
+    pub fn get_column(&self, column_name: &str) -> Option<Arc<Column>> {
+        self.columns
+            .iter()
             .find(|c| c.name == column_name)
             .map(|c| Arc::clone(&c))
     }

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -340,7 +340,7 @@ impl WrenDataSource {
         mode: &Mode,
     ) -> Result<Self> {
         let available_columns = model
-            .get_physical_columns()
+            .get_physical_columns(true)
             .iter()
             .map(|column| {
                 if mode.is_permission_analyze()

--- a/wren-core/core/src/mdl/dataset.rs
+++ b/wren-core/core/src/mdl/dataset.rs
@@ -28,11 +28,11 @@ impl Dataset {
         }
     }
 
-    pub fn to_qualified_schema(&self) -> Result<DFSchema> {
+    pub fn to_qualified_schema(&self, show_visible_only: bool) -> Result<DFSchema> {
         match self {
             Dataset::Model(model) => {
                 let fields: Vec<_> = model
-                    .get_physical_columns()
+                    .get_physical_columns(show_visible_only)
                     .iter()
                     .map(|c| to_field(c))
                     .collect::<Result<_>>()?;
@@ -60,7 +60,7 @@ impl Dataset {
                     DFSchema::try_from_qualified_schema(model.table_reference(), &schema)
                 } else {
                     let fields: Vec<Field> = model
-                        .get_physical_columns()
+                        .get_physical_columns(true)
                         .iter()
                         .filter(|c| !c.is_calculated)
                         .map(|c| to_remote_field(c, Arc::clone(&session_state)))

--- a/wren-core/core/src/mdl/utils.rs
+++ b/wren-core/core/src/mdl/utils.rs
@@ -130,7 +130,7 @@ pub fn create_wren_calculated_field_expr(
         .map(|m| analyzed_wren_mdl.wren_mdl().get_model(&m))
         .filter(|m| m.is_some())
         .map(|m| Dataset::Model(m.unwrap()))
-        .map(|m| m.to_qualified_schema())
+        .map(|m| m.to_qualified_schema(true))
         .reduce(|acc, schema| acc?.join(&schema?))
         .transpose()?
     else {
@@ -163,7 +163,7 @@ pub(crate) fn create_wren_expr_for_model(
     session_state: SessionStateRef,
 ) -> Result<Expr> {
     let dataset = Dataset::Model(model);
-    let schema = dataset.to_qualified_schema()?;
+    let schema = dataset.to_qualified_schema(true)?;
     let session_state = session_state.read();
     session_state.create_logical_expr(
         qualified_expr(expr, &schema, &session_state)?.as_str(),


### PR DESCRIPTION
# Description
`isHidden` is used to avoid a column from being used by SQL directly. However, the column should be available to used by internal usage (e.g. `expression`, `rlac`, `clac`, ...). This PR fixed the issue about rlac using a hidden column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More consistent column visibility: queries and generated schemas respect hidden columns, and SELECT * only returns visible fields.
- Bug Fixes
  - Prevented accidental exposure of hidden columns in row-level access control scenarios.
  - Improved error feedback when querying hidden fields, clearly indicating they’re unavailable.
  - Stabilized field/primary key resolution to use only visible columns where appropriate.
  - Access control validation now gracefully handles empty required properties.
- Tests
  - Added tests ensuring hidden columns remain concealed and RLAC behaves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->