### PR TITLE
feat(wren-core-wasm): integrate profile source for portable MDL (Plan C-2 Phase 2)

### DIFF
--- a/wren-core-py/Cargo.lock
+++ b/wren-core-py/Cargo.lock
@@ -267,7 +267,6 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
- "zstd",
 ]
 
 [[package]]
@@ -359,18 +358,6 @@ dependencies = [
  "num-traits",
  "regex",
  "regex-syntax",
-]
-
-[[package]]
-name = "async-compression"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
-dependencies = [
- "compression-codecs",
- "compression-core",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -496,15 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "bzip2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
-dependencies = [
- "libbz2-rs-sys",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,27 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compression-codecs"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
-dependencies = [
- "bzip2",
- "compression-core",
- "flate2",
- "liblzma",
- "memchr",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
-name = "compression-core"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,15 +586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -741,7 +689,6 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bytes",
- "bzip2",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -768,10 +715,8 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "datafusion-sql",
- "flate2",
  "futures",
  "itertools",
- "liblzma",
  "log",
  "object_store",
  "parking_lot",
@@ -783,7 +728,6 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
- "zstd",
 ]
 
 [[package]]
@@ -853,7 +797,6 @@ dependencies = [
  "object_store",
  "parquet",
  "paste",
- "recursive",
  "sqlparser 0.61.0",
  "tokio",
  "web-time",
@@ -877,10 +820,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
 dependencies = [
  "arrow",
- "async-compression",
  "async-trait",
  "bytes",
- "bzip2",
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -891,18 +832,14 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-session",
- "flate2",
  "futures",
  "glob",
  "itertools",
- "liblzma",
  "log",
  "object_store",
  "rand",
  "tokio",
- "tokio-util",
  "url",
- "zstd",
 ]
 
 [[package]]
@@ -1053,7 +990,6 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools",
  "paste",
- "recursive",
  "serde_json",
  "sqlparser 0.61.0",
 ]
@@ -1233,7 +1169,6 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools",
  "log",
- "recursive",
  "regex",
  "regex-syntax",
 ]
@@ -1258,7 +1193,6 @@ dependencies = [
  "parking_lot",
  "paste",
  "petgraph",
- "recursive",
  "tokio",
 ]
 
@@ -1310,7 +1244,6 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-pruning",
  "itertools",
- "recursive",
 ]
 
 [[package]]
@@ -1390,7 +1323,6 @@ dependencies = [
  "datafusion-functions-nested",
  "indexmap 2.14.0",
  "log",
- "recursive",
  "regex",
  "sqlparser 0.61.0",
 ]
@@ -1512,7 +1444,6 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -2070,36 +2001,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libbz2-rs-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
-
-[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
-
-[[package]]
-name = "liblzma"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "libm"
@@ -2943,7 +2848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
- "recursive",
  "sqlparser_derive 0.5.0",
 ]
 
@@ -3706,6 +3610,7 @@ dependencies = [
  "async-trait",
  "csv",
  "datafusion",
+ "datafusion-session",
  "env_logger",
  "itertools",
  "log",

--- a/wren-core-wasm/.gitignore
+++ b/wren-core-wasm/.gitignore
@@ -1,0 +1,5 @@
+/target/
+/pkg/
+/dist/
+Cargo.lock
+/examples/data/

--- a/wren-core-wasm/Cargo.toml
+++ b/wren-core-wasm/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = "wren-core-wasm"
+version = "0.1.0"
+edition = "2021"
+authors = ["Canner <dev@cannerdata.com>"]
+license = "Apache-2.0"
+description = "Wren Engine compiled to WebAssembly — browser-native semantic layer + query execution"
+repository = "https://github.com/Canner/wren-engine"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[dependencies]
+# --- DataFusion: upstream latest (NOT Canner fork) ---
+# The WASM build does not need the unparser fixes in the Canner fork,
+# because DataFusion is the final execution engine here (no SQL generation).
+# Using latest upstream for best WASM compatibility and performance.
+# DataFusion WITHOUT parquet feature — parquet's default-features=true in
+# DataFusion enables zstd (C library) which cannot compile to WASM.
+# We read Parquet bytes → Arrow RecordBatch → MemTable ourselves.
+datafusion = { version = "53", default-features = false, features = [
+    "nested_expressions",
+    "crypto_expressions",
+    "datetime_expressions",
+    "encoding_expressions",
+    "regex_expressions",
+    "unicode_expressions",
+    "sql",
+] }
+
+# --- Arrow / Parquet ---
+arrow = { version = "58.1", default-features = false, features = ["json"] }
+# No zstd: requires C library (zstd-sys) which cannot compile to WASM.
+# Snappy and LZ4 are pure Rust and WASM-compatible.
+parquet = { version = "58.1", default-features = false, features = ["arrow", "snap", "lz4"] }
+
+# --- WASM bindings ---
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
+
+# --- Async runtime (WASM-compatible, no multi-thread) ---
+tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
+
+# --- Wren semantic layer (no multi-thread for WASM) ---
+wren-core = { path = "../wren-core/core", default-features = false }
+
+# --- Shared types (no DataFusion dependency, no Python binding) ---
+wren-core-base = { path = "../wren-core-base" }
+
+# --- Bytes (for Parquet reader) ---
+bytes = "1"
+
+# --- Serde ---
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# --- Time: chrono needs wasmbind to use js_sys::Date instead of SystemTime ---
+chrono = { version = "0.4", features = ["wasmbind"] }
+
+# --- Logging ---
+log = "0.4"
+
+# --- WASM-specific: getrandom needs a JS backend for wasm32 ---
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+

--- a/wren-core-wasm/Cargo.toml
+++ b/wren-core-wasm/Cargo.toml
@@ -26,8 +26,11 @@ datafusion = { version = "53", default-features = false, features = [
     "encoding_expressions",
     "regex_expressions",
     "unicode_expressions",
+    "parquet",
     "sql",
 ] }
+
+object_store = { version = "0.13.1", features = ["aws", "http"] }
 
 # --- Arrow / Parquet ---
 arrow = { version = "58.1", default-features = false, features = ["json"] }
@@ -60,12 +63,17 @@ serde_json = "1"
 # --- Time: chrono needs wasmbind to use js_sys::Date instead of SystemTime ---
 chrono = { version = "0.4", features = ["wasmbind"] }
 
+# --- URL parsing ---
+url = "2"
+
 # --- Logging ---
 log = "0.4"
 
-# --- WASM-specific: getrandom needs a JS backend for wasm32 ---
+# --- WASM-specific: all getrandom versions need JS backend for wasm32 ---
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom_03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/wren-core-wasm/src/lib.rs
+++ b/wren-core-wasm/src/lib.rs
@@ -12,9 +12,11 @@
 //! ```text
 //! JS (browser)
 //!   │
-//!   ├── loadMDL(json)          → WrenEngine stores manifest
-//!   ├── registerParquet(bytes) → Arrow RecordBatch → DataFusion MemTable
-//!   └── query(sql)             → DataFusion executes → JSON result
+//!   ├── loadMDL(mdl_json, source)       → analyze manifest; URL mode registers
+//!   │                                      ListingTables, local mode expects
+//!   │                                      pre-registered tables
+//!   ├── registerParquet(table_name, data) → Arrow RecordBatch → DataFusion MemTable
+//!   └── query(sql)                       → DataFusion executes → JSON result
 //! ```
 //!
 //! ## Milestone Roadmap
@@ -46,8 +48,7 @@ impl WrenEngine {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Result<WrenEngine, JsError> {
         // Configure DataFusion for single-threaded WASM environment
-        let config = datafusion::execution::context::SessionConfig::new()
-            .with_target_partitions(1); // Single-threaded in WASM
+        let config = datafusion::execution::context::SessionConfig::new().with_target_partitions(1); // Single-threaded in WASM
 
         let ctx = datafusion::execution::context::SessionContext::new_with_config(config);
 
@@ -63,11 +64,7 @@ impl WrenEngine {
     /// * `table_name` - Name to register the table under
     /// * `json_data` - JSON string: array of objects, e.g. `[{"a":1,"b":"x"},...]`
     #[wasm_bindgen(js_name = registerJson)]
-    pub async fn register_json(
-        &self,
-        table_name: &str,
-        json_data: &str,
-    ) -> Result<(), JsError> {
+    pub async fn register_json(&self, table_name: &str, json_data: &str) -> Result<(), JsError> {
         use arrow::json::reader::infer_json_schema;
         use arrow::json::ReaderBuilder;
         use datafusion::datasource::MemTable;
@@ -114,11 +111,7 @@ impl WrenEngine {
     /// Reads the Parquet data into Arrow RecordBatches and registers as a MemTable.
     /// The JS side should pass the file contents as a `Uint8Array`.
     #[wasm_bindgen(js_name = registerParquet)]
-    pub async fn register_parquet(
-        &self,
-        table_name: &str,
-        data: &[u8],
-    ) -> Result<(), JsError> {
+    pub async fn register_parquet(&self, table_name: &str, data: &[u8]) -> Result<(), JsError> {
         use datafusion::datasource::MemTable;
         use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
         use std::sync::Arc;
@@ -156,13 +149,27 @@ impl WrenEngine {
     /// and reconfigures the SessionContext with Wren analyzer rules in
     /// LocalRuntime mode (direct DataFusion execution, no SQL generation).
     ///
-    /// Physical tables (registered via `registerParquet`/`registerJson`) are
-    /// mapped to MDL models through each model's `tableReference`. Register
-    /// the backing tables before calling this method.
+    /// The `source` parameter selects how physical tables are resolved:
     ///
-    /// After loading, queries can reference MDL model names as table names.
+    /// - `http://…/`, `https://…/` → **URL mode**. For each model, registers a
+    ///   DataFusion `ListingTable` at `{source}/{table_name}.parquet`. Tables
+    ///   do not need pre-registering. (`s3://` and `gs://` schemes are Phase 4
+    ///   and fall through to local mode today.)
+    /// - `""` (empty) → **fallback mode**: the M3+ behaviour of auto-detecting
+    ///   URL vs local tables from each model's `tableReference`. Preserved for
+    ///   backwards compatibility with MDLs that still embed URLs in
+    ///   `tableReference`.
+    /// - anything else → **local mode**. The caller is expected to have
+    ///   pre-registered each model's physical table via
+    ///   `registerParquet`/`registerJson`. If any model's physical table is
+    ///   missing, `loadMDL` returns an `Unresolved models: [...]` error up
+    ///   front instead of deferring to query time.
+    ///
+    /// After loading, bare model names resolve under the MDL's catalog/schema
+    /// (typically `wren.public`), so queries can reference models without a
+    /// catalog prefix.
     #[wasm_bindgen(js_name = loadMDL)]
-    pub async fn load_mdl(&mut self, mdl_json: &str) -> Result<(), JsError> {
+    pub async fn load_mdl(&mut self, mdl_json: &str, source: &str) -> Result<(), JsError> {
         use std::collections::HashMap;
         use std::sync::Arc;
         use wren_core::mdl::context::{apply_wren_on_ctx, Mode};
@@ -172,110 +179,252 @@ impl WrenEngine {
         let manifest: Manifest = serde_json::from_str(mdl_json)
             .map_err(|e| JsError::new(&format!("Failed to parse MDL JSON: {e}")))?;
 
-        // Collect existing physical tables from the current context and map them
-        // by the table reference names used in the MDL models.
-        // The model's tableReference (e.g., "orders" or "schema.orders") is resolved
-        // to find the matching physical table in the default DataFusion catalog.
-        let mut register_tables: HashMap<
-            String,
-            Arc<dyn datafusion::datasource::TableProvider>,
-        > = HashMap::new();
+        let source = source.trim();
 
-        let default_catalog = "datafusion";
-        let default_schema = "public";
+        let analyzed_mdl: Arc<AnalyzedWrenMDL> = if is_url_source(source) {
+            self.load_mdl_url_mode(&manifest, source).await?
+        } else if source.is_empty() {
+            self.load_mdl_fallback(manifest.clone()).await?
+        } else {
+            self.load_mdl_local_mode(&manifest).await?
+        };
 
-        // Determine data loading strategy based on data source and tableReference format.
-        //
-        // URL table mode (DataFusion reads Parquet directly via HTTP range requests):
-        //   - local_file with http(s):// tableReferences (rewritten by JS for WASM)
-        //   - s3, gcs, minio with native URLs (s3://, gs://, etc.)
-        //
-        // Pre-register mode (tables already loaded via registerParquet/registerJson):
-        //   - local_file with local paths (not accessible in WASM, must registerParquet first)
-        //   - no dataSource / other data sources (not supported for URL table in WASM)
+        let properties: Arc<HashMap<String, Option<String>>> = Arc::new(HashMap::new());
+
+        let new_ctx = apply_wren_on_ctx(&self.ctx, analyzed_mdl, properties, Mode::LocalRuntime)
+            .await
+            .map_err(|e| JsError::new(&format!("Failed to apply MDL rules: {e}")))?;
+
+        self.ctx = new_ctx;
+        Ok(())
+    }
+
+    /// URL mode: register a `ListingTable` per model under the `source` URL
+    /// and collect them into `register_tables` for `analyze_with_tables`.
+    ///
+    /// The per-model URL is always `{source}/{bare_name}.parquet`. If two
+    /// models share the same bare table name across different schemas (e.g.
+    /// `"raw"."orders"` and `"staging"."orders"`), they both resolve to
+    /// `{source}/orders.parquet` — a silent collision at the file-naming
+    /// level. Phase 2 assumes a flat Parquet layout; richer schema mapping
+    /// (`{source}/{schema}/{name}.parquet`) is tracked as Phase 4 work.
+    async fn load_mdl_url_mode(
+        &mut self,
+        manifest: &wren_core_base::mdl::manifest::Manifest,
+        source: &str,
+    ) -> Result<std::sync::Arc<wren_core::mdl::AnalyzedWrenMDL>, JsError> {
+        use std::collections::{HashMap, HashSet};
+        use std::sync::Arc;
+        use wren_core::mdl::AnalyzedWrenMDL;
+
+        let base_url = source.trim_end_matches('/');
+        let parsed_base = url::Url::parse(base_url)
+            .map_err(|e| JsError::new(&format!("Invalid source URL '{source}': {e}")))?;
+        let scheme = parsed_base.scheme();
+
+        // Register one HTTP object store per unique origin. Subsequent calls
+        // with the same origin are no-ops. (`s3://`/`gs://` are out of scope
+        // for Phase 2 — see `is_url_source`; they never reach this branch.)
+        if scheme == "http" || scheme == "https" {
+            let mut registered_origins: HashSet<String> = HashSet::new();
+            let origin = parsed_base.origin().unicode_serialization();
+            if registered_origins.insert(origin.clone()) {
+                let http_store = object_store::http::HttpBuilder::new()
+                    .with_url(&origin)
+                    .build()
+                    .map_err(|e| {
+                        JsError::new(&format!("Failed to create HTTP store for {origin}: {e}"))
+                    })?;
+                let store_url = url::Url::parse(&format!("{origin}/"))
+                    .map_err(|e| JsError::new(&format!("Invalid base URL: {e}")))?;
+                self.ctx
+                    .register_object_store(&store_url, Arc::new(http_store));
+            }
+        }
+
+        let mut register_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
+            HashMap::new();
+
+        for model in &manifest.models {
+            let bare = extract_bare_table_name(model.table_reference());
+            let name: &str = if bare.is_empty() { model.name() } else { bare };
+            let parquet_url = format!("{base_url}/{name}.parquet");
+
+            // Register under the bare table name in the default datafusion catalog.
+            // `register_listing_table` propagates schema-inference failures
+            // (unreachable URL, bad Parquet) as a JsError with the model context.
+            self.register_listing_table(name, &parquet_url).await?;
+
+            if let Some(catalog) = self.ctx.catalog("datafusion") {
+                if let Some(schema) = catalog.schema("public") {
+                    if let Ok(Some(table)) = schema.table(name).await {
+                        // Key must match `model.table_reference()` so
+                        // `WrenMDL::get_table` finds it during plan analysis.
+                        register_tables.insert(model.table_reference().to_string(), table);
+                    }
+                }
+            }
+        }
+
+        AnalyzedWrenMDL::analyze_with_tables(manifest.clone(), register_tables)
+            .map(Arc::new)
+            .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))
+    }
+
+    /// Local mode: tables must already be registered via
+    /// `registerParquet`/`registerJson`. Collect them into `register_tables`
+    /// and raise a clear error if any model's backing table is missing.
+    async fn load_mdl_local_mode(
+        &self,
+        manifest: &wren_core_base::mdl::manifest::Manifest,
+    ) -> Result<std::sync::Arc<wren_core::mdl::AnalyzedWrenMDL>, JsError> {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        use wren_core::mdl::AnalyzedWrenMDL;
+
+        let mut register_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
+            HashMap::new();
+        let mut missing: Vec<String> = Vec::new();
+
+        for model in &manifest.models {
+            let bare = extract_bare_table_name(model.table_reference());
+            let name: &str = if bare.is_empty() { model.name() } else { bare };
+
+            let mut found = false;
+            if let Some(catalog) = self.ctx.catalog("datafusion") {
+                if let Some(schema) = catalog.schema("public") {
+                    if let Ok(Some(table)) = schema.table(name).await {
+                        // Key must match `model.table_reference()` so
+                        // `WrenMDL::get_table` finds it during plan analysis.
+                        register_tables.insert(model.table_reference().to_string(), table);
+                        found = true;
+                    }
+                }
+            }
+            if !found {
+                missing.push(name.to_string());
+            }
+        }
+
+        if !missing.is_empty() {
+            return Err(JsError::new(&format!(
+                "Unresolved models: [{}]. Register physical tables first via \
+                 registerParquet/registerJson, or call loadMDL with a URL source.",
+                missing.join(", ")
+            )));
+        }
+
+        AnalyzedWrenMDL::analyze_with_tables(manifest.clone(), register_tables)
+            .map(Arc::new)
+            .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))
+    }
+
+    /// M3+ fallback: when `source=""`, auto-detect URL vs local tables from
+    /// each model's `tableReference`. Kept for backwards compatibility with
+    /// MDLs that still embed URLs in `tableReference`.
+    async fn load_mdl_fallback(
+        &mut self,
+        manifest: wren_core_base::mdl::manifest::Manifest,
+    ) -> Result<std::sync::Arc<wren_core::mdl::AnalyzedWrenMDL>, JsError> {
+        use std::collections::{HashMap, HashSet};
+        use std::sync::Arc;
+        use wren_core::mdl::AnalyzedWrenMDL;
+
         let use_url_tables = manifest.models.iter().any(|m| {
             let raw = m.table_reference();
             let url_str = raw.trim_matches('"');
-            // Has a URL scheme → URL table mode
             url::Url::parse(url_str).is_ok()
         });
 
-        let analyzed_mdl = if use_url_tables {
-                // URL table mode: register object stores for each URL scheme+origin,
-                // then DataFusion's ListingTable reads Parquet via range requests.
-                let mut registered_origins = std::collections::HashSet::new();
-                for model in &manifest.models {
-                    let raw = model.table_reference();
-                    let url_str = raw.trim_matches('"');
-                    if let Ok(parsed) = url::Url::parse(url_str) {
-                        let scheme = parsed.scheme();
-                        // Only HTTP(S) needs explicit HttpStore registration.
-                        // S3/GCS/MinIO stores should be pre-registered or use
-                        // DataFusion's built-in object_store integration.
-                        if scheme == "http" || scheme == "https" {
-                            let origin = parsed.origin().unicode_serialization();
-                            if registered_origins.insert(origin.clone()) {
-                                let http_store = object_store::http::HttpBuilder::new()
-                                    .with_url(&origin)
-                                    .build()
-                                    .map_err(|e| JsError::new(&format!("Failed to create HTTP store for {origin}: {e}")))?;
-                                let base_url = url::Url::parse(&format!("{origin}/"))
-                                    .map_err(|e| JsError::new(&format!("Invalid base URL: {e}")))?;
-                                self.ctx.register_object_store(&base_url, Arc::new(http_store));
-                            }
+        if use_url_tables {
+            let mut registered_origins: HashSet<String> = HashSet::new();
+            for model in &manifest.models {
+                let raw = model.table_reference();
+                let url_str = raw.trim_matches('"');
+                if let Ok(parsed) = url::Url::parse(url_str) {
+                    let scheme = parsed.scheme();
+                    if scheme == "http" || scheme == "https" {
+                        let origin = parsed.origin().unicode_serialization();
+                        if registered_origins.insert(origin.clone()) {
+                            let http_store = object_store::http::HttpBuilder::new()
+                                .with_url(&origin)
+                                .build()
+                                .map_err(|e| {
+                                    JsError::new(&format!(
+                                        "Failed to create HTTP store for {origin}: {e}"
+                                    ))
+                                })?;
+                            let base_url = url::Url::parse(&format!("{origin}/"))
+                                .map_err(|e| JsError::new(&format!("Invalid base URL: {e}")))?;
+                            self.ctx
+                                .register_object_store(&base_url, Arc::new(http_store));
                         }
                     }
                 }
+            }
 
-                Arc::new(
-                    AnalyzedWrenMDL::analyze_with_url_tables(manifest, &self.ctx).await
-                        .map_err(|e| JsError::new(&format!("Failed to analyze MDL with URL tables: {e}")))?,
-                )
+            AnalyzedWrenMDL::analyze_with_url_tables(manifest, &self.ctx)
+                .await
+                .map(Arc::new)
+                .map_err(|e| JsError::new(&format!("Failed to analyze MDL with URL tables: {e}")))
         } else {
-                for model in &manifest.models {
-                    let table_ref_str = model.table_reference();
-                    if table_ref_str.is_empty() {
-                        continue;
-                    }
+            let mut register_tables: HashMap<
+                String,
+                Arc<dyn datafusion::datasource::TableProvider>,
+            > = HashMap::new();
 
-                    // Parse the table reference to extract the table name
-                    let table_ref = datafusion::sql::TableReference::from(table_ref_str);
-                    let table_name = table_ref.table();
-
-                    // Look up the physical table in the default catalog/schema
-                    if let Some(catalog_provider) = self.ctx.catalog(default_catalog) {
-                        if let Some(schema_provider) = catalog_provider.schema(default_schema) {
-                            if let Ok(Some(table)) = schema_provider.table(table_name).await {
-                                // Register with fully qualified name so ModelGenerationRule can find it
-                                let qualified_name = format!(
-                                    "{}.{}.{}",
-                                    default_catalog, default_schema, table_name
-                                );
-                                register_tables.insert(qualified_name, table);
-                            }
+            for model in &manifest.models {
+                let bare = extract_bare_table_name(model.table_reference());
+                if bare.is_empty() {
+                    continue;
+                }
+                if let Some(catalog) = self.ctx.catalog("datafusion") {
+                    if let Some(schema) = catalog.schema("public") {
+                        if let Ok(Some(table)) = schema.table(bare).await {
+                            // Key must match `model.table_reference()` so
+                            // `WrenMDL::get_table` finds it during plan analysis.
+                            register_tables.insert(model.table_reference().to_string(), table);
                         }
                     }
                 }
+            }
 
-                Arc::new(
-                    AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
-                        .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))?,
-                )
+            AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
+                .map(Arc::new)
+                .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))
+        }
+    }
+
+    /// Register a `ListingTable` backed by a single Parquet URL under `name`
+    /// in the default catalog/schema. Schema is inferred via a Range GET on
+    /// the Parquet footer.
+    async fn register_listing_table(&self, name: &str, url: &str) -> Result<(), JsError> {
+        use datafusion::datasource::file_format::parquet::ParquetFormat;
+        use datafusion::datasource::listing::{
+            ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
         };
+        use std::sync::Arc;
 
-        let properties: Arc<HashMap<String, Option<String>>> =
-            Arc::new(HashMap::new());
-
-        let new_ctx = apply_wren_on_ctx(
-            &self.ctx,
-            analyzed_mdl,
-            properties,
-            Mode::LocalRuntime,
-        )
-        .await
-        .map_err(|e| JsError::new(&format!("Failed to apply MDL rules: {e}")))?;
-
-        self.ctx = new_ctx;
+        let table_url = ListingTableUrl::parse(url)
+            .map_err(|e| JsError::new(&format!("Invalid table URL '{url}': {e}")))?;
+        let options =
+            ListingOptions::new(Arc::new(ParquetFormat::default())).with_file_extension(".parquet");
+        let state = self.ctx.state();
+        let config = ListingTableConfig::new(table_url)
+            .with_listing_options(options)
+            .infer_schema(&state)
+            .await
+            .map_err(|e| {
+                JsError::new(&format!(
+                    "Failed to infer schema for model '{name}' at '{url}': {e}"
+                ))
+            })?;
+        let table = ListingTable::try_new(config).map_err(|e| {
+            JsError::new(&format!("Failed to create ListingTable for '{name}': {e}"))
+        })?;
+        self.ctx
+            .register_table(name, Arc::new(table))
+            .map_err(|e| JsError::new(&format!("Failed to register table '{name}': {e}")))?;
         Ok(())
     }
 
@@ -312,23 +461,66 @@ impl WrenEngine {
             .finish()
             .map_err(|e| JsError::new(&format!("JSON writer finish error: {e}")))?;
 
-        String::from_utf8(buf)
-            .map_err(|e| JsError::new(&format!("UTF-8 encoding error: {e}")))
+        String::from_utf8(buf).map_err(|e| JsError::new(&format!("UTF-8 encoding error: {e}")))
     }
+}
+
+/// Returns true if `source` starts with a URL scheme that `load_mdl`
+/// recognises as URL mode. Only `http(s)://` is supported in Phase 2;
+/// `s3://` / `gs://` are Phase 4 work and intentionally fall through to
+/// local mode (where they'll fail fast with an `Unresolved models` error).
+fn is_url_source(source: &str) -> bool {
+    source.starts_with("http://") || source.starts_with("https://")
+}
+
+/// Strip dot-separated quoted identifier parts from a MDL `tableReference`
+/// string and return the final segment unquoted.
+///
+/// Only splits on dots that are **outside** double-quoted segments so a name
+/// like `"\"my.weird\".orders"` returns `orders`, not `weird"`. Phase 2 uses
+/// this only to derive the bare physical table name (e.g. for the Parquet file
+/// name under `source`, and for the catalog lookup). The full
+/// `model.table_reference()` string is still used as the key into
+/// `register_tables`, so qualified references remain distinguishable there.
+///
+/// Examples:
+/// - `"\"datafusion\".\"public\".\"Orders\""` → `"Orders"`
+/// - `"\"orders\""` → `"orders"`
+/// - `""` → `""`
+fn extract_bare_table_name(table_ref: &str) -> &str {
+    if table_ref.is_empty() {
+        return table_ref;
+    }
+    // Walk from the end and find the first `.` that is outside quotes.
+    let bytes = table_ref.as_bytes();
+    let mut in_quote = false;
+    let mut split_at: Option<usize> = None;
+    for (i, &b) in bytes.iter().enumerate().rev() {
+        match b {
+            b'"' => in_quote = !in_quote,
+            b'.' if !in_quote => {
+                split_at = Some(i);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let last = match split_at {
+        Some(i) => &table_ref[i + 1..],
+        None => table_ref,
+    };
+    last.trim_matches('"')
 }
 
 /// Convert a JSON array string to NDJSON (one object per line).
 /// Arrow's JSON reader expects NDJSON format.
 fn json_array_to_ndjson(json_data: &str) -> Result<String, JsError> {
-    let parsed: serde_json::Value = serde_json::from_str(json_data)
-        .map_err(|e| JsError::new(&format!("Invalid JSON: {e}")))?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(json_data).map_err(|e| JsError::new(&format!("Invalid JSON: {e}")))?;
 
     match parsed {
         serde_json::Value::Array(arr) => {
-            let lines: Result<Vec<String>, _> = arr
-                .iter()
-                .map(|v| serde_json::to_string(v))
-                .collect();
+            let lines: Result<Vec<String>, _> = arr.iter().map(serde_json::to_string).collect();
             lines
                 .map(|l| l.join("\n"))
                 .map_err(|e| JsError::new(&format!("JSON serialization error: {e}")))
@@ -369,10 +561,7 @@ mod tests {
             {"id": 3, "name": "Charlie", "amount": 150.0}
         ]"#;
 
-        engine
-            .register_json("test_table", json_data)
-            .await
-            .unwrap();
+        engine.register_json("test_table", json_data).await.unwrap();
 
         let result = engine
             .query("SELECT count(*) as cnt, avg(amount) as avg_amount FROM test_table")
@@ -383,5 +572,187 @@ mod tests {
         let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["cnt"], 3);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_is_url_source() {
+        assert!(is_url_source("http://localhost/"));
+        assert!(is_url_source("https://cdn.example.com/data/"));
+        // Phase 4: s3:// and gs:// are not URL mode yet.
+        assert!(!is_url_source("s3://bucket/key/"));
+        assert!(!is_url_source("gs://bucket/key/"));
+        assert!(!is_url_source(""));
+        assert!(!is_url_source("./data/"));
+        assert!(!is_url_source("/var/data"));
+        assert!(!is_url_source("data/"));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_extract_bare_table_name() {
+        assert_eq!(extract_bare_table_name(""), "");
+        assert_eq!(extract_bare_table_name("\"orders\""), "orders");
+        assert_eq!(
+            extract_bare_table_name("\"datafusion\".\"public\".\"Orders\""),
+            "Orders"
+        );
+        assert_eq!(
+            extract_bare_table_name("\"public\".\"customers\""),
+            "customers"
+        );
+        // Bare lowercase names skip quoting in the MDL serializer.
+        assert_eq!(extract_bare_table_name("orders"), "orders");
+        assert_eq!(
+            extract_bare_table_name("datafusion.public.orders"),
+            "orders"
+        );
+        // Dots inside quoted segments must not split the name.
+        assert_eq!(extract_bare_table_name("\"my.weird\".orders"), "orders");
+        assert_eq!(
+            extract_bare_table_name("\"schema\".\"has.dot\""),
+            "has.dot"
+        );
+    }
+
+    fn minimal_mdl(model_name: &str, physical_table: &str) -> String {
+        // Minimal single-model MDL. `tableReference` is a bare table name;
+        // `catalog`/`schema` default to `wren`/`public` so loadMDL will align
+        // the session default catalog to that.
+        serde_json::json!({
+            "catalog": "wren",
+            "schema": "public",
+            "models": [{
+                "name": model_name,
+                "tableReference": { "table": physical_table },
+                "columns": [
+                    { "name": "id", "type": "INTEGER" },
+                    { "name": "amount", "type": "DOUBLE" }
+                ],
+                "primaryKey": "id"
+            }],
+            "relationships": [],
+            "metrics": [],
+            "views": []
+        })
+        .to_string()
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_bare_model_name_query() {
+        // Proves §2.5.2: bare model names resolve without a `wren.public.`
+        // prefix after loadMDL aligns the default catalog/schema.
+        let mut engine = WrenEngine::new().unwrap();
+        engine
+            .register_json(
+                "customers",
+                r#"[
+                    {"id": 1, "amount": 100.0},
+                    {"id": 2, "amount": 50.0}
+                ]"#,
+            )
+            .await
+            .unwrap();
+
+        let mdl = minimal_mdl("Customers", "customers");
+        engine.load_mdl(&mdl, "").await.unwrap();
+
+        // Bare model name — no `wren.public.` prefix.
+        let result = engine
+            .query(r#"SELECT count(*) AS cnt FROM "Customers""#)
+            .await
+            .unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["cnt"], 2);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_empty_source_fallback() {
+        // source="" falls back to M3+ behaviour (auto-detect from tableReference).
+        let mut engine = WrenEngine::new().unwrap();
+        engine
+            .register_json("test_orders", r#"[{"id": 1, "amount": 100.0}]"#)
+            .await
+            .unwrap();
+
+        let mdl = minimal_mdl("Orders", "test_orders");
+        engine.load_mdl(&mdl, "").await.unwrap();
+
+        let result = engine
+            .query(r#"SELECT count(*) AS cnt FROM "Orders""#)
+            .await
+            .unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert_eq!(rows[0]["cnt"], 1);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_local_source_with_preregistered_tables() {
+        // Local mode (non-empty, non-URL) resolves tables registered beforehand.
+        let mut engine = WrenEngine::new().unwrap();
+        engine
+            .register_json(
+                "orders",
+                r#"[
+                    {"id": 1, "amount": 50.0},
+                    {"id": 2, "amount": 75.0}
+                ]"#,
+            )
+            .await
+            .unwrap();
+
+        let mdl = minimal_mdl("Orders", "orders");
+        engine.load_mdl(&mdl, "./data/").await.unwrap();
+
+        let result = engine
+            .query(r#"SELECT sum(amount) AS total FROM "Orders""#)
+            .await
+            .unwrap();
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert_eq!(rows[0]["total"], 125.0);
+    }
+
+    #[wasm_bindgen_test]
+    async fn test_local_source_missing_table_error() {
+        // Proves §2.5.1 (local mode): unresolved models become a clear error
+        // at loadMDL time instead of panicking at query time.
+        let mut engine = WrenEngine::new().unwrap();
+        // NOTE: no registerJson/registerParquet — intentionally leave tables missing.
+
+        let mdl = serde_json::json!({
+            "catalog": "wren",
+            "schema": "public",
+            "models": [
+                {
+                    "name": "Orders",
+                    "tableReference": { "table": "orders" },
+                    "columns": [{ "name": "id", "type": "INTEGER" }]
+                },
+                {
+                    "name": "LineItem",
+                    "tableReference": { "table": "lineitem" },
+                    "columns": [{ "name": "id", "type": "INTEGER" }]
+                }
+            ],
+            "relationships": [],
+            "metrics": [],
+            "views": []
+        })
+        .to_string();
+
+        let err = engine.load_mdl(&mdl, "./").await.unwrap_err();
+        // Pull the error message via js_sys::Error to assert against it.
+        let msg = js_sys::Error::from(JsValue::from(err))
+            .message()
+            .as_string()
+            .unwrap_or_default();
+        assert!(
+            msg.contains("Unresolved models"),
+            "expected Unresolved models error, got: {msg}"
+        );
+        assert!(msg.contains("orders"), "expected 'orders' in error: {msg}");
+        assert!(
+            msg.contains("lineitem"),
+            "expected 'lineitem' in error: {msg}"
+        );
     }
 }

--- a/wren-core-wasm/src/lib.rs
+++ b/wren-core-wasm/src/lib.rs
@@ -1,0 +1,338 @@
+//! # wren-core-wasm
+//!
+//! Wren Engine compiled to WebAssembly for browser-native analytics.
+//!
+//! This crate provides a WASM-compatible version of the Wren Engine that runs
+//! entirely in the browser. It uses **upstream DataFusion** (not the Canner fork)
+//! because the WASM version executes queries directly via DataFusion — no SQL
+//! unparser or dialect transpilation is needed.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! JS (browser)
+//!   │
+//!   ├── loadMDL(json)          → WrenEngine stores manifest
+//!   ├── registerParquet(bytes) → Arrow RecordBatch → DataFusion MemTable
+//!   └── query(sql)             → DataFusion executes → JSON result
+//! ```
+//!
+//! ## Milestone Roadmap
+//!
+//! - **M1**: DataFusion WASM compilation + in-memory query (this milestone)
+//! - **M2**: Parquet file upload + query from browser
+//! - **M3**: wren-core semantic layer (MDL plan rewriting)
+//! - **M4**: npm package + TypeScript API wrapper
+
+use wasm_bindgen::prelude::*;
+
+// wasm-bindgen-test macros are used in the test module below
+
+/// Wren Engine WASM instance.
+///
+/// Holds a DataFusion SessionContext and (in M3+) an AnalyzedWrenMDL.
+/// All query execution happens in-browser via DataFusion.
+#[wasm_bindgen]
+pub struct WrenEngine {
+    ctx: datafusion::execution::context::SessionContext,
+}
+
+#[wasm_bindgen]
+impl WrenEngine {
+    /// Initialize a new WrenEngine instance.
+    ///
+    /// Creates a DataFusion SessionContext with default configuration
+    /// suitable for single-threaded WASM execution.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Result<WrenEngine, JsError> {
+        // Configure DataFusion for single-threaded WASM environment
+        let config = datafusion::execution::context::SessionConfig::new()
+            .with_target_partitions(1); // Single-threaded in WASM
+
+        let ctx = datafusion::execution::context::SessionContext::new_with_config(config);
+
+        Ok(WrenEngine { ctx })
+    }
+
+    /// Register an in-memory table from a JSON array of objects.
+    ///
+    /// This is a convenience method for M1 testing. In M2+, use
+    /// `register_parquet` to load Parquet files from the browser.
+    ///
+    /// # Arguments
+    /// * `table_name` - Name to register the table under
+    /// * `json_data` - JSON string: array of objects, e.g. `[{"a":1,"b":"x"},...]`
+    #[wasm_bindgen(js_name = registerJson)]
+    pub async fn register_json(
+        &self,
+        table_name: &str,
+        json_data: &str,
+    ) -> Result<(), JsError> {
+        use arrow::json::reader::infer_json_schema;
+        use arrow::json::ReaderBuilder;
+        use datafusion::datasource::MemTable;
+        use std::io::BufReader;
+        use std::sync::Arc;
+
+        // Arrow JSON reader expects NDJSON (one object per line), not a JSON array.
+        // Convert JSON array to NDJSON format.
+        let ndjson = json_array_to_ndjson(json_data)?;
+
+        // Infer schema from NDJSON data
+        let buf_reader = BufReader::new(ndjson.as_bytes());
+        let (schema, _) = infer_json_schema(buf_reader, None)
+            .map_err(|e| JsError::new(&format!("Failed to infer JSON schema: {e}")))?;
+
+        // Parse NDJSON into Arrow RecordBatch
+        let buf_reader = BufReader::new(ndjson.as_bytes());
+        let reader = ReaderBuilder::new(Arc::new(schema))
+            .with_batch_size(8192)
+            .build(buf_reader)
+            .map_err(|e| JsError::new(&format!("Failed to parse JSON: {e}")))?;
+
+        let batches: Vec<_> = reader
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| JsError::new(&format!("Failed to read JSON batches: {e}")))?;
+
+        if batches.is_empty() {
+            return Err(JsError::new("No data in JSON input"));
+        }
+
+        let schema = batches[0].schema();
+        let table = MemTable::try_new(schema, vec![batches])
+            .map_err(|e| JsError::new(&format!("Failed to create table: {e}")))?;
+
+        self.ctx
+            .register_table(table_name, Arc::new(table))
+            .map_err(|e| JsError::new(&format!("Failed to register table: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Register a Parquet file from bytes uploaded via JS.
+    ///
+    /// Reads the Parquet data into Arrow RecordBatches and registers as a MemTable.
+    /// The JS side should pass the file contents as a `Uint8Array`.
+    #[wasm_bindgen(js_name = registerParquet)]
+    pub async fn register_parquet(
+        &self,
+        table_name: &str,
+        data: &[u8],
+    ) -> Result<(), JsError> {
+        use datafusion::datasource::MemTable;
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use std::sync::Arc;
+
+        let builder = ParquetRecordBatchReaderBuilder::try_new(bytes::Bytes::from(data.to_vec()))
+            .map_err(|e| JsError::new(&format!("Failed to open Parquet: {e}")))?;
+
+        let schema = builder.schema().clone();
+
+        let reader = builder
+            .build()
+            .map_err(|e| JsError::new(&format!("Failed to build Parquet reader: {e}")))?;
+
+        let batches: Vec<_> = reader
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| JsError::new(&format!("Failed to read Parquet batches: {e}")))?;
+
+        if batches.is_empty() {
+            return Err(JsError::new("No data in Parquet file"));
+        }
+
+        let table = MemTable::try_new(schema, vec![batches])
+            .map_err(|e| JsError::new(&format!("Failed to create table: {e}")))?;
+
+        self.ctx
+            .register_table(table_name, Arc::new(table))
+            .map_err(|e| JsError::new(&format!("Failed to register table: {e}")))?;
+
+        Ok(())
+    }
+
+    /// Load an MDL (Modeling Definition Language) manifest.
+    ///
+    /// Parses the MDL JSON, builds the semantic layer (AnalyzedWrenMDL),
+    /// and reconfigures the SessionContext with Wren analyzer rules in
+    /// LocalRuntime mode (direct DataFusion execution, no SQL generation).
+    ///
+    /// Physical tables (registered via `registerParquet`/`registerJson`) are
+    /// mapped to MDL models through each model's `tableReference`. Register
+    /// the backing tables before calling this method.
+    ///
+    /// After loading, queries can reference MDL model names as table names.
+    #[wasm_bindgen(js_name = loadMDL)]
+    pub async fn load_mdl(&mut self, mdl_json: &str) -> Result<(), JsError> {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+        use wren_core::mdl::context::{apply_wren_on_ctx, Mode};
+        use wren_core::mdl::AnalyzedWrenMDL;
+        use wren_core_base::mdl::manifest::Manifest;
+
+        let manifest: Manifest = serde_json::from_str(mdl_json)
+            .map_err(|e| JsError::new(&format!("Failed to parse MDL JSON: {e}")))?;
+
+        // Collect existing physical tables from the current context and map them
+        // by the table reference names used in the MDL models.
+        // The model's tableReference (e.g., "orders" or "schema.orders") is resolved
+        // to find the matching physical table in the default DataFusion catalog.
+        let mut register_tables: HashMap<
+            String,
+            Arc<dyn datafusion::datasource::TableProvider>,
+        > = HashMap::new();
+
+        let default_catalog = "datafusion";
+        let default_schema = "public";
+
+        for model in &manifest.models {
+            let table_ref_str = model.table_reference();
+            if table_ref_str.is_empty() {
+                continue;
+            }
+
+            // Parse the table reference to extract the table name
+            let table_ref = datafusion::sql::TableReference::from(table_ref_str);
+            let table_name = table_ref.table();
+
+            // Look up the physical table in the default catalog/schema
+            if let Some(catalog_provider) = self.ctx.catalog(default_catalog) {
+                if let Some(schema_provider) = catalog_provider.schema(default_schema) {
+                    if let Ok(Some(table)) = schema_provider.table(table_name).await {
+                        // Register with fully qualified name so ModelGenerationRule can find it
+                        let qualified_name = format!(
+                            "{}.{}.{}",
+                            default_catalog, default_schema, table_name
+                        );
+                        register_tables.insert(qualified_name, table);
+                    }
+                }
+            }
+        }
+
+        let analyzed_mdl = Arc::new(
+            AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
+                .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))?,
+        );
+
+        let properties: Arc<HashMap<String, Option<String>>> =
+            Arc::new(HashMap::new());
+
+        let new_ctx = apply_wren_on_ctx(
+            &self.ctx,
+            analyzed_mdl,
+            properties,
+            Mode::LocalRuntime,
+        )
+        .await
+        .map_err(|e| JsError::new(&format!("Failed to apply MDL rules: {e}")))?;
+
+        self.ctx = new_ctx;
+        Ok(())
+    }
+
+    /// Execute a SQL query and return results as a JSON string.
+    ///
+    /// Returns a JSON array of objects, e.g. `[{"count":42,"avg":3.14},...]`
+    #[wasm_bindgen]
+    pub async fn query(&self, sql: &str) -> Result<String, JsError> {
+        use arrow::json::writer::JsonArray;
+        use arrow::json::WriterBuilder;
+
+        let df = self
+            .ctx
+            .sql(sql)
+            .await
+            .map_err(|e| JsError::new(&format!("SQL error: {e}")))?;
+
+        let batches = df
+            .collect()
+            .await
+            .map_err(|e| JsError::new(&format!("Execution error: {e}")))?;
+
+        let mut buf = Vec::new();
+        let mut writer = WriterBuilder::new()
+            .with_explicit_nulls(false)
+            .build::<_, JsonArray>(&mut buf);
+
+        for batch in &batches {
+            writer
+                .write(batch)
+                .map_err(|e| JsError::new(&format!("JSON serialization error: {e}")))?;
+        }
+        writer
+            .finish()
+            .map_err(|e| JsError::new(&format!("JSON writer finish error: {e}")))?;
+
+        String::from_utf8(buf)
+            .map_err(|e| JsError::new(&format!("UTF-8 encoding error: {e}")))
+    }
+}
+
+/// Convert a JSON array string to NDJSON (one object per line).
+/// Arrow's JSON reader expects NDJSON format.
+fn json_array_to_ndjson(json_data: &str) -> Result<String, JsError> {
+    let parsed: serde_json::Value = serde_json::from_str(json_data)
+        .map_err(|e| JsError::new(&format!("Invalid JSON: {e}")))?;
+
+    match parsed {
+        serde_json::Value::Array(arr) => {
+            let lines: Result<Vec<String>, _> = arr
+                .iter()
+                .map(|v| serde_json::to_string(v))
+                .collect();
+            lines
+                .map(|l| l.join("\n"))
+                .map_err(|e| JsError::new(&format!("JSON serialization error: {e}")))
+        }
+        serde_json::Value::Object(_) => {
+            // Already a single object, return as-is
+            Ok(json_data.to_string())
+        }
+        _ => Err(JsError::new("Expected JSON array or object")),
+    }
+}
+
+impl Default for WrenEngine {
+    fn default() -> Self {
+        Self::new().expect("Failed to create default WrenEngine")
+    }
+}
+
+// =============================================================================
+// Tests (run via wasm-bindgen-test in browser/node)
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    // Configure tests to run in Node.js (no browser needed for CI)
+    wasm_bindgen_test_configure!(run_in_node_experimental);
+
+    #[wasm_bindgen_test]
+    async fn test_basic_query() {
+        let engine = WrenEngine::new().unwrap();
+
+        let json_data = r#"[
+            {"id": 1, "name": "Alice", "amount": 100.0},
+            {"id": 2, "name": "Bob", "amount": 200.0},
+            {"id": 3, "name": "Charlie", "amount": 150.0}
+        ]"#;
+
+        engine
+            .register_json("test_table", json_data)
+            .await
+            .unwrap();
+
+        let result = engine
+            .query("SELECT count(*) as cnt, avg(amount) as avg_amount FROM test_table")
+            .await
+            .unwrap();
+
+        // Parse and verify
+        let rows: Vec<serde_json::Value> = serde_json::from_str(&result).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["cnt"], 3);
+    }
+}

--- a/wren-core-wasm/src/lib.rs
+++ b/wren-core-wasm/src/lib.rs
@@ -184,35 +184,84 @@ impl WrenEngine {
         let default_catalog = "datafusion";
         let default_schema = "public";
 
-        for model in &manifest.models {
-            let table_ref_str = model.table_reference();
-            if table_ref_str.is_empty() {
-                continue;
-            }
+        // Determine data loading strategy based on data source and tableReference format.
+        //
+        // URL table mode (DataFusion reads Parquet directly via HTTP range requests):
+        //   - local_file with http(s):// tableReferences (rewritten by JS for WASM)
+        //   - s3, gcs, minio with native URLs (s3://, gs://, etc.)
+        //
+        // Pre-register mode (tables already loaded via registerParquet/registerJson):
+        //   - local_file with local paths (not accessible in WASM, must registerParquet first)
+        //   - no dataSource / other data sources (not supported for URL table in WASM)
+        let use_url_tables = manifest.models.iter().any(|m| {
+            let raw = m.table_reference();
+            let url_str = raw.trim_matches('"');
+            // Has a URL scheme → URL table mode
+            url::Url::parse(url_str).is_ok()
+        });
 
-            // Parse the table reference to extract the table name
-            let table_ref = datafusion::sql::TableReference::from(table_ref_str);
-            let table_name = table_ref.table();
-
-            // Look up the physical table in the default catalog/schema
-            if let Some(catalog_provider) = self.ctx.catalog(default_catalog) {
-                if let Some(schema_provider) = catalog_provider.schema(default_schema) {
-                    if let Ok(Some(table)) = schema_provider.table(table_name).await {
-                        // Register with fully qualified name so ModelGenerationRule can find it
-                        let qualified_name = format!(
-                            "{}.{}.{}",
-                            default_catalog, default_schema, table_name
-                        );
-                        register_tables.insert(qualified_name, table);
+        let analyzed_mdl = if use_url_tables {
+                // URL table mode: register object stores for each URL scheme+origin,
+                // then DataFusion's ListingTable reads Parquet via range requests.
+                let mut registered_origins = std::collections::HashSet::new();
+                for model in &manifest.models {
+                    let raw = model.table_reference();
+                    let url_str = raw.trim_matches('"');
+                    if let Ok(parsed) = url::Url::parse(url_str) {
+                        let scheme = parsed.scheme();
+                        // Only HTTP(S) needs explicit HttpStore registration.
+                        // S3/GCS/MinIO stores should be pre-registered or use
+                        // DataFusion's built-in object_store integration.
+                        if scheme == "http" || scheme == "https" {
+                            let origin = parsed.origin().unicode_serialization();
+                            if registered_origins.insert(origin.clone()) {
+                                let http_store = object_store::http::HttpBuilder::new()
+                                    .with_url(&origin)
+                                    .build()
+                                    .map_err(|e| JsError::new(&format!("Failed to create HTTP store for {origin}: {e}")))?;
+                                let base_url = url::Url::parse(&format!("{origin}/"))
+                                    .map_err(|e| JsError::new(&format!("Invalid base URL: {e}")))?;
+                                self.ctx.register_object_store(&base_url, Arc::new(http_store));
+                            }
+                        }
                     }
                 }
-            }
-        }
 
-        let analyzed_mdl = Arc::new(
-            AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
-                .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))?,
-        );
+                Arc::new(
+                    AnalyzedWrenMDL::analyze_with_url_tables(manifest, &self.ctx).await
+                        .map_err(|e| JsError::new(&format!("Failed to analyze MDL with URL tables: {e}")))?,
+                )
+        } else {
+                for model in &manifest.models {
+                    let table_ref_str = model.table_reference();
+                    if table_ref_str.is_empty() {
+                        continue;
+                    }
+
+                    // Parse the table reference to extract the table name
+                    let table_ref = datafusion::sql::TableReference::from(table_ref_str);
+                    let table_name = table_ref.table();
+
+                    // Look up the physical table in the default catalog/schema
+                    if let Some(catalog_provider) = self.ctx.catalog(default_catalog) {
+                        if let Some(schema_provider) = catalog_provider.schema(default_schema) {
+                            if let Ok(Some(table)) = schema_provider.table(table_name).await {
+                                // Register with fully qualified name so ModelGenerationRule can find it
+                                let qualified_name = format!(
+                                    "{}.{}.{}",
+                                    default_catalog, default_schema, table_name
+                                );
+                                register_tables.insert(qualified_name, table);
+                            }
+                        }
+                    }
+                }
+
+                Arc::new(
+                    AnalyzedWrenMDL::analyze_with_tables(manifest, register_tables)
+                        .map_err(|e| JsError::new(&format!("Failed to analyze MDL: {e}")))?,
+                )
+        };
 
         let properties: Arc<HashMap<String, Option<String>>> =
             Arc::new(HashMap::new());

--- a/wren-core/Cargo.toml
+++ b/wren-core/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.1.0"
 
 [workspace.dependencies]
 async-trait = "0.1.89"
-datafusion = { version = "53", features = [
+datafusion = { version = "53", default-features = false, features = [
     "nested_expressions",
     "crypto_expressions",
     "datetime_expressions",
@@ -31,6 +31,6 @@ log = { version = "0.4.14" }
 serde = { version = "1.0.201", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149" }
 serde_with = { version = "3.18.0" }
-tokio = { version = "1.46", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.46", features = ["rt", "macros"] }
 wren-core = { path = "core" }
 wren-core-base = { path = "../wren-core-base" }

--- a/wren-core/Cargo.toml
+++ b/wren-core/Cargo.toml
@@ -24,6 +24,7 @@ datafusion = { version = "53", default-features = false, features = [
     "parquet",
     "sql",
 ] }
+datafusion-session = { version = "53", default-features = false }
 env_logger = "0.11.10"
 hashbrown = "0.17.0"
 insta = { version = "1.41.1" }

--- a/wren-core/benchmarks/Cargo.toml
+++ b/wren-core/benchmarks/Cargo.toml
@@ -21,5 +21,5 @@ num_cpus = "1.16.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 structopt = { version = "0.3.26", default-features = false }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 wren-core = { workspace = true }

--- a/wren-core/core/Cargo.toml
+++ b/wren-core/core/Cargo.toml
@@ -29,6 +29,8 @@ datafusion = { workspace = true, features = [
     "regex_expressions",
     "unicode_expressions",
 ] }
+
+datafusion-session = { workspace = true }
 env_logger = { workspace = true }
 itertools = "0.14.0"
 log = { workspace = true }

--- a/wren-core/core/Cargo.toml
+++ b/wren-core/core/Cargo.toml
@@ -12,6 +12,12 @@ authors = { workspace = true }
 name = "wren_core"
 path = "src/lib.rs"
 
+[features]
+default = ["multi-thread"]
+# Enable multi-threaded tokio runtime (required for sync transform_sql).
+# Disable for WASM builds where only single-threaded async is available.
+multi-thread = ["tokio/rt-multi-thread"]
+
 [dependencies]
 async-trait = { workspace = true }
 csv = "1.3.0"
@@ -33,7 +39,7 @@ regex = "1.10.5"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 wren-core-base = { workspace = true }
 
 [dev-dependencies]

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -30,6 +30,7 @@ use datafusion::optimizer::eliminate_join::EliminateJoin;
 use datafusion::optimizer::eliminate_outer_join::EliminateOuterJoin;
 use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
 use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
+use datafusion::optimizer::optimize_unions::OptimizeUnions;
 use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
 use datafusion::optimizer::{AnalyzerRule, OptimizerRule};
 use datafusion::physical_plan::ExecutionPlan;

--- a/wren-core/core/src/mdl/context.rs
+++ b/wren-core/core/src/mdl/context.rs
@@ -30,7 +30,6 @@ use datafusion::optimizer::eliminate_join::EliminateJoin;
 use datafusion::optimizer::eliminate_outer_join::EliminateOuterJoin;
 use datafusion::optimizer::extract_equijoin_predicate::ExtractEquijoinPredicate;
 use datafusion::optimizer::filter_null_join_keys::FilterNullJoinKeys;
-use datafusion::optimizer::optimize_unions::OptimizeUnions;
 use datafusion::optimizer::propagate_empty_relation::PropagateEmptyRelation;
 use datafusion::optimizer::{AnalyzerRule, OptimizerRule};
 use datafusion::physical_plan::ExecutionPlan;

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -114,21 +114,25 @@ impl AnalyzedWrenMDL {
         manifest: Manifest,
         ctx: &SessionContext,
     ) -> Result<Self> {
+        use datafusion::datasource::file_format::parquet::ParquetFormat;
         use datafusion::datasource::listing::{
             ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
         };
-        use datafusion::datasource::file_format::parquet::ParquetFormat;
 
         let mut wren_mdl = WrenMDL::new(manifest);
-        match wren_mdl.data_source().unwrap_or(DataSource::Datafusion) {
-            DataSource::LocalFile
-            | DataSource::MinioFile
-            | DataSource::S3File
-            | DataSource::GcsFile => {}
-            _ => {
-                return plan_err!(
-                    "Only file-based data source is supported for analyze_with_url_tables"
-                )
+        // Allow manifests that omit `dataSource` (treat as file-backed). Only
+        // reject when `dataSource` is explicitly set to a non-file backend.
+        if let Some(data_source) = wren_mdl.data_source() {
+            match data_source {
+                DataSource::LocalFile
+                | DataSource::MinioFile
+                | DataSource::S3File
+                | DataSource::GcsFile => {}
+                _ => {
+                    return plan_err!(
+                        "Only file-based data source is supported for analyze_with_url_tables"
+                    )
+                }
             }
         }
 
@@ -148,10 +152,7 @@ impl AnalyzedWrenMDL {
                 .await?;
 
             let table = ListingTable::try_new(config)?;
-            wren_mdl.register_table(
-                model.table_reference().to_string(),
-                Arc::new(table),
-            );
+            wren_mdl.register_table(model.table_reference().to_string(), Arc::new(table));
         }
 
         let lineage = lineage::Lineage::new(&wren_mdl)?;

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -9,11 +9,11 @@ use crate::mdl::function::{
     RemoteFunction,
 };
 use crate::mdl::manifest::{Column, Manifest, Metric, Model, View};
-use crate::mdl::utils::to_field;
+use crate::mdl::utils::{dequote_identifier, to_field};
 use crate::DataFusionError;
 use context::SessionPropertiesRef;
 use datafusion::arrow::datatypes::Field;
-use datafusion::common::internal_datafusion_err;
+use datafusion::common::{internal_datafusion_err, plan_err};
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::execution::context::SessionState;
@@ -94,6 +94,66 @@ impl AnalyzedWrenMDL {
         for (name, table) in register_tables {
             wren_mdl.register_table(name, table);
         }
+        let lineage = lineage::Lineage::new(&wren_mdl)?;
+        Ok(AnalyzedWrenMDL {
+            wren_mdl: Arc::new(wren_mdl),
+            lineage: Arc::new(lineage),
+        })
+    }
+
+    /// Analyze MDL with URL-based table references.
+    ///
+    /// Instead of using `DynamicListTableFactory` (which requires WebDAV PROPFIND),
+    /// directly creates `ListingTable` for each model by:
+    /// 1. Parsing the tableReference as a URL
+    /// 2. Setting format to Parquet (known from file extension)
+    /// 3. Only calling `infer_schema` (uses GET + Range to read Parquet footer)
+    ///
+    /// This follows the DuckDB-WASM pattern: known URL + known format = no listing needed.
+    pub async fn analyze_with_url_tables(
+        manifest: Manifest,
+        ctx: &SessionContext,
+    ) -> Result<Self> {
+        use datafusion::datasource::listing::{
+            ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl,
+        };
+        use datafusion::datasource::file_format::parquet::ParquetFormat;
+
+        let mut wren_mdl = WrenMDL::new(manifest);
+        match wren_mdl.data_source().unwrap_or(DataSource::Datafusion) {
+            DataSource::LocalFile
+            | DataSource::MinioFile
+            | DataSource::S3File
+            | DataSource::GcsFile => {}
+            _ => {
+                return plan_err!(
+                    "Only file-based data source is supported for analyze_with_url_tables"
+                )
+            }
+        }
+
+        let state = ctx.state();
+        for model in wren_mdl.models().to_vec() {
+            let url_str = dequote_identifier(model.table_reference());
+            let table_url = ListingTableUrl::parse(url_str)?;
+
+            // Skip infer_options (which does PROPFIND/list).
+            // We know the format is Parquet from the tableReference extension.
+            let options = ListingOptions::new(Arc::new(ParquetFormat::default()))
+                .with_file_extension(".parquet");
+
+            let config = ListingTableConfig::new(table_url)
+                .with_listing_options(options)
+                .infer_schema(&state)
+                .await?;
+
+            let table = ListingTable::try_new(config)?;
+            wren_mdl.register_table(
+                model.table_reference().to_string(),
+                Arc::new(table),
+            );
+        }
+
         let lineage = lineage::Lineage::new(&wren_mdl)?;
         Ok(AnalyzedWrenMDL {
             wren_mdl: Arc::new(wren_mdl),

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -401,7 +401,10 @@ pub fn create_wren_ctx(
     SessionContext::new_with_state(builder.build())
 }
 
-/// Transform the SQL based on the MDL
+/// Transform the SQL based on the MDL (sync wrapper, requires multi-thread tokio runtime).
+///
+/// Not available on WASM — use [`transform_sql_with_ctx`] directly in async context.
+#[cfg(feature = "multi-thread")]
 pub fn transform_sql(
     analyzed_mdl: Arc<AnalyzedWrenMDL>,
     remote_functions: &[RemoteFunction],

--- a/wren-core/core/src/mdl/utils.rs
+++ b/wren-core/core/src/mdl/utils.rs
@@ -208,7 +208,8 @@ pub fn quoted(s: &str) -> String {
 
 #[inline]
 pub fn dequote_identifier(s: &str) -> &str {
-    if s.starts_with('"') && s.ends_with('"') {
+    // Require >= 2 chars so a single `"` doesn't slice 1..0 and panic.
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
         &s[1..s.len() - 1]
     } else {
         s

--- a/wren-core/core/src/mdl/utils.rs
+++ b/wren-core/core/src/mdl/utils.rs
@@ -206,6 +206,15 @@ pub fn quoted(s: &str) -> String {
     format!("\"{s}\"")
 }
 
+#[inline]
+pub fn dequote_identifier(s: &str) -> &str {
+    if s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
 /// Transform the column to a datafusion field
 pub fn to_field(column: &wren_core_base::mdl::Column) -> Result<Field> {
     let data_type = try_map_data_type(&column.r#type)?;

--- a/wren-core/wren-example/Cargo.toml
+++ b/wren-core/wren-example/Cargo.toml
@@ -15,5 +15,5 @@ async-trait = { workspace = true }
 datafusion = { workspace = true }
 env_logger = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 wren-core = { workspace = true }


### PR DESCRIPTION
## Summary

Plan C-2 Phase 2 — `loadMDL` now takes a second `source` argument so one MDL manifest runs across CLI local / CLI S3 / WASM local / WASM CDN without ever editing `tableReference`. Deployment specifics move out of the MDL and into the profile.

Builds on PR #1541 (two-phase API + DataFusion connector). Carries forward the wasm POC from \`feat/wren-core-wasm-poc\`: multi-thread feature flag, \`analyze_with_url_tables\`, and the initial \`wren-core-wasm\` crate.

## Commits in this PR

| Commit | Origin |
|---|---|
| refactor(wren-core): add multi-thread feature flag for WASM compatibility | cherry-pick from \`feat/wren-core-wasm-poc\` |
| feat(wren-core-wasm): add WASM POC — semantic layer + DataFusion in browser | cherry-pick |
| feat(wren-core): add analyze_with_url_tables for direct Parquet reading | cherry-pick |
| feat(wren-core-wasm): add URL table support for direct HTTP Parquet reading | cherry-pick |
| **feat(wren-core-wasm): integrate profile source for portable MDL** | **new — Phase 2** |

## What the new commit does

**\`loadMDL(mdl_json, source)\`** — three branches keyed off \`source\`:

- \`http(s)://\`, \`s3://\`, \`gs://\` → **URL mode**. Registers one HTTP \`object_store\` per unique origin, then a DataFusion \`ListingTable\` per model at \`{source}/{name}.parquet\`. No \`registerParquet\` needed on the JS side.
- \`\"\"\` (empty) → **fallback** to M3+ auto-detect (URL vs local inferred from \`tableReference\`). Preserves existing examples.
- otherwise (e.g. \`./data/\`) → **local mode**. Caller pre-registered tables; missing models now raise \`Unresolved models: [...]\` at \`loadMDL\` time instead of the old query-time \`RuntimeError: unreachable\` (Plan A M4a §2.5.1).

The lookup key in \`register_tables\` must match \`model.table_reference()\` verbatim — that's what \`WrenMDL::get_table\` uses during plan analysis. Default catalog/schema alignment (§2.5.2) is already handled by \`apply_wren_on_ctx\` from #1541, no extra code needed.

## Test plan

- [x] \`cargo fmt --check\` (wren-core + wren-core-wasm) — clean
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo test -p wren-core\` — 74/74 pass
- [x] \`wasm-pack build --target web\` — \`loadMDL(mdl_json: string, source: string): Promise<void>\` in .d.ts
- [x] \`wasm-pack test --node\` — 7/7 pass:
  - \`test_basic_query\`
  - \`test_is_url_source\`, \`test_extract_bare_table_name\`
  - \`test_bare_model_name_query\` — proves §2.5.2 catalog/schema alignment
  - \`test_empty_source_fallback\` — M3+ compat
  - \`test_local_source_with_preregistered_tables\`
  - \`test_local_source_missing_table_error\` — proves §2.5.1 M4a validation
- [x] \`node examples/test-node.mjs\` / \`test-parquet-node.mjs\` / \`test-mdl-node.mjs\` / \`test-jaffle-node.mjs\` — all pass
- [x] \`node examples/test-source-url-node.mjs\` (new, requires \`serve-jaffle.mjs\`) — bare model names + fully-qualified both return correct counts
- [x] \`node examples/test-url-table-node.mjs\` — legacy \`source=''\` fallback still works

## Notes

- Building \`wren-core-wasm\` requires LLVM with the wasm target: \`CC=/opt/homebrew/opt/llvm/bin/clang AR=/opt/homebrew/opt/llvm/bin/llvm-ar wasm-pack build --target web\` (the \`ring\` dep pulls in C sources).
- Out of scope here: Phase 3 (dlt skill simplification) and Phase 4 (E2E matrix + docs).

Plan reference: [plan-datafusion-integration.md](https://github.com/Canner/wren-engine/blob/feat/wren-wasm/plan-datafusion-integration.md) §Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced WebAssembly runtime enabling Wren to run natively in JavaScript environments
  * Added support for registering data from JSON and Parquet formats
  * Added MDL model loading with URL-based HTTP/HTTPS data source support
  * Added SQL query execution capabilities with JSON formatted results

* **Tests**
  * Added comprehensive test coverage for WASM functionality and data operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->