### PR TITLE
feat(wren-core): add refSql model support

### DIFF
--- a/wren-core-base/src/mdl/manifest.rs
+++ b/wren-core-base/src/mdl/manifest.rs
@@ -358,13 +358,42 @@ impl Model {
     }
 
     /// Return the table reference of the model
-    pub fn table_reference(&self) -> &str {
-        self.table_reference.as_deref().unwrap_or("")
+    pub fn table_reference(&self) -> Option<&str> {
+        self.table_reference.as_deref()
+    }
+
+    /// Return the ref_sql of the model
+    pub fn ref_sql(&self) -> Option<&str> {
+        self.ref_sql.as_deref()
+    }
+
+    /// Determine the source type of this model
+    pub fn source(&self) -> ModelSource {
+        match (
+            self.table_reference.is_some(),
+            self.ref_sql.is_some(),
+        ) {
+            (true, false) => ModelSource::TableReference,
+            (false, true) => ModelSource::RefSql,
+            (true, true) => ModelSource::Invalid(
+                "Both table_reference and ref_sql are defined".to_string(),
+            ),
+            (false, false) => ModelSource::Invalid(
+                "No source defined: must have either table_reference or ref_sql".to_string(),
+            ),
+        }
     }
 
     pub fn row_level_access_controls(&self) -> &[Arc<RowLevelAccessControl>] {
         &self.row_level_access_controls
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum ModelSource {
+    TableReference,
+    RefSql,
+    Invalid(String),
 }
 
 impl PartialOrd for Model {
@@ -419,7 +448,9 @@ impl SessionProperty {
 
 #[cfg(test)]
 mod tests {
+    use crate::mdl::builder::ModelBuilder;
     use crate::mdl::manifest::table_reference;
+    use crate::mdl::manifest::ModelSource;
     use serde_json::Serializer;
 
     #[test]
@@ -457,5 +488,35 @@ mod tests {
             serialized,
             r#"{"catalog":"Catalog","schema":"Schema","table":"Table"}"#
         );
+    }
+
+    #[test]
+    fn test_model_source() {
+        // table_reference only → TableReference
+        let model = ModelBuilder::new("tref_model")
+            .table_reference("schema.orders")
+            .build();
+        assert!(matches!(model.source(), ModelSource::TableReference));
+        assert_eq!(model.table_reference(), Some("schema.orders"));
+        assert_eq!(model.ref_sql(), None);
+
+        // ref_sql only → RefSql
+        let model = ModelBuilder::new("sql_model")
+            .ref_sql("SELECT 1")
+            .build();
+        assert!(matches!(model.source(), ModelSource::RefSql));
+        assert_eq!(model.table_reference(), None);
+        assert_eq!(model.ref_sql(), Some("SELECT 1"));
+
+        // both defined → Invalid
+        let mut model = ModelBuilder::new("both_model")
+            .table_reference("schema.orders")
+            .ref_sql("SELECT 1")
+            .build();
+        assert!(matches!(model.source(), ModelSource::Invalid(_)));
+
+        // neither defined → Invalid
+        model = ModelBuilder::new("empty_model").build();
+        assert!(matches!(model.source(), ModelSource::Invalid(_)));
     }
 }

--- a/wren-core-py/src/manifest.rs
+++ b/wren-core-py/src/manifest.rs
@@ -92,7 +92,7 @@ mod tests {
             Some("SELECT * FROM table".to_string())
         );
         assert_eq!(manifest.models[1].name(), "model_2");
-        assert_eq!(manifest.models[1].table_reference(), "catalog.schema.table");
+        assert_eq!(manifest.models[1].table_reference(), Some("catalog.schema.table"));
         assert_eq!(manifest.data_source, Some(BigQuery));
     }
 }

--- a/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -179,7 +179,7 @@ impl ModelGenerationRule {
                                     .project(required_exprs)?
                                     .build()
                                 }
-                                _ => {
+                                wren_core_base::mdl::ModelSource::TableReference => {
                                     let table_ref_name = model.table_reference()
                                         .expect("table_reference model must have a table_reference");
                                     LogicalPlanBuilder::scan(
@@ -193,6 +193,9 @@ impl ModelGenerationRule {
                                     .alias(SOURCE_ALIAS)?
                                     .project(required_exprs)?
                                     .build()
+                                }
+                                wren_core_base::mdl::ModelSource::Invalid(reason) => {
+                                    return plan_err!("{reason}");
                                 }
                             }
                         },

--- a/wren-core/core/src/logical_plan/analyze/model_generation.rs
+++ b/wren-core/core/src/logical_plan/analyze/model_generation.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 
 use crate::logical_plan::analyze::plan::{
     CalculationPlanNode, ModelPlanNode, ModelSourceNode, PartialModelPlanNode,
+    SqlReferencePlanNode,
 };
 use crate::logical_plan::utils::{
-    create_remote_table_source, eliminate_ambiguous_columns, rebase_column,
+    create_df_schema, create_remote_table_source, eliminate_ambiguous_columns,
+    rebase_column,
 };
 use crate::mdl::context::SessionPropertiesRef;
 use crate::mdl::manifest::Model;
@@ -143,11 +145,12 @@ impl ModelGenerationRule {
                         *expr = rebase_column(expr, SOURCE_ALIAS)?;
                         Ok::<(), DataFusionError>(())
                     })?;
-                    // support table reference
                     let table_scan = match &model_plan.original_table_scan {
                         Some(LogicalPlan::TableScan(original_scan)) => {
+                            let table_ref_name = model.table_reference()
+                                .expect("TableScan-based model must have a table_reference");
                             LogicalPlanBuilder::scan_with_filters(
-                                TableReference::from(model.table_reference()),
+                                TableReference::from(table_ref_name),
                                 create_remote_table_source(
                                     Arc::clone(&model),
                                     &self.analyzed_wren_mdl.wren_mdl(),
@@ -165,17 +168,33 @@ impl ModelGenerationRule {
                                 .to_string(),
                         )),
                         None => {
-                            LogicalPlanBuilder::scan(
-                                TableReference::from(model.table_reference()),
-                                create_remote_table_source(
-                                    Arc::clone(&model),
-                                    &self.analyzed_wren_mdl.wren_mdl(),
-                                    Arc::clone(&self.session_state))?,
-                                None,
-                            )?
-                                .alias(SOURCE_ALIAS)?
-                                .project(required_exprs)?
-                                .build()
+                            match model.source() {
+                                wren_core_base::mdl::ModelSource::RefSql => {
+                                    let schema_ref = create_df_schema(&model)?;
+                                    let plan = SqlReferencePlanNode::new(&model, schema_ref)?;
+                                    LogicalPlanBuilder::from(LogicalPlan::Extension(Extension {
+                                        node: Arc::new(plan),
+                                    }))
+                                    .alias(SOURCE_ALIAS)?
+                                    .project(required_exprs)?
+                                    .build()
+                                }
+                                _ => {
+                                    let table_ref_name = model.table_reference()
+                                        .expect("table_reference model must have a table_reference");
+                                    LogicalPlanBuilder::scan(
+                                        TableReference::from(table_ref_name),
+                                        create_remote_table_source(
+                                            Arc::clone(&model),
+                                            &self.analyzed_wren_mdl.wren_mdl(),
+                                            Arc::clone(&self.session_state))?,
+                                        None,
+                                    )?
+                                    .alias(SOURCE_ALIAS)?
+                                    .project(required_exprs)?
+                                    .build()
+                                }
+                            }
                         },
                     }?;
 

--- a/wren-core/core/src/logical_plan/analyze/plan.rs
+++ b/wren-core/core/src/logical_plan/analyze/plan.rs
@@ -1200,3 +1200,74 @@ impl UserDefinedLogicalNodeCore for PartialModelPlanNode {
         })
     }
 }
+
+/// A logical plan node representing a model whose source is a raw SQL query (`ref_sql`).
+///
+/// Instead of scanning a physical table, this node carries the original SQL string
+/// and gets unparsed back into a subquery by [`SqlReferenceNodeUnparser`].
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+pub struct SqlReferencePlanNode {
+    pub sql: String,
+    pub model_name: String,
+    pub schema_ref: DFSchemaRef,
+}
+
+impl SqlReferencePlanNode {
+    pub fn new(model: &Model, schema_ref: DFSchemaRef) -> Result<Self> {
+        let sql = model.ref_sql().ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Model '{}' has no ref_sql defined",
+                model.name()
+            ))
+        })?;
+        Ok(Self {
+            sql: sql.to_string(),
+            model_name: model.name().to_string(),
+            schema_ref,
+        })
+    }
+}
+
+impl PartialOrd for SqlReferencePlanNode {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        None
+    }
+}
+
+impl UserDefinedLogicalNodeCore for SqlReferencePlanNode {
+    fn name(&self) -> &str {
+        "SqlReference"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema_ref
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        self.schema_ref
+            .fields()
+            .iter()
+            .map(|field| col(field.name()))
+            .collect()
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "SqlReference: model={}, sql={}",
+            self.model_name, self.sql
+        )
+    }
+
+    fn with_exprs_and_inputs(&self, _: Vec<Expr>, _: Vec<LogicalPlan>) -> Result<Self> {
+        Ok(Self {
+            sql: self.sql.clone(),
+            model_name: self.model_name.clone(),
+            schema_ref: self.schema_ref.clone(),
+        })
+    }
+}

--- a/wren-core/core/src/logical_plan/mod.rs
+++ b/wren-core/core/src/logical_plan/mod.rs
@@ -1,4 +1,5 @@
 pub mod analyze;
 pub mod error;
 pub mod optimize;
+pub mod unparser;
 pub mod utils;

--- a/wren-core/core/src/logical_plan/unparser.rs
+++ b/wren-core/core/src/logical_plan/unparser.rs
@@ -1,0 +1,63 @@
+use datafusion::common::Result;
+use datafusion::logical_expr::UserDefinedLogicalNode;
+use datafusion::sql::sqlparser::ast::Statement;
+use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::parser::Parser;
+use datafusion::sql::unparser::ast::{
+    DerivedRelationBuilder, QueryBuilder, RelationBuilder, SelectBuilder,
+};
+use datafusion::sql::unparser::extension_unparser::{
+    UnparseWithinStatementResult, UserDefinedLogicalNodeUnparser,
+};
+use datafusion::sql::unparser::Unparser;
+
+use crate::logical_plan::analyze::plan::SqlReferencePlanNode;
+
+pub struct SqlReferenceNodeUnparser;
+
+impl UserDefinedLogicalNodeUnparser for SqlReferenceNodeUnparser {
+    fn unparse(
+        &self,
+        node: &dyn UserDefinedLogicalNode,
+        _unparser: &Unparser,
+        _query: &mut Option<&mut QueryBuilder>,
+        _select: &mut Option<&mut SelectBuilder>,
+        relation: &mut Option<&mut RelationBuilder>,
+    ) -> Result<UnparseWithinStatementResult> {
+        let Some(sql_ref) = node.as_any().downcast_ref::<SqlReferencePlanNode>() else {
+            return Ok(UnparseWithinStatementResult::Unmodified);
+        };
+
+        // Parse the ref_sql string into a SQL AST
+        let dialect = GenericDialect {};
+        let statements = Parser::new(&dialect)
+            .try_with_sql(&sql_ref.sql)?
+            .parse_statements()?;
+
+        if statements.len() != 1 {
+            return Err(datafusion::error::DataFusionError::Plan(format!(
+                "ref_sql for model '{}' must contain exactly one SQL statement, found {}",
+                sql_ref.model_name,
+                statements.len()
+            )));
+        }
+
+        let statement = statements.into_iter().next().expect("checked length == 1");
+        let Statement::Query(parsed_query) = statement else {
+            return Err(datafusion::error::DataFusionError::Plan(format!(
+                "ref_sql for model '{}' must be a SELECT statement",
+                sql_ref.model_name
+            )));
+        };
+
+        let mut derived_builder = DerivedRelationBuilder::default();
+        derived_builder.subquery(parsed_query);
+        derived_builder.lateral(false);
+
+        if let Some(rel) = relation {
+            rel.derived(derived_builder);
+        }
+
+        Ok(UnparseWithinStatementResult::Modified)
+    }
+}

--- a/wren-core/core/src/logical_plan/utils.rs
+++ b/wren-core/core/src/logical_plan/utils.rs
@@ -6,7 +6,7 @@ use crate::mdl::{Dataset, SessionStateRef};
 use datafusion::arrow::datatypes::{
     DataType, Field, IntervalUnit, Schema, SchemaBuilder, SchemaRef, TimeUnit,
 };
-use datafusion::common::plan_err;
+use datafusion::common::{plan_err, DFSchema, DFSchemaRef};
 use datafusion::common::tree_node::{
     Transformed, TransformedResult, TreeNode, TreeNodeRecursion,
 };
@@ -259,12 +259,36 @@ pub fn create_schema(columns: Vec<Arc<Column>>) -> Result<SchemaRef> {
     )))
 }
 
+pub fn create_df_schema(model: &Model) -> Result<DFSchemaRef> {
+    let fields: Vec<_> = model
+        .get_physical_columns(false)
+        .iter()
+        .map(|col| {
+            Ok((
+                Some(TableReference::bare(model.name())),
+                Arc::new(Field::new(
+                    col.name(),
+                    try_map_data_type(&col.r#type)?,
+                    col.not_null,
+                )),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Arc::new(DFSchema::new_with_metadata(
+        fields,
+        HashMap::new(),
+    )?))
+}
+
 pub fn create_remote_table_source(
     model: Arc<Model>,
     mdl: &WrenMDL,
     session_state_ref: SessionStateRef,
 ) -> Result<Arc<dyn TableSource>> {
-    if let Some(table_provider) = mdl.get_table(model.table_reference()) {
+    let key = model
+        .table_reference()
+        .unwrap_or_else(|| model.name());
+    if let Some(table_provider) = mdl.get_table(key) {
         Ok(Arc::new(DefaultTableSource::new(table_provider)))
     } else {
         let dataset = Dataset::Model(model);

--- a/wren-core/core/src/mdl/dataset.rs
+++ b/wren-core/core/src/mdl/dataset.rs
@@ -51,13 +51,19 @@ impl Dataset {
     ) -> Result<DFSchema> {
         match self {
             Dataset::Model(model) => {
+                // For refSql models, use the model name as qualifier
+                let qualifier = model
+                    .table_reference()
+                    .map(|t| t.to_string())
+                    .unwrap_or_else(|| quoted(model.name()));
+
                 let schema = register_tables
-                    .map(|rt| rt.get(model.table_reference()))
+                    .map(|rt| rt.get(&qualifier))
                     .filter(|rt| rt.is_some())
                     .map(|rt| rt.unwrap().schema());
 
                 if let Some(schema) = schema {
-                    DFSchema::try_from_qualified_schema(model.table_reference(), &schema)
+                    DFSchema::try_from_qualified_schema(qualifier.as_str(), &schema)
                 } else {
                     let fields: Vec<Field> = model
                         .get_physical_columns(true)
@@ -71,7 +77,7 @@ impl Dataset {
                     let arrow_schema = datafusion::arrow::datatypes::Schema::new(fields);
 
                     DFSchema::try_from_qualified_schema(
-                        model.table_reference(),
+                        qualifier.as_str(),
                         &arrow_schema,
                     )
                 }

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -9,7 +9,7 @@ use crate::mdl::function::{
     RemoteFunction,
 };
 use crate::mdl::manifest::{Column, Manifest, Metric, Model, View};
-use crate::mdl::utils::to_field;
+use crate::mdl::utils::{quoted, to_field};
 use crate::DataFusionError;
 use context::SessionPropertiesRef;
 use datafusion::arrow::datatypes::Field;
@@ -194,45 +194,63 @@ impl WrenMDL {
         properties: SessionPropertiesRef,
         mode: Mode,
     ) -> Result<Self> {
+        use wren_core_base::mdl::ModelSource;
+
         let mut mdl = WrenMDL::new(manifest);
         let sources: Vec<_> = mdl
             .models()
             .iter()
             .map(|model| {
-                let name = TableReference::from(model.table_reference());
-                let available_columns = model
-                    .columns
-                    .iter()
-                    .map(|column| {
-                        if mode.is_permission_analyze()
-                            || validate_clac_rule(
-                                model.name(),
-                                column,
-                                &properties,
-                                None,
-                            )?
-                            .0
-                        {
-                            Ok(Some(Arc::clone(column)))
-                        } else {
-                            Ok(None)
-                        }
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                let fields: Vec<_> = available_columns
-                    .into_iter()
-                    .filter(|c| c.is_some())
-                    .filter_map(|column| {
-                        Self::infer_source_column(&column.unwrap()).ok().flatten()
-                    })
-                    .collect();
-                let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(fields));
-                let datasource = WrenDataSource::new_with_schema(schema);
-                Ok((name.to_quoted_string(), Arc::new(datasource)))
+                match model.source() {
+                    ModelSource::TableReference => {
+                        let name = TableReference::from(model.table_reference().expect("table_reference must exist for TableReference source"));
+                        let available_columns = model
+                            .columns
+                            .iter()
+                            .map(|column| {
+                                if mode.is_permission_analyze()
+                                    || validate_clac_rule(
+                                        model.name(),
+                                        column,
+                                        &properties,
+                                        None,
+                                    )?
+                                    .0
+                                {
+                                    Ok(Some(Arc::clone(column)))
+                                } else {
+                                    Ok(None)
+                                }
+                            })
+                            .collect::<Result<Vec<_>>>()?;
+                        let fields: Vec<_> = available_columns
+                            .into_iter()
+                            .filter(|c| c.is_some())
+                            .filter_map(|column| {
+                                Self::infer_source_column(&column.unwrap()).ok().flatten()
+                            })
+                            .collect();
+                        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(fields));
+                        let datasource = WrenDataSource::new_with_schema(schema);
+                        Ok(Some((name.to_quoted_string(), Arc::new(datasource))))
+                    }
+                    ModelSource::RefSql => {
+                        let fields: Vec<_> = model
+                            .get_physical_columns(false)
+                            .iter()
+                            .filter_map(|column| to_field(column).ok())
+                            .collect();
+                        let schema = Arc::new(datafusion::arrow::datatypes::Schema::new(fields));
+                        let datasource = WrenDataSource::new_with_schema(schema);
+                        Ok(Some((quoted(model.name()), Arc::new(datasource))))
+                    }
+                    ModelSource::Invalid(_) => Ok(None),
+                }
             })
             .collect::<Result<Vec<_>>>()?;
         sources
             .into_iter()
+            .flatten()
             .for_each(|(name, ds_ref)| mdl.register_table(name, ds_ref));
         Ok(mdl)
     }
@@ -460,7 +478,11 @@ pub async fn transform_sql_with_ctx(
 
     let data_source = analyzed_mdl.wren_mdl().data_source().unwrap_or_default();
     let wren_dialect = WrenDialect::new(&data_source);
-    let unparser = Unparser::new(&wren_dialect).with_pretty(true);
+    let unparser = Unparser::new(&wren_dialect)
+        .with_pretty(true)
+        .with_extension_unparsers(vec![Arc::new(
+            crate::logical_plan::unparser::SqlReferenceNodeUnparser,
+        )]);
     // show the planned sql
     match unparser.plan_to_sql(&analyzed) {
         Ok(sql) => {
@@ -4059,5 +4081,156 @@ mod test {
             headers.insert(key.to_lowercase(), value.clone());
         }
         headers
+    }
+
+    #[tokio::test]
+    async fn test_ref_sql_model() -> Result<()> {
+        let mdl_json = r#"
+        {
+            "catalog": "wren",
+            "schema": "test",
+            "models": [
+                {
+                    "name": "revenue_summary",
+                    "refSql": "SELECT region, SUM(amount) AS total FROM raw_sales GROUP BY region",
+                    "columns": [
+                        {
+                            "name": "region",
+                            "type": "string"
+                        },
+                        {
+                            "name": "total",
+                            "type": "int"
+                        }
+                    ]
+                }
+            ]
+        }
+        "#;
+        let manifest: Manifest = serde_json::from_str(mdl_json).unwrap();
+        let ctx = create_wren_ctx(None, None);
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+
+        // Simple SELECT on refSql model
+        let sql = r#"SELECT region, total FROM revenue_summary"#;
+        let result = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &[],
+            Arc::new(HashMap::new()),
+            sql,
+        )
+        .await?;
+        // The refSql should appear as a subquery in the output
+        assert!(
+            result.contains("SELECT region, SUM(amount) AS total FROM raw_sales GROUP BY region"),
+            "Expected refSql subquery in output, got: {result}"
+        );
+
+        // SELECT with WHERE filter on refSql model
+        let sql = r#"SELECT region FROM revenue_summary WHERE total > 100"#;
+        let result = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &[],
+            Arc::new(HashMap::new()),
+            sql,
+        )
+        .await?;
+        assert!(
+            result.contains("SELECT region, SUM(amount) AS total FROM raw_sales GROUP BY region"),
+            "Expected refSql subquery in filtered output, got: {result}"
+        );
+        assert!(
+            result.contains("total > 100"),
+            "Expected WHERE filter in output, got: {result}"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ref_sql_model_with_table_ref_model() -> Result<()> {
+        let mdl_json = r#"
+        {
+            "catalog": "wren",
+            "schema": "test",
+            "models": [
+                {
+                    "name": "orders",
+                    "tableReference": {
+                        "table": "orders"
+                    },
+                    "columns": [
+                        {
+                            "name": "o_orderkey",
+                            "type": "int"
+                        },
+                        {
+                            "name": "o_totalprice",
+                            "type": "float"
+                        }
+                    ]
+                },
+                {
+                    "name": "order_summary",
+                    "refSql": "SELECT o_orderkey, SUM(o_totalprice) AS total FROM orders GROUP BY o_orderkey",
+                    "columns": [
+                        {
+                            "name": "o_orderkey",
+                            "type": "int"
+                        },
+                        {
+                            "name": "total",
+                            "type": "float"
+                        }
+                    ]
+                }
+            ]
+        }
+        "#;
+        let manifest: Manifest = serde_json::from_str(mdl_json).unwrap();
+        let ctx = create_wren_ctx(None, None);
+        let analyzed_mdl = Arc::new(AnalyzedWrenMDL::analyze(
+            manifest,
+            Arc::new(HashMap::default()),
+            Mode::Unparse,
+        )?);
+
+        // Query the refSql model — coexistence with table_reference model
+        let sql = r#"SELECT o_orderkey, total FROM order_summary"#;
+        let result = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &[],
+            Arc::new(HashMap::new()),
+            sql,
+        )
+        .await?;
+        assert!(
+            result.contains("SELECT o_orderkey, SUM(o_totalprice) AS total FROM orders GROUP BY o_orderkey"),
+            "Expected refSql subquery in output, got: {result}"
+        );
+
+        // Query the table_reference model — should still work normally
+        let sql = r#"SELECT o_orderkey FROM orders"#;
+        let result = transform_sql_with_ctx(
+            &ctx,
+            Arc::clone(&analyzed_mdl),
+            &[],
+            Arc::new(HashMap::new()),
+            sql,
+        )
+        .await?;
+        assert!(
+            !result.contains("refSql"),
+            "Table reference model output should not contain refSql, got: {result}"
+        );
+
+        Ok(())
     }
 }

--- a/wren-core/core/src/mdl/mod.rs
+++ b/wren-core/core/src/mdl/mod.rs
@@ -244,7 +244,9 @@ impl WrenMDL {
                         let datasource = WrenDataSource::new_with_schema(schema);
                         Ok(Some((quoted(model.name()), Arc::new(datasource))))
                     }
-                    ModelSource::Invalid(_) => Ok(None),
+                    ModelSource::Invalid(reason) => {
+                        Err(datafusion::error::DataFusionError::Plan(reason))
+                    }
                 }
             })
             .collect::<Result<Vec<_>>>()?;

--- a/wren/tests/suite/test_ref_sql.py
+++ b/wren/tests/suite/test_ref_sql.py
@@ -1,0 +1,188 @@
+"""End-to-end tests for refSql model support.
+
+Uses DuckDB with TPCH data to verify that models defined via ``refSql``
+(a raw SQL query instead of a table reference) work through the full
+WrenEngine pipeline: dry_plan → query → result.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import duckdb
+import orjson
+import pyarrow as pa
+import pytest
+
+from wren import WrenEngine
+from wren.model.data_source import DataSource
+
+pytestmark = pytest.mark.duckdb
+
+
+def _make_ref_sql_manifest() -> dict:
+    """Manifest with one table_reference model and two refSql models.
+
+    - ``orders``: standard TPCH orders table (table_reference)
+    - ``high_value_orders``: refSql model filtering orders > $100k
+    - ``order_summary``: refSql model aggregating orders by status
+    """
+    return {
+        "catalog": "wren",
+        "schema": "public",
+        "models": [
+            {
+                "name": "orders",
+                "tableReference": {
+                    "catalog": "tpch",
+                    "schema": "main",
+                    "table": "orders",
+                },
+                "columns": [
+                    {"name": "o_orderkey", "type": "integer"},
+                    {"name": "o_custkey", "type": "integer"},
+                    {"name": "o_orderstatus", "type": "varchar"},
+                    {"name": "o_totalprice", "type": "double"},
+                    {"name": "o_orderdate", "type": "date"},
+                ],
+                "primaryKey": "o_orderkey",
+            },
+            {
+                "name": "high_value_orders",
+                "refSql": (
+                    "SELECT o_orderkey, o_custkey, o_totalprice "
+                    "FROM tpch.main.orders WHERE o_totalprice > 100000"
+                ),
+                "columns": [
+                    {"name": "o_orderkey", "type": "integer"},
+                    {"name": "o_custkey", "type": "integer"},
+                    {"name": "o_totalprice", "type": "double"},
+                ],
+            },
+            {
+                "name": "order_summary",
+                "refSql": (
+                    "SELECT o_orderstatus, COUNT(*) AS order_count, "
+                    "SUM(o_totalprice) AS total_amount "
+                    "FROM tpch.main.orders GROUP BY o_orderstatus"
+                ),
+                "columns": [
+                    {"name": "o_orderstatus", "type": "varchar"},
+                    {"name": "order_count", "type": "bigint"},
+                    {"name": "total_amount", "type": "double"},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def engine(tmp_path_factory):
+    """WrenEngine backed by DuckDB with TPCH sf=0.01 data."""
+    db_dir = tmp_path_factory.mktemp("refsql_duckdb")
+    db_path = db_dir / "tpch.duckdb"
+
+    con = duckdb.connect(str(db_path))
+    con.execute("INSTALL tpch; LOAD tpch; CALL dbgen(sf=0.01)")
+    con.close()
+
+    manifest = _make_ref_sql_manifest()
+    manifest_str = base64.b64encode(orjson.dumps(manifest)).decode()
+    conn_info = {"url": str(db_dir), "format": "duckdb"}
+    with WrenEngine(manifest_str, DataSource.duckdb, conn_info, fallback=False) as e:
+        yield e
+
+
+# ------------------------------------------------------------------
+# dry_plan — verify SQL transpilation (no execution)
+# ------------------------------------------------------------------
+
+
+class TestRefSqlDryPlan:
+    """dry_plan should expand refSql models into subqueries."""
+
+    def test_dry_plan_ref_sql_model(self, engine: WrenEngine) -> None:
+        planned = engine.dry_plan('SELECT o_orderkey FROM "high_value_orders" LIMIT 1')
+        assert isinstance(planned, str)
+        # The refSql should appear as a subquery in the planned output
+        assert "100000" in planned, f"Expected refSql content in planned SQL: {planned}"
+
+    def test_dry_plan_ref_sql_aggregate_model(self, engine: WrenEngine) -> None:
+        planned = engine.dry_plan(
+            'SELECT o_orderstatus, order_count FROM "order_summary"'
+        )
+        assert isinstance(planned, str)
+        assert "o_orderstatus" in planned.lower()
+        assert "group by" in planned.lower()
+
+    def test_dry_plan_table_ref_model_still_works(self, engine: WrenEngine) -> None:
+        planned = engine.dry_plan('SELECT o_orderkey FROM "orders" LIMIT 1')
+        assert isinstance(planned, str)
+        assert "orders" in planned.lower()
+
+
+# ------------------------------------------------------------------
+# Query execution — end-to-end with real data
+# ------------------------------------------------------------------
+
+
+class TestRefSqlQuery:
+    """Full query execution against refSql models backed by real DuckDB data."""
+
+    def test_query_ref_sql_returns_rows(self, engine: WrenEngine) -> None:
+        result = engine.query(
+            'SELECT o_orderkey, o_totalprice FROM "high_value_orders" LIMIT 5'
+        )
+        assert isinstance(result, pa.Table)
+        assert result.num_rows == 5
+        assert "o_orderkey" in result.column_names
+        assert "o_totalprice" in result.column_names
+        # All rows should have totalprice > 100000 (filter in refSql)
+        for i in range(result.num_rows):
+            assert result["o_totalprice"][i].as_py() > 100000
+
+    def test_query_ref_sql_aggregate(self, engine: WrenEngine) -> None:
+        result = engine.query(
+            'SELECT o_orderstatus, order_count, total_amount FROM "order_summary"'
+        )
+        assert isinstance(result, pa.Table)
+        # TPCH has 3 order statuses: F, O, P
+        assert result.num_rows > 0
+        statuses = {result["o_orderstatus"][i].as_py() for i in range(result.num_rows)}
+        assert statuses.issubset({"F", "O", "P"})
+        # Each count should be positive
+        for i in range(result.num_rows):
+            assert result["order_count"][i].as_py() > 0
+            assert result["total_amount"][i].as_py() > 0
+
+    def test_query_ref_sql_with_where(self, engine: WrenEngine) -> None:
+        """WHERE clause on top of a refSql model should compose correctly."""
+        result = engine.query(
+            'SELECT o_orderkey FROM "high_value_orders" '
+            "WHERE o_totalprice > 200000 LIMIT 10"
+        )
+        assert isinstance(result, pa.Table)
+        # All rows must satisfy both the refSql filter (>100k) and query filter (>200k)
+        for i in range(result.num_rows):
+            assert result["o_orderkey"][i].as_py() > 0
+
+    def test_query_ref_sql_count(self, engine: WrenEngine) -> None:
+        """COUNT(*) on a refSql model."""
+        result = engine.query('SELECT COUNT(*) AS cnt FROM "high_value_orders"')
+        count = result["cnt"][0].as_py()
+        # The refSql filters orders > 100k, so count should be less than total (15000)
+        assert 0 < count < 15000
+
+    def test_query_table_ref_model_coexists(self, engine: WrenEngine) -> None:
+        """Table-reference models should still work alongside refSql models."""
+        result = engine.query('SELECT COUNT(*) AS cnt FROM "orders"')
+        assert result["cnt"][0].as_py() == 15000  # TPCH sf=0.01
+
+    def test_query_ref_sql_with_order_by(self, engine: WrenEngine) -> None:
+        result = engine.query(
+            'SELECT o_orderkey, o_totalprice FROM "high_value_orders" '
+            "ORDER BY o_totalprice DESC LIMIT 3"
+        )
+        assert result.num_rows == 3
+        prices = [result["o_totalprice"][i].as_py() for i in range(3)]
+        assert prices == sorted(prices, reverse=True)

--- a/wren/tests/suite/test_ref_sql.py
+++ b/wren/tests/suite/test_ref_sql.py
@@ -158,13 +158,13 @@ class TestRefSqlQuery:
     def test_query_ref_sql_with_where(self, engine: WrenEngine) -> None:
         """WHERE clause on top of a refSql model should compose correctly."""
         result = engine.query(
-            'SELECT o_orderkey FROM "high_value_orders" '
+            'SELECT o_orderkey, o_totalprice FROM "high_value_orders" '
             "WHERE o_totalprice > 200000 LIMIT 10"
         )
         assert isinstance(result, pa.Table)
         # All rows must satisfy both the refSql filter (>100k) and query filter (>200k)
         for i in range(result.num_rows):
-            assert result["o_orderkey"][i].as_py() > 0
+            assert result["o_totalprice"][i].as_py() > 200000
 
     def test_query_ref_sql_count(self, engine: WrenEngine) -> None:
         """COUNT(*) on a refSql model."""


### PR DESCRIPTION
## Summary
- Add `ModelSource` enum and `Model::source()` to distinguish `table_reference` vs `refSql` models
- Add `SqlReferencePlanNode` + `SqlReferenceNodeUnparser` so refSql models are planned as subqueries and correctly unparsed back to SQL
- Route refSql models through the new plan node in `ModelGenerationRule`, register them by model name in MDL analysis
- Change `Model::table_reference()` return type to `Option<&str>` for type safety; update all callers across wren-core, wren-core-base, wren-core-py
- Add 9 end-to-end Python tests (DuckDB + TPCH) covering dry_plan, query execution, WHERE composition, aggregation, and coexistence with table_reference models

## Test plan
- [x] `cargo test` — 76 wren-core tests pass (including 2 new refSql integration tests)
- [x] `cargo test` — 19 wren-core-base tests pass (including new `test_model_source`)
- [x] `cargo test --no-default-features` — 28 wren-core-py tests pass
- [x] `cargo clippy -D warnings` — zero warnings on wren-core and wren-core-base
- [x] `pytest tests/suite/test_ref_sql.py` — 9 E2E tests pass (dry_plan + query execution)
- [ ] Verify wren-core-wasm builds after forward-merge (wasm doesn't exist on canner/main yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models can now be defined with inline SQL (`refSql`) as well as table references; refSql models are expanded into subqueries in plans and queries.

* **Bug Fixes / Validation**
  * Invalid model configurations (both/none of refSql and tableReference) now produce explicit plan errors.

* **Tests**
  * Added end-to-end tests verifying refSql planning, execution, aggregation, filters, composition, and coexistence with table-reference models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->