### PR TITLE
docs: add archive notice pointing to Canner/WrenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# Wren Engine — Archived
+
+> **This repository has been merged into [Canner/WrenAI](https://github.com/Canner/WrenAI) under the `core/` directory and is now archived (read-only).**
+>
+> New issues and PRs → [Canner/WrenAI](https://github.com/Canner/WrenAI/issues)
+> Full migration details (path mapping, archived modules, rationale) → [discussion #1592](https://github.com/Canner/wren-engine/discussions/1592)
+
+---
+
 <p align="center">
   <a href="https://getwren.ai">
     <picture>


### PR DESCRIPTION
## Summary
- Adds a short archive banner at the top of `README.md` indicating the repo has been merged into [Canner/WrenAI](https://github.com/Canner/WrenAI) under `core/`.
- Redirects new issues/PRs to Canner/WrenAI and points readers to [discussion #1592](https://github.com/Canner/wren-engine/discussions/1592) for full migration details (path mapping, archived modules, rationale).

## Test plan
- [ ] Verify the rendered README banner on GitHub displays the links correctly.
- [ ] Confirm discussion #1592 is publicly accessible before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Project marked as archived with documentation updated to reflect repository relocation and consolidation. Archival notice includes new location details, migration guidance, development discussion links, and issue tracking information to support the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->