### PR TITLE
fix(ci): use semver for Cargo.toml in wren-core-py RC releases

### DIFF
--- a/.github/workflows/publish-wren-core-py.yml
+++ b/.github/workflows/publish-wren-core-py.yml
@@ -49,23 +49,34 @@ jobs:
           VERSION: ${{ inputs.version }}
         shell: python
         run: |
-          import re, os
+          import re, os, sys
           version = os.environ["VERSION"]
-          # Cargo requires semver: convert PEP 440 "0.3.0rc1" to "0.3.0-rc.1"
-          cargo_version = re.sub(r'(\d+\.\d+\.\d+)rc(\d+)', r'\1-rc.\2', version)
+          if re.fullmatch(r"\d+\.\d+\.\d+", version):
+              cargo_version = version
+          elif re.fullmatch(r"\d+\.\d+\.\d+rc\d+", version):
+              cargo_version = re.sub(r"(\d+\.\d+\.\d+)rc(\d+)", r"\1-rc.\2", version)
+          else:
+              print(f"::error::Unsupported version format: {version!r}. Expected X.Y.Z or X.Y.ZrcN.")
+              sys.exit(1)
           for path, ver in [
               ("wren-core-py/Cargo.toml", cargo_version),
               ("wren-core-py/pyproject.toml", version),
           ]:
               text = open(path).read()
-              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
+              text, n = re.subn(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
+              if n != 1:
+                  print(f"::error::Failed to update version in {path}")
+                  sys.exit(1)
               open(path, "w").write(text)
           lock = open("wren-core-py/Cargo.lock").read()
-          lock = re.sub(
+          lock, n = re.subn(
               r'(name = "wren-core-py"\nversion = )".*?"',
               rf'\1"{cargo_version}"',
               lock, count=1,
           )
+          if n != 1:
+              print("::error::Failed to update wren-core-py version in Cargo.lock")
+              sys.exit(1)
           open("wren-core-py/Cargo.lock", "w").write(lock)
       - name: Build wheel
         uses: PyO3/maturin-action@v1
@@ -95,23 +106,34 @@ jobs:
           VERSION: ${{ inputs.version }}
         shell: python
         run: |
-          import re, os
+          import re, os, sys
           version = os.environ["VERSION"]
-          # Cargo requires semver: convert PEP 440 "0.3.0rc1" to "0.3.0-rc.1"
-          cargo_version = re.sub(r'(\d+\.\d+\.\d+)rc(\d+)', r'\1-rc.\2', version)
+          if re.fullmatch(r"\d+\.\d+\.\d+", version):
+              cargo_version = version
+          elif re.fullmatch(r"\d+\.\d+\.\d+rc\d+", version):
+              cargo_version = re.sub(r"(\d+\.\d+\.\d+)rc(\d+)", r"\1-rc.\2", version)
+          else:
+              print(f"::error::Unsupported version format: {version!r}. Expected X.Y.Z or X.Y.ZrcN.")
+              sys.exit(1)
           for path, ver in [
               ("wren-core-py/Cargo.toml", cargo_version),
               ("wren-core-py/pyproject.toml", version),
           ]:
               text = open(path).read()
-              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
+              text, n = re.subn(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
+              if n != 1:
+                  print(f"::error::Failed to update version in {path}")
+                  sys.exit(1)
               open(path, "w").write(text)
           lock = open("wren-core-py/Cargo.lock").read()
-          lock = re.sub(
+          lock, n = re.subn(
               r'(name = "wren-core-py"\nversion = )".*?"',
               rf'\1"{cargo_version}"',
               lock, count=1,
           )
+          if n != 1:
+              print("::error::Failed to update wren-core-py version in Cargo.lock")
+              sys.exit(1)
           open("wren-core-py/Cargo.lock", "w").write(lock)
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/publish-wren-core-py.yml
+++ b/.github/workflows/publish-wren-core-py.yml
@@ -51,14 +51,19 @@ jobs:
         run: |
           import re, os
           version = os.environ["VERSION"]
-          for path in ["wren-core-py/Cargo.toml", "wren-core-py/pyproject.toml"]:
+          # Cargo requires semver: convert PEP 440 "0.3.0rc1" to "0.3.0-rc.1"
+          cargo_version = re.sub(r'(\d+\.\d+\.\d+)rc(\d+)', r'\1-rc.\2', version)
+          for path, ver in [
+              ("wren-core-py/Cargo.toml", cargo_version),
+              ("wren-core-py/pyproject.toml", version),
+          ]:
               text = open(path).read()
-              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{version}"', text, count=1, flags=re.MULTILINE)
+              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
               open(path, "w").write(text)
           lock = open("wren-core-py/Cargo.lock").read()
           lock = re.sub(
               r'(name = "wren-core-py"\nversion = )".*?"',
-              rf'\1"{version}"',
+              rf'\1"{cargo_version}"',
               lock, count=1,
           )
           open("wren-core-py/Cargo.lock", "w").write(lock)
@@ -92,14 +97,19 @@ jobs:
         run: |
           import re, os
           version = os.environ["VERSION"]
-          for path in ["wren-core-py/Cargo.toml", "wren-core-py/pyproject.toml"]:
+          # Cargo requires semver: convert PEP 440 "0.3.0rc1" to "0.3.0-rc.1"
+          cargo_version = re.sub(r'(\d+\.\d+\.\d+)rc(\d+)', r'\1-rc.\2', version)
+          for path, ver in [
+              ("wren-core-py/Cargo.toml", cargo_version),
+              ("wren-core-py/pyproject.toml", version),
+          ]:
               text = open(path).read()
-              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{version}"', text, count=1, flags=re.MULTILINE)
+              text = re.sub(r'^(version\s*=\s*)".*?"', rf'\1"{ver}"', text, count=1, flags=re.MULTILINE)
               open(path, "w").write(text)
           lock = open("wren-core-py/Cargo.lock").read()
           lock = re.sub(
               r'(name = "wren-core-py"\nversion = )".*?"',
-              rf'\1"{version}"',
+              rf'\1"{cargo_version}"',
               lock, count=1,
           )
           open("wren-core-py/Cargo.lock", "w").write(lock)


### PR DESCRIPTION
## Summary
- The RC workflow passes PEP 440 versions (e.g. `0.3.0rc1`) to the publish workflow, but Cargo.toml only accepts semver (e.g. `0.3.0-rc.1`).
- Converts PEP 440 RC versions to semver for `Cargo.toml` and `Cargo.lock`, while keeping PEP 440 for `pyproject.toml`.
- Normal releases (e.g. `0.3.0`) are unaffected.

Fixes https://github.com/Canner/wren-engine/actions/runs/24499485349/job/71602344668

## Test plan
- [ ] Re-run RC release for wren-core-py after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to validate version formats (stable and RC) and to format package versions correctly for different package ecosystems.
  * Added stricter checks with explicit error reporting and failed releases when expected version updates aren't applied, reducing incorrect or partial publish attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->