### PR TITLE
fix(core): generate `trim` for BigQuery

### DIFF
--- a/wren-core/core/src/mdl/dialect/inner_dialect.rs
+++ b/wren-core/core/src/mdl/dialect/inner_dialect.rs
@@ -196,6 +196,7 @@ impl InnerDialect for BigQueryDialect {
             "now" => {
                 scalar_function_to_sql_internal(unparser, None, "CURRENT_TIMESTAMP", args)
             }
+            "btrim" => scalar_function_to_sql_internal(unparser, None, "trim", args),
             _ => Ok(None),
         }
     }

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -3629,7 +3629,55 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_dummy() -> Result<()> {
+    async fn test_trim_function_bigquery() -> Result<()> {
+        let ctx = SessionContext::new();
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("customer")
+                    .table_reference("customer")
+                    .column(ColumnBuilder::new("c_custkey", "int").build())
+                    .column(ColumnBuilder::new("c_name", "string").build())
+                    .build(),
+            )
+            .data_source(DataSource::BigQuery)
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let headers = Arc::new(HashMap::default());
+        let sql = "SELECT trim(c_name) FROM customer";
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::clone(&headers), sql).await?,
+            @"SELECT trim(customer.c_name) FROM (SELECT customer.c_name FROM (SELECT __source.c_name AS c_name FROM customer AS __source) AS customer) AS customer"
+        );
+
+        // normal data source will be transformed to btrim
+        let manifest = ManifestBuilder::new()
+            .catalog("wren")
+            .schema("test")
+            .model(
+                ModelBuilder::new("customer")
+                    .table_reference("customer")
+                    .column(ColumnBuilder::new("c_custkey", "int").build())
+                    .column(ColumnBuilder::new("c_name", "string").build())
+                    .build(),
+            )
+            .build();
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+        let headers = Arc::new(HashMap::default());
+        let sql = "SELECT trim(c_name) FROM customer";
+        assert_snapshot!(
+            transform_sql_with_ctx(&ctx, Arc::clone(&analyzed_mdl), &[], Arc::clone(&headers), sql).await?,
+            @"SELECT btrim(customer.c_name) FROM (SELECT customer.c_name FROM (SELECT __source.c_name AS c_name FROM customer AS __source) AS customer) AS customer"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
# Description
`trim` is an alias of `btrim` for DataFusion. So, if we input a SQL used `trim`, it will be planned to `btrim` function call. The unparsed SQL will be `btrim()`. However, `btrim` is not a valid function for BigQuery. We should unparse it to `trim` for BigQuery dialect.