### PR TITLE
chore(wren-core-wasm): add release-please config and npm publish workflow

### DIFF
--- a/.github/workflows/publish-wren-core-wasm.yml
+++ b/.github/workflows/publish-wren-core-wasm.yml
@@ -1,0 +1,90 @@
+name: Publish wren-core-wasm to npm
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version number (e.g. 0.2.0)"
+        required: true
+        type: string
+      tag_name:
+        description: "Git tag to checkout (e.g. wren-core-wasm-v0.2.0)"
+        required: true
+        type: string
+      npm_tag:
+        description: "npm dist-tag (latest or rc)"
+        required: false
+        type: string
+        default: "latest"
+    secrets:
+      NPM_TOKEN:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build WASM + publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag_name }}
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            wren-core-wasm/target/
+          key: wasm-cargo-${{ hashFiles('wren-core-wasm/Cargo.toml', 'wren-core-wasm/Cargo.lock') }}
+          restore-keys: wasm-cargo-
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.14.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install npm dependencies
+        working-directory: wren-core-wasm
+        run: npm install
+
+      - name: Set version in package.json
+        working-directory: wren-core-wasm
+        env:
+          VERSION: ${{ inputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version
+
+      - name: Build WASM (wasm-pack)
+        working-directory: wren-core-wasm
+        run: wasm-pack build --target web --release
+
+      - name: Build dist (TypeScript + copy)
+        working-directory: wren-core-wasm
+        run: npm run build:dist
+
+      - name: Run integration tests
+        working-directory: wren-core-wasm
+        run: npm test
+
+      - name: Publish to npm
+        working-directory: wren-core-wasm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TAG: ${{ inputs.npm_tag }}
+        run: npm publish --tag "$NPM_TAG" --access public

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -12,6 +12,7 @@ on:
           - mcp-server
           - wren-core-py
           - wren
+          - wren-core-wasm
       rc_version:
         description: "RC version override (e.g. 0.25.0-rc.2). Leave empty to auto-increment."
         required: false
@@ -138,8 +139,19 @@ jobs:
       contents: read
       id-token: write
 
+  publish-wren-core-wasm:
+    needs: create-rc
+    if: inputs.component == 'wren-core-wasm'
+    uses: ./.github/workflows/publish-wren-core-wasm.yml
+    with:
+      version: ${{ needs.create-rc.outputs.version }}
+      tag_name: ${{ needs.create-rc.outputs.tag_name }}
+      npm_tag: rc
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   create-release:
-    needs: [create-rc, publish-ibis-server, publish-mcp-server, publish-wren-core-py, publish-wren]
+    needs: [create-rc, publish-ibis-server, publish-mcp-server, publish-wren-core-py, publish-wren, publish-wren-core-wasm]
     if: always() && needs.create-rc.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,9 @@ jobs:
       wren--release_created: ${{ steps.release.outputs['wren--release_created'] }}
       wren--tag_name: ${{ steps.release.outputs['wren--tag_name'] }}
       wren--version: ${{ steps.release.outputs['wren--version'] }}
+      wren-core-wasm--release_created: ${{ steps.release.outputs['wren-core-wasm--release_created'] }}
+      wren-core-wasm--tag_name: ${{ steps.release.outputs['wren-core-wasm--tag_name'] }}
+      wren-core-wasm--version: ${{ steps.release.outputs['wren-core-wasm--version'] }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -72,3 +75,13 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
+  publish-wren-core-wasm:
+    needs: release-please
+    if: needs.release-please.outputs['wren-core-wasm--release_created'] == 'true'
+    uses: ./.github/workflows/publish-wren-core-wasm.yml
+    with:
+      version: ${{ needs.release-please.outputs['wren-core-wasm--version'] }}
+      tag_name: ${{ needs.release-please.outputs['wren-core-wasm--tag_name'] }}
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,6 @@
   "ibis-server": "0.24.6",
   "mcp-server": "0.24.6",
   "wren-core-py": "0.1.0",
-  "wren": "0.2.0"
+  "wren": "0.2.0",
+  "wren-core-wasm": "0.1.0"
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,6 +10,7 @@ Wren Engine uses [release-please](https://github.com/googleapis/release-please) 
 | mcp-server | — (bundled in ibis-server image) | `mcp-server-v0.25.0` | Version verify only |
 | wren-core-py | `wren-core-py` on PyPI | `wren-core-py-v0.2.0` | PyPI |
 | wren | `wren-engine` on PyPI | `wren-v0.3.0` | PyPI |
+| wren-core-wasm | `wren-core-wasm` on npm | `wren-core-wasm-v0.2.0` | npm |
 
 ## How it works
 
@@ -113,6 +114,7 @@ Note: while on 0.x with `bump-minor-pre-major`, this only bumps minor. Use `Rele
 | `.github/workflows/publish-ibis-server.yml` | Docker multi-arch build + push |
 | `.github/workflows/publish-wren-core-py.yml` | Multi-platform wheel build + PyPI publish |
 | `.github/workflows/publish-wren.yml` | sdist + wheel build + PyPI publish |
+| `.github/workflows/publish-wren-core-wasm.yml` | WASM build + npm publish |
 | `.github/workflows/publish-mcp-server.yml` | Version verification |
 
 ## Continuous builds (unchanged)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,14 @@
       "extra-files": [
         "src/wren/__init__.py"
       ]
+    },
+    "wren-core-wasm": {
+      "component": "wren-core-wasm",
+      "release-type": "node",
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        "Cargo.toml"
+      ]
     }
   }
 }

--- a/wren-core-wasm/.claude/CLAUDE.md
+++ b/wren-core-wasm/.claude/CLAUDE.md
@@ -71,7 +71,7 @@ just clean           # Remove pkg/, dist/, target/
 - **macOS build**: Needs LLVM (`brew install llvm`) for C deps — justfile handles env vars automatically
 - **Binary size**: ~68 MB raw / ~14 MB gzip (target: < 15 MB gzip)
 
-## npm Package (wren-core-sdk)
+## npm Package (wren-core-wasm)
 
 `package.json` defines the npm package. TypeScript SDK wraps the raw wasm-bindgen API:
 - `WrenEngine.init(options?)` — load WASM binary, create engine

--- a/wren-core-wasm/AGENT_GUIDE.md
+++ b/wren-core-wasm/AGENT_GUIDE.md
@@ -1,12 +1,12 @@
 # WASM Dashboard Generation Guide
 
-Reference for AI agents generating browser-based HTML dashboard artifacts using `wren-core-sdk`.
+Reference for AI agents generating browser-based HTML dashboard artifacts using `wren-core-wasm`.
 
 ## How to Import
 
 ```html
 <script type="module">
-  import { WrenEngine } from 'https://unpkg.com/wren-core-sdk@0.1.0/dist/index.js';
+  import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
 </script>
 ```
 
@@ -103,7 +103,7 @@ const mdl = {
   <div id="status">Loading engine...</div>
 
   <script type="module">
-    import { WrenEngine } from 'https://unpkg.com/wren-core-sdk@0.1.0/dist/index.js';
+    import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
 
     const status = document.getElementById('status');
 

--- a/wren-core-wasm/README.md
+++ b/wren-core-wasm/README.md
@@ -1,4 +1,4 @@
-# wren-core-sdk
+# wren-core-wasm
 
 Browser-native semantic SQL engine powered by [Apache DataFusion](https://datafusion.apache.org/) compiled to WebAssembly.
 
@@ -7,14 +7,14 @@ Query Parquet files directly in the browser through a semantic layer (MDL), with
 ## Installation
 
 ```bash
-npm install wren-core-sdk
+npm install wren-core-wasm
 ```
 
 Or use directly via CDN:
 
 ```html
 <script type="module">
-  import { WrenEngine } from 'https://unpkg.com/wren-core-sdk@0.1.0/dist/index.js';
+  import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
 </script>
 ```
 
@@ -28,7 +28,7 @@ Or use directly via CDN:
 Load Parquet files from a URL-accessible location. DataFusion reads them via HTTP range requests.
 
 ```javascript
-import { WrenEngine } from 'wren-core-sdk';
+import { WrenEngine } from 'wren-core-wasm';
 
 const engine = await WrenEngine.init();
 

--- a/wren-core-wasm/examples/test-cdn.html
+++ b/wren-core-wasm/examples/test-cdn.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CDN Test: wren-core-sdk</title>
+    <title>CDN Test: wren-core-wasm</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
     <style>
         body { font-family: -apple-system, sans-serif; max-width: 800px; margin: 2em auto; padding: 0 1em; color: #333; }
@@ -20,7 +20,7 @@
 </head>
 <body>
     <h1>Revenue Dashboard</h1>
-    <p>Self-contained HTML using <code>wren-core-sdk</code> from CDN. Zero server dependencies.</p>
+    <p>Self-contained HTML using <code>wren-core-wasm</code> from CDN. Zero server dependencies.</p>
     <div id="log"></div>
 
     <h3>MDL</h3>
@@ -38,7 +38,7 @@
     <script type="module">
         // unpkg used instead of jsDelivr: jsDelivr's free CDN has a 50 MB per-file
         // limit and the WASM binary is ~68 MB raw. unpkg handles larger files.
-        import { WrenEngine } from 'https://unpkg.com/wren-core-sdk@0.1.0/dist/index.js';
+        import { WrenEngine } from 'https://unpkg.com/wren-core-wasm@0.1.0/dist/index.js';
 
         const logEl = document.getElementById('log');
 

--- a/wren-core-wasm/package.json
+++ b/wren-core-wasm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wren-core-sdk",
+  "name": "wren-core-wasm",
   "version": "0.1.0",
   "description": "Browser-native semantic SQL engine powered by DataFusion WASM",
   "type": "module",

--- a/wren-core-wasm/scripts/build.mjs
+++ b/wren-core-wasm/scripts/build.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Build script for wren-core-sdk npm package.
+ * Build script for wren-core-wasm npm package.
  *
  * Assembles dist/ from wasm-pack output (pkg/) and TypeScript wrapper (sdk/).
  * Run `npm run build:wasm` first to populate pkg/, then `npm run build:dist`.

--- a/wren-core-wasm/sdk/tests/index.test.mjs
+++ b/wren-core-wasm/sdk/tests/index.test.mjs
@@ -1,5 +1,5 @@
 /**
- * Integration tests for the wren-core-sdk TypeScript wrapper.
+ * Integration tests for the wren-core-wasm TypeScript wrapper.
  *
  * These tests load the actual WASM binary and exercise the full SDK API.
  * Run with: `npm test` (or `node --test sdk/tests/index.test.mjs`)


### PR DESCRIPTION
## Summary

- Rename npm package from `wren-core-sdk` to `wren-core-wasm` (7 files, 14 occurrences) for monorepo naming consistency
- Register `wren-core-wasm` as a `node`-type component in release-please config (tracks `package.json` + syncs `Cargo.toml` via extra-files, starting at `0.1.0`)
- Add `publish-wren-core-wasm.yml` workflow (WASM build + npm publish), wire it into `release-please.yml` and `rc-release.yml`

### Post-merge manual steps

- [ ] Add `NPM_TOKEN` secret (automation type, public scope) in GitHub repo Settings → Secrets → Actions
- [ ] `npm deprecate wren-core-sdk "Renamed to wren-core-wasm. Use: npm install wren-core-wasm"`

## Test plan

- [ ] `wasm-ci.yml` passes in this PR (build + test + size check)
- [ ] After merge: release-please opens a `wren-core-wasm` Release PR (triggered by the `feat(wren-core-wasm)` commits already on main)
- [ ] Merge Release PR → npm publish succeeds → `https://unpkg.com/wren-core-wasm@<version>/dist/index.js` accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced browser-native WebAssembly semantic SQL engine enabling client-side analytics on Parquet data
  * Added DataFusion connector for querying local Parquet and CSV files

* **Documentation**
  * Added SDK guides, API reference, and browser examples for WASM engine

* **Deprecations**
  * Ibis Server Module deprecated; users should migrate to CLI tool

* **Chores**
  * Upgraded DataFusion to v53 with compatibility updates
  * Enhanced CI/CD workflows for automated package publishing and testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->