### PR TITLE
fix(ci): disable PyPI attestations for reusable workflow

### DIFF
--- a/.github/workflows/publish-wren-core-py.yml
+++ b/.github/workflows/publish-wren-core-py.yml
@@ -135,3 +135,4 @@ jobs:
         with:
           repository-url: ${{ inputs.pypi_target == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
+          attestations: false

--- a/.github/workflows/publish-wren.yml
+++ b/.github/workflows/publish-wren.yml
@@ -77,3 +77,4 @@ jobs:
         with:
           repository-url: ${{ inputs.pypi_target == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
           packages-dir: dist/
+          attestations: false


### PR DESCRIPTION
## Summary
- PyPI attestation verification fails when publishing via a reusable workflow (`publish-wren-core-py.yml` called from `release-please.yml`). The attestation certificate embeds the parent workflow ref but PyPI validates it against the trusted publisher's workflow, causing a mismatch.
- Disables attestations in the publish step as a workaround until PyPI officially supports reusable workflows.

Ref: https://github.com/pypa/gh-action-pypi-publish/issues/166

## Test plan
- [ ] After merge, delete `wren-core-py-v0.3.0` release/tag and re-trigger release-please to verify publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyPI publishing workflow configuration by disabling provenance attestations in package publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->