### PR TITLE
feat(ibis): add statement level timeout for BigQuery

### DIFF
--- a/ibis-server/app/model/__init__.py
+++ b/ibis-server/app/model/__init__.py
@@ -103,6 +103,10 @@ class BigQueryConnectionInfo(BaseConnectionInfo):
     credentials: SecretStr = Field(
         description="Base64 encode `credentials.json`", examples=["eyJ..."]
     )
+    job_timeout_ms: int | None = Field(
+        description="Job timeout in milliseconds. If the job is not complete within the specified time, it will be cancelled.",
+        default=None,
+    )
 
 
 class AthenaConnectionInfo(BaseConnectionInfo):

--- a/ibis-server/app/model/connector.py
+++ b/ibis-server/app/model/connector.py
@@ -233,6 +233,9 @@ class SimpleConnector:
             elif hasattr(self.connection, "close"):
                 # Try to close the connection directly if it has a close method
                 self.connection.close()
+            elif hasattr(self.connection, "disconnect"):
+                # Some backends use disconnect instead of close
+                self.connection.disconnect()
             else:
                 logger.warning(
                     f"Closing connection for {self.data_source.value} is not implemented."

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import unquote_plus
 
 import ibis
+from google.cloud import bigquery
 from google.oauth2 import service_account
 from ibis import BaseBackend
 
@@ -124,6 +125,10 @@ class DataSource(StrEnum):
                         f"{session_timeout}s"
                     )
                 info.kwargs["session_properties"] = session_properties
+            case DataSource.bigquery:
+                session_timeout = headers.get(X_WREN_DB_STATEMENT_TIMEOUT, 180)
+                if not hasattr(info, "job_timeout_ms") or info.job_timeout_ms is None:
+                    info.job_timeout_ms = int(session_timeout) * 1000
         return info
 
     def _build_connection_info(self, data: dict) -> ConnectionInfo:
@@ -265,11 +270,13 @@ class DataSourceExtension(Enum):
                 "https://www.googleapis.com/auth/cloud-platform",
             ]
         )
-        return ibis.bigquery.connect(
-            project_id=info.project_id.get_secret_value(),
-            dataset_id=info.dataset_id.get_secret_value(),
-            credentials=credentials,
+        bq_client = bigquery.Client(
+            project=info.project_id.get_secret_value(), credentials=credentials
         )
+        job_config = bigquery.QueryJobConfig()
+        bq_client.default_query_job_config = job_config
+        backend = ibis.bigquery.connect(client=bq_client, credentials=credentials)
+        return backend
 
     @staticmethod
     def get_canner_connection(info: CannerConnectionInfo) -> BaseBackend:

--- a/ibis-server/app/model/data_source.py
+++ b/ibis-server/app/model/data_source.py
@@ -274,6 +274,7 @@ class DataSourceExtension(Enum):
             project=info.project_id.get_secret_value(), credentials=credentials
         )
         job_config = bigquery.QueryJobConfig()
+        job_config.job_timeout_ms = info.job_timeout_ms
         bq_client.default_query_job_config = job_config
         backend = ibis.bigquery.connect(client=bq_client, credentials=credentials)
         return backend


### PR DESCRIPTION
# Description
- Add `job_timeout_ms` for BigQueryConnectionInfo
- Apply `X_WREN_DB_STATEMENT_TIMEOUT` to BigQuery
- Use `disconnect` to close the BigQuery connection.

# How to test
BigQuery has no `sleep` or `wait` function. To avoid making flaky tests, I only tested locally. If a timeout occurs, the error message would be
```json
{
  "errorCode": "GENERIC_USER_ERROR",
  "message": "499 GET https://bigquery.googleapis.com/bigquery/v2/projects/....: Job execution was cancelled: Job timed out after 1 sec\n\nLocation: asia-east1\nJob ID: 4357235c-c72b-4398-96fb-2f3af803cd17\n",
  "metadata": {
    "dialectSql": "SELECT COUNT(1) AS count_40_42_41 FROM (SELECT events.`_TABLE_SUFFIX` FROM (SELECT events.`_TABLE_SUFFIX` FROM (SELECT __source.`_TABLE_SUFFIX` AS `_TABLE_SUFFIX` FROM project.analytics_446447784.`events_*` AS __source) AS events) AS events WHERE regexp_contains(events.`_TABLE_SUFFIX`, '^[0-9]+')) AS events"
  },
  "phase": "SQL_EXECUTION",
  "timestamp": "2025-09-26T17:53:33.590191",
  "correlationId": "dd043b2a-8f82-46b9-a7f6-2708c0a3bc1e"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BigQuery connections now support client-based connections and honor an optional job timeout.
  * Job timeouts can be set via the X_WREN_DB_STATEMENT_TIMEOUT header (interpreted as milliseconds).

* **Bug Fixes**
  * Connection shutdown is more reliable by also handling backends that expose a disconnect-style shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->