### PR TITLE
ci: narrow build-image trigger to ibis-server and mcp-server changes

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,9 +10,6 @@ on:
       - main
     paths:
       - 'ibis-server/**'
-      - 'wren-core/**'
-      - 'wren-core-base/**'
-      - 'wren-core-py/**'
       - 'mcp-server/**'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Remove `wren-core/**`, `wren-core-base/**`, and `wren-core-py/**` from the `build-image.yml` push trigger paths
- The workflow now only triggers on `ibis-server/**` or `mcp-server/**` changes (push to main), or via manual `workflow_dispatch`
- Avoids unnecessary image rebuilds when only Rust core code changes

## Test plan
- [ ] Verify workflow does not trigger on wren-core-only commits to main
- [ ] Verify workflow triggers on ibis-server or mcp-server commits to main
- [ ] Verify manual dispatch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->