### PR TITLE
feat: add DataFusion data source for local Parquet/CSV analysis

### DIFF
--- a/wren-core-py/src/context.rs
+++ b/wren-core-py/src/context.rs
@@ -319,19 +319,16 @@ impl PySessionContext {
     /// Execute SQL using DataFusion LocalRuntime and return results as Arrow IPC stream bytes.
     #[pyo3(signature = (sql))]
     pub fn query(&self, sql: &str) -> PyResult<Vec<u8>> {
-        let batches = self
+        let (batches, schema) = self
             .runtime
             .block_on(async {
                 let df = self.exec_ctx.sql(sql).await?;
-                df.collect().await
+                let schema = df.schema().inner().clone();
+                let batches = df.collect().await?;
+                Ok::<_, wren_core::DataFusionError>((batches, schema))
             })
             .map_err(CoreError::from)?;
 
-        if batches.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let schema = batches[0].schema();
         let mut buf = Vec::new();
         {
             let mut writer = StreamWriter::try_new(&mut buf, &schema)

--- a/wren-core-py/src/context.rs
+++ b/wren-core-py/src/context.rs
@@ -33,13 +33,15 @@ use wren_core::array::{AsArray, GenericByteArray};
 use wren_core::ast::{Expr, LimitClause, Statement, Value, ValueWithSpan, visit_statements_mut};
 use wren_core::datatypes::GenericStringType;
 use wren_core::dialect::GenericDialect;
+use wren_core::ipc::writer::StreamWriter;
 use wren_core::mdl::context::apply_wren_on_ctx;
 use wren_core::mdl::function::{
     ByPassAggregateUDF, ByPassScalarUDF, ByPassWindowFunction, FunctionType,
     RemoteFunction,
 };
 use wren_core::{
-    mdl, AggregateUDF, AnalyzedWrenMDL, ScalarUDF, SessionConfig, WindowUDF,
+    mdl, AggregateUDF, AnalyzedWrenMDL, CsvReadOptions, ParquetReadOptions, ScalarUDF,
+    SessionConfig, WindowUDF,
 };
 use wren_core_base::mdl::DataSource;
 
@@ -47,6 +49,9 @@ use wren_core_base::mdl::DataSource;
 #[pyclass(name = "SessionContext")]
 #[derive(Clone)]
 pub struct PySessionContext {
+    /// Base context — physical tables are registered here.
+    /// Used as the source for `load_mdl()` (two-phase init).
+    base_ctx: wren_core::SessionContext,
     ctx: wren_core::SessionContext,
     exec_ctx: wren_core::SessionContext,
     mdl: Arc<AnalyzedWrenMDL>,
@@ -62,9 +67,11 @@ impl Hash for PySessionContext {
 
 impl Default for PySessionContext {
     fn default() -> Self {
+        let ctx = wren_core::SessionContext::new();
         Self {
-            ctx: wren_core::SessionContext::new(),
-            exec_ctx: wren_core::SessionContext::new(),
+            base_ctx: ctx.clone(),
+            ctx: ctx.clone(),
+            exec_ctx: ctx,
             mdl: Arc::new(AnalyzedWrenMDL::default()),
             properties: Arc::new(HashMap::new()),
             runtime: Arc::new(Runtime::new().unwrap()),
@@ -101,6 +108,7 @@ impl PySessionContext {
                 &ctx,
             )?;
             return Ok(Self {
+                base_ctx: ctx.clone(),
                 ctx: ctx.clone(),
                 exec_ctx: ctx,
                 mdl: Arc::new(AnalyzedWrenMDL::default()),
@@ -193,6 +201,7 @@ impl PySessionContext {
                         .map_err(CoreError::from)?;
 
                     Ok(Self {
+                        base_ctx: ctx.clone(),
                         ctx: unparser_ctx,
                         exec_ctx,
                         mdl: analyzed_mdl,
@@ -249,7 +258,7 @@ impl PySessionContext {
             .block_on(Self::get_registered_function(function_name, &self.exec_ctx))
             .map_err(CoreError::from)?
             .into_iter()
-            .map(|f| PyRemoteFunction::from(f))
+            .map(PyRemoteFunction::from)
             .collect::<Vec<_>>();
         Ok(functions)
     }
@@ -305,6 +314,157 @@ impl PySessionContext {
             ControlFlow::<()>::Continue(())
         });
         Ok(statements[0].to_string())
+    }
+
+    /// Execute SQL using DataFusion LocalRuntime and return results as Arrow IPC stream bytes.
+    #[pyo3(signature = (sql))]
+    pub fn query(&self, sql: &str) -> PyResult<Vec<u8>> {
+        let batches = self
+            .runtime
+            .block_on(async {
+                let df = self.exec_ctx.sql(sql).await?;
+                df.collect().await
+            })
+            .map_err(CoreError::from)?;
+
+        if batches.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let schema = batches[0].schema();
+        let mut buf = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buf, &schema)
+                .map_err(|e| CoreError::new(&e.to_string()))?;
+            for batch in &batches {
+                writer
+                    .write(batch)
+                    .map_err(|e| CoreError::new(&e.to_string()))?;
+            }
+            writer
+                .finish()
+                .map_err(|e| CoreError::new(&e.to_string()))?;
+        }
+        Ok(buf)
+    }
+
+    /// Register a Parquet file as a named table.
+    /// Tables registered on base_ctx are visible to exec_ctx via shared catalog.
+    #[pyo3(signature = (name, path))]
+    pub fn register_parquet(&self, name: &str, path: &str) -> PyResult<()> {
+        self.runtime
+            .block_on(
+                self.base_ctx
+                    .register_parquet(name, path, ParquetReadOptions::default()),
+            )
+            .map_err(CoreError::from)?;
+        Ok(())
+    }
+
+    /// Register a CSV file as a named table.
+    /// Tables registered on base_ctx are visible to exec_ctx via shared catalog.
+    #[pyo3(signature = (name, path))]
+    pub fn register_csv(&self, name: &str, path: &str) -> PyResult<()> {
+        self.runtime
+            .block_on(
+                self.base_ctx
+                    .register_csv(name, path, CsvReadOptions::default()),
+            )
+            .map_err(CoreError::from)?;
+        Ok(())
+    }
+
+    /// List registered table names in the execution context.
+    pub fn list_tables(&self) -> PyResult<Vec<String>> {
+        let catalog_names = self.exec_ctx.catalog_names();
+        let mut tables = Vec::new();
+        for catalog_name in &catalog_names {
+            if let Some(catalog) = self.exec_ctx.catalog(catalog_name) {
+                for schema_name in catalog.schema_names() {
+                    if let Some(schema) = catalog.schema(&schema_name) {
+                        tables.extend(schema.table_names());
+                    }
+                }
+            }
+        }
+        Ok(tables)
+    }
+
+    /// Dry-run SQL (EXPLAIN) to validate without executing.
+    #[pyo3(signature = (sql))]
+    pub fn dry_run(&self, sql: &str) -> PyResult<String> {
+        let result = self
+            .runtime
+            .block_on(async {
+                let df = self.exec_ctx.sql(&format!("EXPLAIN {sql}")).await?;
+                df.collect().await
+            })
+            .map_err(CoreError::from)?;
+        Ok(wren_core::util::pretty::pretty_format_batches(&result)
+            .map_err(|e| CoreError::new(&e.to_string()))?
+            .to_string())
+    }
+
+    /// Load MDL and apply semantic layer rules (two-phase init).
+    /// Call this after registering physical tables to enable the semantic layer.
+    #[pyo3(signature = (mdl_base64))]
+    pub fn load_mdl(&mut self, mdl_base64: &str) -> PyResult<()> {
+        let manifest = to_manifest(mdl_base64)?;
+
+        // Extract physical table providers from base_ctx so the MDL can
+        // resolve table references to real data during LocalRuntime execution.
+        let register_tables = self.runtime.block_on(async {
+            let mut tables = HashMap::new();
+            for catalog_name in self.base_ctx.catalog_names() {
+                if let Some(catalog) = self.base_ctx.catalog(&catalog_name) {
+                    for schema_name in catalog.schema_names() {
+                        if let Some(schema) = catalog.schema(&schema_name) {
+                            for table_name in schema.table_names() {
+                                let full_ref = format!(
+                                    "{catalog_name}.{schema_name}.{table_name}"
+                                );
+                                if let Ok(Some(provider)) =
+                                    schema.table(&table_name).await
+                                {
+                                    tables.insert(full_ref, provider);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            tables
+        });
+
+        let analyzed_mdl = Arc::new(
+            AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
+                .map_err(CoreError::from)?,
+        );
+
+        let unparser_ctx = self
+            .runtime
+            .block_on(apply_wren_on_ctx(
+                &self.base_ctx,
+                Arc::clone(&analyzed_mdl),
+                Arc::clone(&self.properties),
+                mdl::context::Mode::Unparse,
+            ))
+            .map_err(CoreError::from)?;
+
+        let exec_ctx = self
+            .runtime
+            .block_on(apply_wren_on_ctx(
+                &self.base_ctx,
+                Arc::clone(&analyzed_mdl),
+                Arc::clone(&self.properties),
+                mdl::context::Mode::LocalRuntime,
+            ))
+            .map_err(CoreError::from)?;
+
+        self.ctx = unparser_ctx;
+        self.exec_ctx = exec_ctx;
+        self.mdl = analyzed_mdl;
+        Ok(())
     }
 }
 

--- a/wren/justfile
+++ b/wren/justfile
@@ -47,6 +47,9 @@ test:
 test-unit:
     uv run pytest tests/unit/ -v -m unit
 
+test-datafusion:
+    uv run pytest tests/connectors/test_datafusion.py -v -m datafusion
+
 test-duckdb:
     uv run pytest tests/connectors/test_duckdb.py -v -m duckdb
 

--- a/wren/pyproject.toml
+++ b/wren/pyproject.toml
@@ -89,3 +89,8 @@ select = ["E", "F", "I", "PLC"]
 ignore = [
   "E501", # line-too-long, enforced by ruff format
 ]
+
+[dependency-groups]
+dev = [
+    "duckdb>=1.5.0",
+]

--- a/wren/src/wren/connector/datafusion.py
+++ b/wren/src/wren/connector/datafusion.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.ipc as ipc
+from loguru import logger
+
+from wren.connector.base import ConnectorABC
+from wren.model import DataFusionConnectionInfo
+from wren.model.error import ErrorCode, WrenError
+
+
+class DataFusionConnector(ConnectorABC):
+    """DataFusion-native connector for local file analysis.
+
+    Uses wren-core-py's LocalRuntime mode to execute SQL directly
+    via DataFusion, without unparsing to SQL or routing through
+    ibis-server.
+    """
+
+    def __init__(self, connection_info: DataFusionConnectionInfo):
+        from wren_core import SessionContext  # noqa: PLC0415
+
+        self.ctx = SessionContext()
+        self.source = Path(connection_info.source).resolve()
+        self.format = connection_info.format
+        self._register_tables()
+
+    def query(self, sql: str, limit: int | None = None) -> pa.Table:
+        if limit is not None:
+            sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
+        ipc_bytes = self.ctx.query(sql)
+        if not ipc_bytes:
+            return pa.table({})
+        reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
+        return reader.read_all()
+
+    def dry_run(self, sql: str) -> None:
+        self.ctx.dry_run(sql)
+
+    def close(self) -> None:
+        pass
+
+    def _register_tables(self) -> None:
+        """Auto-discover and register files from source directory."""
+        if not self.source.is_dir():
+            raise WrenError(
+                ErrorCode.GENERIC_USER_ERROR,
+                f"Source directory not found: {self.source}",
+            )
+
+        glob_pattern = f"*.{self.format}"
+        registered = []
+        for file_path in sorted(self.source.glob(glob_pattern)):
+            table_name = file_path.stem
+            try:
+                if self.format == "parquet":
+                    self.ctx.register_parquet(table_name, str(file_path))
+                elif self.format == "csv":
+                    self.ctx.register_csv(table_name, str(file_path))
+                else:
+                    logger.warning(
+                        f"Unsupported format '{self.format}' for {file_path}"
+                    )
+                    continue
+                registered.append(table_name)
+            except Exception as e:
+                raise WrenError(
+                    ErrorCode.GENERIC_USER_ERROR,
+                    f"Failed to register {file_path.name}: {e!s}",
+                ) from e
+
+        if not registered:
+            raise WrenError(
+                ErrorCode.GENERIC_USER_ERROR,
+                f"No .{self.format} files found in {self.source}",
+            )
+
+        logger.info(
+            f"Registered {len(registered)} tables from {self.source}: {registered}"
+        )
+
+
+def create_connector(connection_info) -> DataFusionConnector:
+    return DataFusionConnector(connection_info)

--- a/wren/src/wren/connector/datafusion.py
+++ b/wren/src/wren/connector/datafusion.py
@@ -32,8 +32,6 @@ class DataFusionConnector(ConnectorABC):
         if limit is not None:
             sql = f"SELECT * FROM ({sql}) AS _q LIMIT {int(limit)}"
         ipc_bytes = self.ctx.query(sql)
-        if not ipc_bytes:
-            return pa.table({})
         reader = ipc.open_stream(io.BytesIO(bytes(ipc_bytes)))
         return reader.read_all()
 
@@ -43,8 +41,16 @@ class DataFusionConnector(ConnectorABC):
     def close(self) -> None:
         pass
 
+    _SUPPORTED_FORMATS = {"parquet", "csv"}
+
     def _register_tables(self) -> None:
         """Auto-discover and register files from source directory."""
+        if self.format not in self._SUPPORTED_FORMATS:
+            raise WrenError(
+                ErrorCode.GENERIC_USER_ERROR,
+                f"Unsupported format '{self.format}'. "
+                f"Supported: {', '.join(sorted(self._SUPPORTED_FORMATS))}",
+            )
         if not self.source.is_dir():
             raise WrenError(
                 ErrorCode.GENERIC_USER_ERROR,
@@ -58,13 +64,8 @@ class DataFusionConnector(ConnectorABC):
             try:
                 if self.format == "parquet":
                     self.ctx.register_parquet(table_name, str(file_path))
-                elif self.format == "csv":
-                    self.ctx.register_csv(table_name, str(file_path))
                 else:
-                    logger.warning(
-                        f"Unsupported format '{self.format}' for {file_path}"
-                    )
-                    continue
+                    self.ctx.register_csv(table_name, str(file_path))
                 registered.append(table_name)
             except Exception as e:
                 raise WrenError(

--- a/wren/src/wren/connector/factory.py
+++ b/wren/src/wren/connector/factory.py
@@ -10,6 +10,7 @@ _REGISTRY: dict[DataSource, str] = {
     DataSource.mssql: "wren.connector.mssql",
     DataSource.canner: "wren.connector.canner",
     DataSource.bigquery: "wren.connector.bigquery",
+    DataSource.datafusion: "wren.connector.datafusion",
     DataSource.local_file: "wren.connector.duckdb",
     DataSource.s3_file: "wren.connector.duckdb",
     DataSource.minio_file: "wren.connector.duckdb",

--- a/wren/src/wren/mdl/cte_rewriter.py
+++ b/wren/src/wren/mdl/cte_rewriter.py
@@ -24,6 +24,7 @@ from wren.model.data_source import DataSource
 
 _SQLGLOT_DIALECT_MAP: dict[DataSource, str] = {
     DataSource.canner: "trino",
+    DataSource.datafusion: "wren",
     DataSource.mssql: "tsql",
     DataSource.local_file: "duckdb",
     DataSource.s3_file: "duckdb",

--- a/wren/src/wren/model/__init__.py
+++ b/wren/src/wren/model/__init__.py
@@ -241,10 +241,9 @@ class DataFusionConnectionInfo(BaseConnectionInfo):
         description="Root path for data files",
         examples=["./data", "/absolute/path/data"],
     )
-    format: str = Field(
+    format: Literal["parquet", "csv"] = Field(
         default="parquet",
         description="Default file format to scan",
-        examples=["parquet", "csv"],
     )
 
 

--- a/wren/src/wren/model/__init__.py
+++ b/wren/src/wren/model/__init__.py
@@ -244,7 +244,7 @@ class DataFusionConnectionInfo(BaseConnectionInfo):
     format: str = Field(
         default="parquet",
         description="Default file format to scan",
-        examples=["parquet", "csv", "json"],
+        examples=["parquet", "csv"],
     )
 
 

--- a/wren/src/wren/model/__init__.py
+++ b/wren/src/wren/model/__init__.py
@@ -236,6 +236,18 @@ class TrinoConnectionInfo(BaseConnectionInfo):
     kwargs: dict[str, str] | None = Field(default=None)
 
 
+class DataFusionConnectionInfo(BaseConnectionInfo):
+    source: str = Field(
+        description="Root path for data files",
+        examples=["./data", "/absolute/path/data"],
+    )
+    format: str = Field(
+        default="parquet",
+        description="Default file format to scan",
+        examples=["parquet", "csv", "json"],
+    )
+
+
 class LocalFileConnectionInfo(BaseConnectionInfo):
     url: str = Field(default="/", examples=["/data"])
     format: str = Field(default="csv", examples=["csv", "parquet", "json", "duckdb"])
@@ -281,6 +293,7 @@ ConnectionInfo = (
     | CannerConnectionInfo
     | ClickHouseConnectionInfo
     | ConnectionUrl
+    | DataFusionConnectionInfo
     | MSSqlConnectionInfo
     | MySqlConnectionInfo
     | DorisConnectionInfo

--- a/wren/src/wren/model/data_source.py
+++ b/wren/src/wren/model/data_source.py
@@ -23,6 +23,7 @@ from wren.model import (
     ConnectionUrl,
     DatabricksServicePrincipalConnectionInfo,
     DatabricksTokenConnectionInfo,
+    DataFusionConnectionInfo,
     DorisConnectionInfo,
     GcsFileConnectionInfo,
     LocalFileConnectionInfo,
@@ -49,6 +50,7 @@ class DataSource(StrEnum):
     bigquery = auto()
     canner = auto()
     clickhouse = auto()
+    datafusion = auto()
     mssql = auto()
     mysql = auto()
     doris = auto()
@@ -154,6 +156,8 @@ class DataSource(StrEnum):
                 return SnowflakeConnectionInfo.model_validate(data)
             case DataSource.trino:
                 return TrinoConnectionInfo.model_validate(data)
+            case DataSource.datafusion:
+                return DataFusionConnectionInfo.model_validate(data)
             case DataSource.duckdb | DataSource.local_file:
                 return LocalFileConnectionInfo.model_validate(data)
             case DataSource.s3_file:
@@ -209,6 +213,7 @@ class DataSourceExtension(Enum):
     bigquery = "bigquery"
     canner = "canner"
     clickhouse = "clickhouse"
+    datafusion = "datafusion"
     mssql = "mssql"
     mysql = "mysql"
     doris = "doris"
@@ -230,7 +235,7 @@ class DataSourceExtension(Enum):
             if hasattr(info, "connection_url"):
                 kwargs = info.kwargs if info.kwargs else {}
                 return ibis.connect(info.connection_url.get_secret_value(), **kwargs)
-            if self.name in {"local_file", "redshift", "spark", "duckdb"}:
+            if self.name in {"local_file", "redshift", "spark", "duckdb", "datafusion"}:
                 raise NotImplementedError(
                     f"{self.name} connection is not implemented to get ibis backend"
                 )

--- a/wren/src/wren/model/field_registry.py
+++ b/wren/src/wren/model/field_registry.py
@@ -181,7 +181,7 @@ _MODEL_UI_OVERRIDES: dict[str, dict[str, dict]] = {
 _DATASOURCE_UI_OVERRIDES: dict[str, dict[str, dict]] = {
     "datafusion": {
         "source": {"label": "Data Directory", "examples": ["./data"]},
-        "format": {"input_type": "hidden", "default": "parquet"},
+        "format": {"label": "File Format", "placeholder": "parquet"},
     },
     "duckdb": {
         "url": {

--- a/wren/src/wren/model/field_registry.py
+++ b/wren/src/wren/model/field_registry.py
@@ -23,6 +23,7 @@ from wren.model import (
     ConnectionUrl,
     DatabricksServicePrincipalConnectionInfo,
     DatabricksTokenConnectionInfo,
+    DataFusionConnectionInfo,
     DorisConnectionInfo,
     GcsFileConnectionInfo,
     LocalFileConnectionInfo,
@@ -46,6 +47,7 @@ DATASOURCE_MODELS: dict[str, list[type[BaseConnectionInfo]]] = {
     "bigquery": [BigQueryDatasetConnectionInfo, BigQueryProjectConnectionInfo],
     "canner": [CannerConnectionInfo],
     "clickhouse": [ClickHouseConnectionInfo],
+    "datafusion": [DataFusionConnectionInfo],
     "databricks": [
         DatabricksTokenConnectionInfo,
         DatabricksServicePrincipalConnectionInfo,
@@ -177,6 +179,10 @@ _MODEL_UI_OVERRIDES: dict[str, dict[str, dict]] = {
 # Datasource-level overrides: datasource_name → field_name → override dict.
 # Takes priority over model-level overrides.
 _DATASOURCE_UI_OVERRIDES: dict[str, dict[str, dict]] = {
+    "datafusion": {
+        "source": {"label": "Data Directory", "examples": ["./data"]},
+        "format": {"input_type": "hidden", "default": "parquet"},
+    },
     "duckdb": {
         "url": {
             "label": "Directory Path",

--- a/wren/tests/conftest.py
+++ b/wren/tests/conftest.py
@@ -6,6 +6,10 @@ import pytest
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "unit: unit tests — no database required")
     config.addinivalue_line(
+        "markers",
+        "datafusion: DataFusion connector tests — no Docker required",
+    )
+    config.addinivalue_line(
         "markers", "duckdb: DuckDB connector tests — no Docker required"
     )
     config.addinivalue_line(

--- a/wren/tests/connectors/test_datafusion.py
+++ b/wren/tests/connectors/test_datafusion.py
@@ -1,0 +1,52 @@
+"""DataFusion connector tests.
+
+Uses DuckDB's TPCH extension to generate Parquet test data, then queries
+via DataFusion — no Docker, no external server needed.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import duckdb
+import orjson
+import pytest
+
+from tests.suite.manifests import make_tpch_manifest
+from tests.suite.query import WrenQueryTestSuite
+from wren import WrenEngine
+from wren.model.data_source import DataSource
+
+pytestmark = pytest.mark.datafusion
+
+# DataFusion registers Parquet files in the default catalog/schema.
+_CATALOG = "datafusion"
+_SCHEMA = "public"
+
+
+class TestDataFusion(WrenQueryTestSuite):
+    manifest = make_tpch_manifest(table_catalog=_CATALOG, table_schema=_SCHEMA)
+    # DuckDB TPCH dbgen writes INTEGER as int64 in Parquet
+    order_id_dtype = "int64"
+
+    @pytest.fixture(scope="class")
+    def engine(self, tmp_path_factory) -> WrenEngine:  # type: ignore[override]
+        data_dir = tmp_path_factory.mktemp("datafusion")
+
+        # Generate TPCH sf=0.01 and export as Parquet files.
+        con = duckdb.connect()
+        con.execute("INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01)")
+        con.execute(
+            f"COPY (SELECT * FROM orders) TO '{data_dir}/orders.parquet' (FORMAT PARQUET)"
+        )
+        con.execute(
+            f"COPY (SELECT * FROM customer) TO '{data_dir}/customer.parquet' (FORMAT PARQUET)"
+        )
+        con.close()
+
+        manifest_str = base64.b64encode(orjson.dumps(self.manifest)).decode()
+        conn_info = {"source": str(data_dir), "format": "parquet"}
+        with WrenEngine(
+            manifest_str, DataSource.datafusion, conn_info, fallback=False
+        ) as e:
+            yield e

--- a/wren/uv.lock
+++ b/wren/uv.lock
@@ -3513,6 +3513,11 @@ ui = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "duckdb" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.26" },
@@ -3584,6 +3589,9 @@ requires-dist = [
     { name = "wren-core-py", specifier = ">=0.1" },
 ]
 provides-extras = ["all", "athena", "bigquery", "clickhouse", "databricks", "dev", "memory", "mssql", "mysql", "oracle", "postgres", "redshift", "snowflake", "spark", "trino", "ui"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "duckdb", specifier = ">=1.5.0" }]
 
 [[package]]
 name = "zstandard"


### PR DESCRIPTION
## Summary
- Add `datafusion` as a new data source type in the Wren CLI, enabling direct SQL execution on local Parquet/CSV files via DataFusion — no DuckDB, ibis-server, or external database needed
- New wren-core-py PyO3 bindings: `query()`, `register_parquet()`, `register_csv()`, `list_tables()`, `dry_run()`, `load_mdl()` with two-phase initialization support
- `DataFusionConnector` auto-discovers files from a source directory and executes SQL through the WrenEngine CTE rewriter pipeline

## Changes
| Area | Files | What |
|------|-------|------|
| **Rust** | `wren-core-py/src/context.rs` | `base_ctx` field, 6 new PyO3 methods, Arrow IPC stream for query results, `analyze_with_tables` for physical table resolution |
| **Python model** | `model/__init__.py`, `data_source.py`, `field_registry.py` | `DataFusionConnectionInfo`, enum registration, UI metadata |
| **Connector** | `connector/datafusion.py`, `connector/factory.py` | New `DataFusionConnector`, factory wiring |
| **Rewriter** | `mdl/cte_rewriter.py` | sqlglot dialect mapping (`datafusion → wren`) |
| **Tests** | `tests/connectors/test_datafusion.py`, `conftest.py`, `justfile` | 9 tests via `WrenQueryTestSuite` (TPCH sf=0.01 as Parquet), `just test-datafusion` recipe |

## Test plan
- [x] `cargo check` + `cargo clippy -D warnings` clean
- [x] `ruff format --check` + `ruff check` clean
- [x] 25/25 existing wren-core-py Python tests pass (backward compat)
- [x] 9/9 DataFusion connector tests pass (`just test-datafusion`)
- [x] 9/9 DuckDB connector tests still pass (regression check)
- [x] End-to-end: bare DataFusion queries, two-phase MDL init, connector factory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added DataFusion data source support enabling direct querying of Parquet and CSV files.
  - Automatic file discovery and table registration in source directories.
  - Query preview functionality for validation.

* **Tests**
  - Added DataFusion connector test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->