### PR TITLE
fix(ci): update Cargo.lock in wren-core-py release workflow

### DIFF
--- a/.github/workflows/publish-wren-core-py.yml
+++ b/.github/workflows/publish-wren-core-py.yml
@@ -55,6 +55,13 @@ jobs:
               text = open(path).read()
               text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{version}"', text, count=1, flags=re.MULTILINE)
               open(path, "w").write(text)
+          lock = open("wren-core-py/Cargo.lock").read()
+          lock = re.sub(
+              r'(name = "wren-core-py"\nversion = )".*?"',
+              rf'\1"{version}"',
+              lock, count=1,
+          )
+          open("wren-core-py/Cargo.lock", "w").write(lock)
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -89,6 +96,13 @@ jobs:
               text = open(path).read()
               text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{version}"', text, count=1, flags=re.MULTILINE)
               open(path, "w").write(text)
+          lock = open("wren-core-py/Cargo.lock").read()
+          lock = re.sub(
+              r'(name = "wren-core-py"\nversion = )".*?"',
+              rf'\1"{version}"',
+              lock, count=1,
+          )
+          open("wren-core-py/Cargo.lock", "w").write(lock)
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
## Summary
- Maturin v1.13+ uses `--locked` by default when a `Cargo.lock` exists. The "Set version" step was updating `Cargo.toml` and `pyproject.toml` but not `Cargo.lock`, causing all wheel builds to fail with a lockfile mismatch error.
- Extends the version-setting Python script to also patch the `wren-core-py` version in `Cargo.lock`, in both the `build-wheels` and `build-sdist` jobs.

Fixes https://github.com/Canner/wren-engine/actions/runs/24493639398

## Test plan
- [ ] Re-run the wren-core-py release after merging to verify all 4 wheel builds (Linux, macOS Intel, macOS ARM, Windows) succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to synchronize version information across all configuration files during package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->